### PR TITLE
FilteredQuery should not clear boost by default

### DIFF
--- a/src/main/scala/com/sksamuel/elastic4s/queries.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/queries.scala
@@ -430,7 +430,7 @@ class FilteredQueryDefinition extends QueryDefinition {
   def builder = QueryBuilders.filteredQuery(_query, _filter).boost(_boost.toFloat)
   private var _query: QueryBuilder = null
   private var _filter: FilterBuilder = null
-  private var _boost: Double = 0d
+  private var _boost: Double = -1d
   def boost(boost: Double): FilteredQueryDefinition = {
     _boost = boost
     this


### PR DESCRIPTION
Changed the default to match the default of the wrapped builder, so that it does not matter if a boost is not specified.
