### PR TITLE
Enable Routing in Mappings

### DIFF
--- a/src/main/scala/com/sksamuel/elastic4s/mapping/mappings.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/mapping/mappings.scala
@@ -13,11 +13,6 @@ trait MappingDsl {
   implicit def map(`type`: String) = new MappingDefinition(`type`)
 }
 
-case class RoutingDefinition (
-  required: Boolean,
-  path: Option[String]
-)
-
 class MappingDefinition(val `type`: String) {
 
   var _source = true
@@ -520,3 +515,8 @@ final class MultiFieldDefinition(name: String)
     source.endObject()
   }
 }
+
+case class RoutingDefinition (
+  required: Boolean,
+  path: Option[String]
+)


### PR DESCRIPTION
Added DSL element to enable routing during index creation. Usage:

Enable routing:
mappings ( 
   "comment" as (...) routing true
)

Enable routing with path
mappings ( 
   "comment" as (...) routing true Some("Path")
)
