### PR TITLE
Added factorScore scorer to support boost_factor

### DIFF
--- a/src/main/scala/com/sksamuel/elastic4s/scorers.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/scorers.scala
@@ -6,6 +6,7 @@ import org.elasticsearch.index.query.functionscore.script.ScriptScoreFunctionBui
 import org.elasticsearch.index.query.functionscore.gauss.GaussDecayFunctionBuilder
 import org.elasticsearch.index.query.functionscore.exp.ExponentialDecayFunctionBuilder
 import org.elasticsearch.index.query.functionscore.lin.LinearDecayFunctionBuilder
+import org.elasticsearch.index.query.functionscore.factor.FactorBuilder
 
 /** @author Stephen Samuel */
 trait ScoreDsl {
@@ -18,6 +19,12 @@ trait ScoreDsl {
     new LinearDecayScoreDefinition(field, origin, scale)
   def exponentialScore(field: String, origin: String, scale: String) =
     new ExponentialDecayScoreDefinition(field, origin, scale)
+  def factorScore(boost: Double) =
+    new FactorScoreDefinition(boost)
+}
+
+class FactorScoreDefinition(boost: Double) extends ScoreDefinition[FactorScoreDefinition] {
+  val builder = new FactorBuilder().boostFactor(boost.toFloat)
 }
 
 trait ScoreDefinition[T] {

--- a/src/test/resources/com/sksamuel/elastic4s/search_function_score.json
+++ b/src/test/resources/com/sksamuel/elastic4s/search_function_score.json
@@ -1,39 +1,48 @@
 {
-    "query": {
-        "function_score": {
-            "query": {
-                "simple_query_string": {
-                    "query": "coldplay"
-                }
+   "query":{
+      "function_score":{
+         "query":{
+            "simple_query_string":{
+               "query":"coldplay"
+            }
+         },
+         "functions":[
+            {
+               "random_score":{
+                  "seed":1234
+               }
             },
-            "functions": [
-                {
-                    "random_score": {
-                        "seed": 1234
-                    }
-                },
-                {
-                    "script_score": {
-                        "script": "some script here"
-                    }
-                },
-                {
-                    "filter": {
-                        "term": {
-                            "band": "coldplay"
-                        }
-                    },
-                    "gauss": {
-                        "field1": {
-                            "origin": "1m",
-                            "scale": "2m"
-                        }
-                    }
-                }
-            ],
-            "score_mode": "multiply",
-            "boost_mode": "max",
-            "max_boost": 1.9,
-            "boost": 1.4
-        }
-    }}
+            {
+               "script_score":{
+                  "script":"some script here"
+               }
+            },
+            {
+               "filter":{
+                  "term":{
+                     "band":"coldplay"
+                  }
+               },
+               "gauss":{
+                  "field1":{
+                     "origin":"1m",
+                     "scale":"2m"
+                  }
+               }
+            },
+            {
+               "filter":{
+                  "term":{
+                     "band":"taylor swift"
+                  }
+               },
+               "boost_factor":1.2
+            }
+         ],
+         "score_mode":"multiply",
+         "boost_mode":"max",
+         "max_boost":1.9,
+         "boost":1.4
+      }
+   }
+}

--- a/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
+++ b/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
@@ -605,7 +605,8 @@ class SearchDslTest extends FlatSpec with MockitoSugar with OneInstancePerTest {
       functionScoreQuery("coldplay").boost(1.4).maxBoost(1.9).scoreMode("multiply").boostMode("max").scorers(
         randomScore(1234),
         scriptScore("some script here"),
-        gaussianScore("field1", "1m", "2m").filter(termFilter("band", "coldplay"))
+        gaussianScore("field1", "1m", "2m").filter(termFilter("band", "coldplay")),
+        factorScore(1.2).filter(termFilter("band", "taylor swift"))
       )
     }
     assert(json === mapper.readTree(req._builder.toString))


### PR DESCRIPTION
boost_factor appears in function_score_query:
http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html#_boost_factor
