### PR TITLE
Add ability to add parent mappings typed as parent

### DIFF
--- a/src/main/scala/com/sksamuel/elastic4s/mapping/mappings.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/mapping/mappings.scala
@@ -175,6 +175,7 @@ private[mapping] class FieldDefinition(val name: String) {
   def typed(ft: ShortType.type) = new ShortFieldDefinition(name)
   def typed(ft: StringType.type) = new StringFieldDefinition(name)
   def typed(ft: TokenCountType.type) = new TokenCountDefinition(name)
+  def typed(ft: ParentType) = new ParentFieldDefinition(ft)
 
   def nested(fields: TypedFieldDefinition*) = new NestedFieldDefinition(name).as(fields: _*)
   def inner(fields: TypedFieldDefinition*) = new ObjectFieldDefinition(name).as(fields: _*)
@@ -188,6 +189,15 @@ abstract class TypedFieldDefinition(val `type`: FieldType, name: String) extends
   }
 
   private[mapping] def build(source: XContentBuilder): Unit
+}
+
+/** @author Jack Viers and Trent Johnson */
+final class ParentFieldDefinition(`type`: FieldType) extends TypedFieldDefinition(`type`, "_parent") {
+  def build(source: XContentBuilder) = {
+    source.startObject(name)
+    insertType(source)
+    source.endObject()
+  }
 }
 
 /** @author Fehmi Can Saglam */

--- a/src/main/scala/com/sksamuel/elastic4s/mapping/types.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/mapping/types.scala
@@ -22,4 +22,6 @@ object FieldType {
   case object ShortType extends FieldType("short")
   case object StringType extends FieldType("string")
   case object TokenCountType extends FieldType("token_count")
+  case class ParentType(_parent: String) extends FieldType(_parent)
 }
+

--- a/src/test/resources/json/createindex/create_parent_mappings.json
+++ b/src/test/resources/json/createindex/create_parent_mappings.json
@@ -1,0 +1,28 @@
+{
+    "mappings": {
+        "tags": {
+            "_all": {
+                "enabled": true
+            },
+            "_source": {
+                "enabled": true
+            },
+            "dynamic": "dynamic",
+            "numeric_detection": true,
+            "properties": {
+                "_parent": {
+                    "type": "docs"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        }
+    },
+    "settings": {
+        "index": {
+            "number_of_replicas": 1,
+            "number_of_shards": 5
+        }
+    }
+}

--- a/src/test/scala/com/sksamuel/elastic4s/CreateIndexDslTest.scala
+++ b/src/test/scala/com/sksamuel/elastic4s/CreateIndexDslTest.scala
@@ -86,6 +86,16 @@ class CreateIndexDslTest extends FlatSpec with MockitoSugar with JsonSugar with 
     req._source.string should matchJsonResource("/json/createindex/createindex_settings.json")
   }
 
+  it should "support creating parent mappings" in {
+    val req = create.index("docsAndTags").mappings(
+      "tags" as (
+        "tag" typed StringType,
+        "_parent" typed ParentType("docs")
+      )
+    )
+    req._source.string should matchJsonResource("/json/createindex/create_parent_mappings.json")
+  }
+
   it should "support inner objects" in {
     val req = create.index("tweets").shards(2).mappings(
       "tweet" as (


### PR DESCRIPTION
To add a parent mapping with the dsl, currently it is necessary to
create a special type and field definition. Adding these in will allow
users to use

``` scala
client.execute {
  create index "myIndex" mappings(
    "tags" as (
      "tag" typed StringType,
      "_parent" typed ParentType("my_parent_document_type")
    )
  )
}
```
