### PR TITLE
Set index and type on percolate queries.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ name := "elastic4s"
 
 organization := "com.sksamuel.elastic4s"
 
-version := "0.90.9.0"
+version := "0.90.9.1"
 
 scalaVersion := "2.10.3"
 

--- a/src/main/scala/com/sksamuel/elastic4s/PercolateDsl.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/PercolateDsl.scala
@@ -23,7 +23,7 @@ trait PercolateDsl extends QueryDsl {
     private val _fields = new ListBuffer[(String, Any)]
     private[this] var _query: QueryDefinition = _
 
-    def build = new PercolateRequestBuilder(null).setSource(_doc).request()
+    def build = new PercolateRequestBuilder(null).setSource(_doc).setIndex(index).setType("doc").request()
 
     private[elastic4s] def _doc: XContentBuilder = {
       val source = XContentFactory.jsonBuilder().startObject()


### PR DESCRIPTION
Eliminates the following exception:

```
org.elasticsearch.action.ActionRequestValidationException: Validation Failed: 1: index is missing;2: type is missing;
    at org.elasticsearch.action.ValidateActions.addValidationError(ValidateActions.java:29) ~[elasticsearch-0.90.9.jar:na]
    at org.elasticsearch.action.percolate.PercolateRequest.validate(PercolateRequest.java:145) ~[elasticsearch-0.90.9.jar:na]
    at org.elasticsearch.action.TransportActionNodeProxy.execute(TransportActionNodeProxy.java:63) ~[elasticsearch-0.90.9.jar:na]
    at org.elasticsearch.client.transport.support.InternalTransportClient$2.doWithNode(InternalTransportClient.java:109) ~[elasticsearch-0.90.9.jar:na]
    at org.elasticsearch.client.transport.TransportClientNodesService.execute(TransportClientNodesService.java:222) ~[elasticsearch-0.90.9.jar:na]
    at org.elasticsearch.client.transport.support.InternalTransportClient.execute(InternalTransportClient.java:106) ~[elasticsearch-0.90.9.jar:na]
    at org.elasticsearch.client.transport.TransportClient.execute(TransportClient.java:306) ~[elasticsearch-0.90.9.jar:na]
    at com.sksamuel.elastic4s.ElasticClient.execute(Client.scala:56) ~[elastic4s_2.10-0.90.9.0.jar:0.90.9.0]
    at com.sksamuel.elastic4s.ElasticClient$$anonfun$execute$1.apply(Client.scala:52) ~[elastic4s_2.10-0.90.9.0.jar:0.90.9.0]
    at com.sksamuel.elastic4s.ElasticClient$$anonfun$execute$1.apply(Client.scala:52) ~[elastic4s_2.10-0.90.9.0.jar:0.90.9.0]
    at com.sksamuel.elastic4s.ElasticClient.injectFuture(Client.scala:279) ~[elastic4s_2.10-0.90.9.0.jar:0.90.9.0]
    at com.sksamuel.elastic4s.ElasticClient.execute(Client.scala:52) ~[elastic4s_2.10-0.90.9.0.jar:0.90.9.0]
```
