### PR TITLE
Fix `notindexed` -> `not_analyzed`

### DIFF
--- a/src/main/scala/com/sksamuel/elastic4s/Analyzer.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/Analyzer.scala
@@ -5,7 +5,7 @@ import org.elasticsearch.common.xcontent.XContentBuilder
 /** @author Stephen Samuel */
 abstract class Analyzer(val name: String)
 
-case object NotAnalyzed extends Analyzer("notindexed")
+case object NotAnalyzed extends Analyzer("not_analyzed")
 case object WhitespaceAnalyzer extends Analyzer("whitespace")
 case object StandardAnalyzer extends Analyzer("standard")
 case object SimpleAnalyzer extends Analyzer("simple")


### PR DESCRIPTION
Using `notindexed` throws me a MapperParsingException. I think it should be `not_analyzed`. Can you also do a release soon?
