### PR TITLE
Fix delete by query

### DIFF
--- a/src/main/scala/com/sksamuel/elastic4s/DeleteDsl.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/DeleteDsl.scala
@@ -72,14 +72,22 @@ trait DeleteDsl extends QueryDsl with IndexesTypesDsl {
   class DeleteByQueryDefinition(indexesTypes: IndexesTypes, q: QueryDefinition)
       extends RequestDefinition(DeleteByQueryAction.INSTANCE) {
 
-    private val builder = new DeleteByQueryRequestBuilder(null).setIndices(indexesTypes.indexes: _*)
-      .setTypes(indexesTypes.types: _*)
-      .setQuery(q.builder)
+    private val builder: DeleteByQueryRequestBuilder =
+      new DeleteByQueryRequestBuilder(null)
+        .setIndices(indexesTypes.indexes: _*)
+        .setTypes(indexesTypes.types: _*)
 
     def types(types: String*): DeleteByQueryDefinition = {
       builder.setTypes(types.toSeq: _*)
       this
     }
-    def build = builder.request()
+
+    def build = {
+      val req = builder.request()
+
+      // need to set the query on the request - workaround for ES internals
+      val qsb = new QuerySourceBuilder().setQuery(q.builder)
+      req.source(qsb)
+    }
   }
 }

--- a/src/test/scala/com/sksamuel/elastic4s/DeleteTest.scala
+++ b/src/test/scala/com/sksamuel/elastic4s/DeleteTest.scala
@@ -66,13 +66,11 @@ class DeleteTest extends FlatSpec with MockitoSugar with ElasticSugar {
     blockUntilCount(2, "places")
   }
 
-  // todo looks like elasticsearch bug
-  //  it should "remove a document when deleting by query" in {
-  //    client.sync.execute {
-  //      // delete from "places" types "cities" where "continent:Europe"
-  //      delete from Seq("places") types Seq("cities") where "continent:Europe"
-  //    }
-  //    refresh("places")
-  //    blockUntilCount(1, "places")
-  //  }
+  it should "remove a document when deleting by query" in {
+    client.sync.execute {
+      delete from "places" types "cities" where matchQuery("continent", "Europe")
+    }
+    refresh("places")
+    blockUntilCount(1, "places")
+  }
 }


### PR DESCRIPTION
This is a workaround for the internal changes in ES to do with delete by query.

I had to change the test case to use a matchQuery instead of a simple string query to get it to work. I don't think this is a bug at our end but something that has changed in ES (I couldn't get delete by a query to work with a simple string on the REST API either).
