### PR TITLE
make log4j optional so it is not pulled in transitively

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,6 +248,7 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -256,6 +257,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>


### PR DESCRIPTION
I'm using logback in a (sbt) project that depends on elastic4s.  Log4j is pulled in transitively and upon initialization I see the warnings:

```
log4j:WARN No appenders could be found for logger (org.elasticsearch.node).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
```

This PR makes `log4j` and `slf4j-log4j12` optional dependencies downstream users can choose whatever `slf4j` implementation they prefer.
