### PR TITLE
Add the ability to get aliases

### DIFF
--- a/src/main/scala/com/sksamuel/elastic4s/AliasesDsl.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/AliasesDsl.scala
@@ -3,6 +3,7 @@ package com.sksamuel.elastic4s
 import org.elasticsearch.action.admin.indices.alias.{IndicesAliasesAction, IndicesAliasesRequest}
 import org.elasticsearch.index.query.FilterBuilder
 import org.elasticsearch.cluster.metadata.AliasAction
+import org.elasticsearch.action.admin.indices.alias.get.{IndicesGetAliasesRequest, IndicesGetAliasesAction}
 
 trait AliasesDsl {
   def aliases = new AliasesExpectsAction
@@ -10,6 +11,7 @@ trait AliasesDsl {
   class AliasesExpectsAction {
     def add(alias: String) = new AddAliasExpectsIndex(alias)
     def remove(alias: String) = new RemoveAliasExpectsIndex(alias)
+    def get(alias: String*) = new AliasQueryDefinition(new IndicesGetAliasesRequest(alias.toArray))
   }
 
   class AddAliasExpectsIndex(alias: String) {
@@ -26,5 +28,12 @@ trait AliasesDsl {
     def filter(filter: FilterBuilder) = new AliasDefinition(aliasAction.filter(filter))
 
     def build = new IndicesAliasesRequest().addAliasAction(aliasAction)
+  }
+
+  class AliasQueryDefinition(request: IndicesGetAliasesRequest) extends IndicesRequestDefinition(IndicesGetAliasesAction.INSTANCE) {
+
+    def on(indices: String*) = new AliasQueryDefinition(request.indices(indices:_*))
+
+    def build = request
   }
 }

--- a/src/test/scala/com/sksamuel/elastic4s/AliasesTest.scala
+++ b/src/test/scala/com/sksamuel/elastic4s/AliasesTest.scala
@@ -61,4 +61,26 @@ class AliasesTest extends FlatSpec with MockitoSugar with ElasticSugar {
     assert(1 === resp.getHits.totalHits())
     assert("12" === resp.getHits.getAt(0).id())
   }
+
+  it should "be in query for alias" in {
+    val resp = client.sync.execute {
+      aliases get "english_waterways"
+    }
+
+    val waterwaysAliases = resp.getAliases.get("waterways")
+    assert(waterwaysAliases !== null)
+    assert(1 === waterwaysAliases.size)
+    assert("english_waterways" === waterwaysAliases.head.alias())
+  }
+
+  it should "be in query for alias on waterways" in {
+    val resp = client.sync.execute {
+      aliases get "english_waterways" on "waterways"
+    }
+
+    val waterwaysAliases = resp.getAliases.get("waterways")
+    assert(waterwaysAliases !== null)
+    assert(1 === waterwaysAliases.size)
+    assert("english_waterways" === waterwaysAliases.head.alias())
+  }
 }


### PR DESCRIPTION
Sample query:

``` scala
client.execute {
  aliases get "my-alias"
}
```
