### PR TITLE
Correctly construct the SearchDefinition when calling 'highlighting(high...

### DIFF
--- a/src/main/scala/com/sksamuel/elastic4s/SearchDsl.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/SearchDsl.scala
@@ -151,6 +151,7 @@ trait SearchDsl extends QueryDsl with FilterDsl with FacetDsl with HighlightDsl 
     }
 
     def highlighting(highlights: HighlightDefinition*): SearchDefinition = {
+      highlights.foreach(highlight => _builder.addHighlightedField(highlight.builder))
       this
     }
 


### PR DESCRIPTION
...lights: HighlightDefinition*)' API
