### PR TITLE
Fixed inheritance of mapping.IndexOptions objects

### DIFF
--- a/src/main/scala/com/sksamuel/elastic4s/mapping/package.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/mapping/package.scala
@@ -23,9 +23,9 @@ package object mapping {
 
   sealed abstract class IndexOptions(val value: String)
   object IndexOptions {
-    case object Docs extends TermVector("docs")
-    case object Freqs extends TermVector("freqs")
-    case object Positions extends TermVector("positions")
+    case object Docs extends IndexOptions("docs")
+    case object Freqs extends IndexOptions("freqs")
+    case object Positions extends IndexOptions("positions")
   }
 
   sealed abstract class PostingsFormat(val value: String)


### PR DESCRIPTION
`mapping.IndexOptions` is `sealed abstract` so only usable _via_ its object instances, yet those extend `TemVector` instead, I guess from an unfinished copy-paste.
