### PR TITLE
Remove cache flags from parent/child filters

### DIFF
--- a/src/main/scala/com/sksamuel/elastic4s/filters.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/filters.scala
@@ -234,9 +234,7 @@ class RangeFilter(field: String)
 }
 
 class HasChildFilterDefinition(val builder: HasChildFilterBuilder)
-  extends FilterDefinition
-  with DefinitionAttributeCache
-  with DefinitionAttributeCacheKey {
+  extends FilterDefinition {
   val _builder = builder
   def name(name: String): HasChildFilterDefinition = {
     builder.filterName(name)
@@ -245,9 +243,7 @@ class HasChildFilterDefinition(val builder: HasChildFilterBuilder)
 }
 
 class HasParentFilterDefinition(val builder: HasParentFilterBuilder)
-  extends FilterDefinition
-  with DefinitionAttributeCache
-  with DefinitionAttributeCacheKey {
+  extends FilterDefinition {
   val _builder = builder
   def name(name: String): HasParentFilterDefinition = {
     builder.filterName(name)

--- a/src/test/resources/com/sksamuel/elastic4s/search_haschild_filter.json
+++ b/src/test/resources/com/sksamuel/elastic4s/search_haschild_filter.json
@@ -6,8 +6,6 @@
             }
         },
         "child_type": "singer",
-        "_name": "my-filter4",
-        "_cache": true,
-        "_cache_key": "band-singers"
+        "_name": "my-filter4"
     }
 }}

--- a/src/test/resources/com/sksamuel/elastic4s/search_hasparent_filter.json
+++ b/src/test/resources/com/sksamuel/elastic4s/search_hasparent_filter.json
@@ -6,8 +6,6 @@
             }
         },
         "parent_type": "singer",
-        "_name": "my-filter5",
-        "_cache": true,
-        "_cache_key": "band-singers"
+        "_name": "my-filter5"
     }
 }}

--- a/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
+++ b/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
@@ -336,7 +336,7 @@ class SearchDslTest extends FlatSpec with MockitoSugar with OneInstancePerTest {
     val req = search in "music" types "bands" filter {
       hasChildFilter("singer") filter {
         termFilter("name", "chris")
-      } cache true cacheKey "band-singers" name "my-filter4"
+      } name "my-filter4"
     } preference Preference.Primary
     assert(json === mapper.readTree(req._builder.toString))
   }
@@ -346,7 +346,7 @@ class SearchDslTest extends FlatSpec with MockitoSugar with OneInstancePerTest {
     val req = search in "music" types "bands" filter {
       hasParentFilter("singer") filter {
         termFilter("name", "chris")
-      } cache true cacheKey "band-singers" name "my-filter5"
+      } name "my-filter5"
     } preference Preference.Primary
     assert(json === mapper.readTree(req._builder.toString))
   }


### PR DESCRIPTION
`SearchDslTest` was setting the `cache` and `cacheKey` flags which were getting ignored when generating the JSON (and failing the tests). This removes them from the DSl.
