### PR TITLE
move log4j to test scope for both SBT and Maven

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,9 +40,9 @@ libraryDependencies += "com.fasterxml.jackson.module" % "jackson-module-scala_2.
 
 libraryDependencies += "org.slf4j" % "slf4j-api" % "1.6.6"
 
-libraryDependencies += "log4j" % "log4j" % "1.2.17"
+libraryDependencies += "log4j" % "log4j" % "1.2.17" % "test"
 
-libraryDependencies += "org.slf4j" % "log4j-over-slf4j" % "1.6.6"
+libraryDependencies += "org.slf4j" % "log4j-over-slf4j" % "1.6.6" % "test"
 
 libraryDependencies += "commons-io" % "commons-io" % "2.4"
 

--- a/pom.xml
+++ b/pom.xml
@@ -248,7 +248,7 @@
         <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
-            <optional>true</optional>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -257,7 +257,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <optional>true</optional>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>


### PR DESCRIPTION
The test scope is easier to understand than optional and it also keeps Log4j classes out of the compile classpath. Follow-up to PR #12.
