### PR TITLE
Fix nested mapping properties

### DIFF
--- a/src/main/scala/com/sksamuel/elastic4s/mapping/mappings.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/mapping/mappings.scala
@@ -185,9 +185,11 @@ final class NestedFieldDefinition(name: String)
   def build(source: XContentBuilder): Unit = {
     source.startObject(name)
     insertType(source)
+    source.startObject("properties")
     for ( field <- _fields ) {
       field.build(source)
     }
+    source.endObject()
     source.endObject()
   }
 }

--- a/src/test/resources/com/sksamuel/elastic4s/mapping_nested.json
+++ b/src/test/resources/com/sksamuel/elastic4s/mapping_nested.json
@@ -45,16 +45,20 @@
             },
             "user": {
                 "type": "nested",
-                "name": {
-                    "type": "string"
-                },
-                "email": {
-                    "type": "string"
-                },
-                "last": {
-                    "type": "nested",
-                    "lastLogin": {
-                        "type": "date"
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "email": {
+                        "type": "string"
+                    },
+                    "last": {
+                        "type": "nested",
+                        "properties": {
+                            "lastLogin": {
+                                "type": "date"
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Properties of nested types should be within a properties object and not directly in the parent.

Current JSON output (incorrect):

``` json
{
  "type": {
    "nestedProp": {
      "type": "nested",
      "nested1": { "type": "string" },
      "nested2": { "type": "long" }
    }
  }
}
```

Correct JSON:

``` json
{
  "type": {
    "nestedProp": {
      "type": "nested",
      "properties": {
        "nested1": { "type": "string" },
        "nested2": { "type": "long" }
      }
    }
  }
}
```

This was causing ES to ignore the nested properties and create an empty nested type.
