### PR TITLE
Added support to filter executed queries in percolate API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ name := "elastic4s"
 
 organization := "com.sksamuel.elastic4s"
 
-version := "0.90.6.0"
+version := "0.90.6.1"
 
 scalaVersion := "2.10.3"
 

--- a/src/main/scala/com/sksamuel/elastic4s/PercolateDsl.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/PercolateDsl.scala
@@ -1,10 +1,10 @@
 package com.sksamuel.elastic4s
 
 import scala.collection.mutable.ListBuffer
-import org.elasticsearch.action.percolate.{PercolateAction, PercolateResponse, PercolateRequest, PercolateRequestBuilder}
+import org.elasticsearch.action.percolate.{PercolateAction, PercolateRequestBuilder}
 import org.elasticsearch.common.xcontent.{XContentFactory, XContentBuilder}
-import org.elasticsearch.action.index.{IndexAction, IndexResponse, IndexRequest, IndexRequestBuilder}
-import org.elasticsearch.search.query.QuerySearchRequest
+import org.elasticsearch.action.index.{IndexAction, IndexRequestBuilder}
+
 
 /** @author Stephen Samuel */
 trait PercolateDsl extends QueryDsl {
@@ -21,11 +21,17 @@ trait PercolateDsl extends QueryDsl {
   class PercolateDefinition(index: String) extends RequestDefinition(PercolateAction.INSTANCE) {
 
     private val _fields = new ListBuffer[(String, Any)]
+    private[this] var _query: QueryDefinition = _
 
     def build = new PercolateRequestBuilder(null, index, "type1").setSource(_doc).request()
 
     private[elastic4s] def _doc: XContentBuilder = {
-      val source = XContentFactory.jsonBuilder().startObject().startObject("doc")
+      val source = XContentFactory.jsonBuilder().startObject()
+
+      if (_query != null)
+        source.field("query", _query.builder)
+
+      source.startObject("doc")
       for ( tuple <- _fields ) {
         source.field(tuple._1, tuple._2)
       }
@@ -42,6 +48,12 @@ trait PercolateDsl extends QueryDsl {
       this._fields ++= fields
       this
     }
+
+    def query(string: String): PercolateDefinition = query(new StringQueryDefinition(string))
+    def query(block: => QueryDefinition) = {
+      _query = block
+      this
+    }
   }
 
   def register = new RegisterExpectsId
@@ -55,19 +67,31 @@ trait PercolateDsl extends QueryDsl {
 
   class RegisterDefinition(index: String, id: String) extends RequestDefinition(IndexAction.INSTANCE) {
     private[this] var _query: QueryDefinition = _
+    private val _fields = new ListBuffer[(String, Any)]
     def build = {
       val source = XContentFactory.jsonBuilder()
-        .startObject().field("query", _query.builder).endObject()
+        .startObject().field("query", _query.builder)
+      for ( tuple <- _fields ) {
+        source.field(tuple._1, tuple._2)
+      }
+      source.endObject()
       new IndexRequestBuilder(null).setIndex("_percolator")
         .setType(index).setId(id).setRefresh(true)
         .setSource(source).request
     }
+
     def query(block: => QueryDefinition): RegisterDefinition = {
       _query = block
       this
     }
     def query(string: String) = {
       _query = new StringQueryDefinition(string)
+      this
+    }
+    def fields(map: Map[String, Any]): RegisterDefinition = fields(map.toList)
+    def fields(_fields: (String, Any)*): RegisterDefinition = fields(_fields.toIterable)
+    def fields(iterable: Iterable[(String, Any)]) = {
+      this._fields ++= iterable
       this
     }
   }

--- a/src/test/resources/com/sksamuel/elastic4s/percolate_register.json
+++ b/src/test/resources/com/sksamuel/elastic4s/percolate_register.json
@@ -1,7 +1,8 @@
 {
+    "color" : "blue",
     "query": {
         "term": {
-            "field1": "value1"
+            "name": "cook"
         }
     }
 }

--- a/src/test/resources/com/sksamuel/elastic4s/percolate_request.json
+++ b/src/test/resources/com/sksamuel/elastic4s/percolate_request.json
@@ -1,5 +1,10 @@
 {
     "doc": {
         "name": "cook"
+    },
+    "query" : {
+        "term" : {
+            "color" : "blue"
+        }
     }
 }

--- a/src/test/scala/com/sksamuel/elastic4s/PercolateDslTest.scala
+++ b/src/test/scala/com/sksamuel/elastic4s/PercolateDslTest.scala
@@ -12,13 +12,13 @@ class PercolateDslTest extends FlatSpec with MockitoSugar with OneInstancePerTes
 
   "the percolate dsl" should "should generate json for a register query" in {
     val json = mapper.readTree(getClass.getResource("/com/sksamuel/elastic4s/percolate_register.json"))
-    val req = register id 2 into "captains" query term("field1", "value1")
+    val req = register id 2 into "captains" query term("name", "cook") fields { "color" -> "blue" }
     assert(json === mapper.readTree(req.build.source.toUtf8))
   }
 
   it should "should generate fields json for a percolate request" in {
     val json = mapper.readTree(getClass.getResource("/com/sksamuel/elastic4s/percolate_request.json"))
-    val req = percolate in "captains" doc "name" -> "cook"
+    val req = percolate in "captains" doc "name" -> "cook" query { term("color"-> "blue") }
     assert(json === mapper.readTree(req._doc.string))
   }
 }

--- a/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
+++ b/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
@@ -171,7 +171,7 @@ class SearchDslTest extends FlatSpec with MockitoSugar with OneInstancePerTest {
   it should "generate json for a filtered query" in {
     val json = mapper.readTree(getClass.getResource("/com/sksamuel/elastic4s/search_query_filter.json"))
     val req = search in "music" types "bands" query {
-      filterQuery query {
+      filteredQuery query {
         "coldplay"
       } filter {
         termFilter("location", "uk")


### PR DESCRIPTION
Added support to filter executed queries in percolate API as described here - http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-percolate.html#_filtering_executed_queries
