### PR TITLE
Update to Elasticsearch 1.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ name := "elastic4s"
 
 organization := "com.sksamuel.elastic4s"
 
-version := "1.0.1.2"
+version := "1.1.0.0"
 
 scalaVersion := "2.10.3"
 
@@ -30,7 +30,7 @@ parallelExecution in Test := false
 testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDF")
 
 libraryDependencies ++= Seq(
-  "org.elasticsearch"              %  "elasticsearch"               % "1.0.2",
+  "org.elasticsearch"              %  "elasticsearch"               % "1.1.0",
   "org.slf4j"                      %  "slf4j-api"                   % "1.6.6",
   "commons-io"                     %  "commons-io"                  % "2.4",
   "com.fasterxml.jackson.core"     %  "jackson-core"                % "2.1.3"  % "optional",

--- a/src/main/scala/com/sksamuel/elastic4s/IndexDsl.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/IndexDsl.scala
@@ -4,7 +4,6 @@ import org.elasticsearch.index.VersionType
 import org.elasticsearch.action.index.IndexRequest.OpType
 import org.elasticsearch.common.xcontent.{ XContentFactory, XContentBuilder }
 import org.elasticsearch.action.index.{ IndexAction, IndexRequest }
-import scala.collection.mutable.ListBuffer
 import scala.collection.JavaConverters._
 import com.sksamuel.elastic4s.source.{ DocumentMap, DocumentSource, Source }
 import scala.collection.mutable

--- a/src/main/scala/com/sksamuel/elastic4s/queries.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/queries.scala
@@ -29,14 +29,6 @@ trait QueryDsl {
     def query(q: String): CommonQueryDefinition = text(q)
   }
 
-  @deprecated("@deprecated use functionScoreQuery instead", "0.90.8")
-  def customScore = new CustomScoreDefinition
-  @deprecated("@deprecated use functionScoreQuery instead", "0.90.8")
-  def customBoost = new CustomBoostExpectingQuery
-  @deprecated("@deprecated use functionScoreQuery instead", "0.90.8")
-  class CustomBoostExpectingQuery {
-    def query(query: QueryDefinition) = new CustomBoostFactorQueryDefinition(query)
-  }
   def constantScore = new ConstantScoreExpectsQueryOrFilter
   class ConstantScoreExpectsQueryOrFilter {
     def query(query: QueryDefinition) = new ConstantScoreDefinition(QueryBuilders.constantScoreQuery(query.builder))
@@ -321,34 +313,6 @@ class HasParentQueryDefinition(`type`: String, q: QueryDefinition)
   }
 }
 
-@deprecated("@deprecated use functionScoreQuery instead", "0.90.8")
-class CustomScoreDefinition extends QueryDefinition {
-  private var _query: QueryDefinition = _
-  private var _boost: Double = _
-  private var _lang: String = _
-  private var _script: String = _
-  def builder = {
-    require(_query != null, "must specify query for custom score query")
-    QueryBuilders.customScoreQuery(_query.builder).script(_script).lang(_lang).boost(_boost.toFloat)
-  }
-  def query(query: QueryDefinition): CustomScoreDefinition = {
-    this._query = query
-    this
-  }
-  def boost(b: Double): CustomScoreDefinition = {
-    _boost = b
-    this
-  }
-  def script(script: String): CustomScoreDefinition = {
-    _script = script
-    this
-  }
-  def lang(lang: String): CustomScoreDefinition = {
-    _lang = lang
-    this
-  }
-}
-
 class ConstantScoreDefinition(val builder: ConstantScoreQueryBuilder) extends QueryDefinition {
   def boost(b: Double): QueryDefinition = {
     builder.boost(b.toFloat)
@@ -408,15 +372,6 @@ class CommonQueryDefinition(name: String, text: String)
   }
   def lowFreqOperator(operator: String): CommonQueryDefinition = {
     builder.lowFreqOperator(if (operator.toLowerCase == "and") Operator.AND else Operator.OR)
-    this
-  }
-}
-
-@deprecated("@deprecated use functionScoreQuery instead", "0.90.8")
-class CustomBoostFactorQueryDefinition(query: QueryDefinition) extends QueryDefinition {
-  val builder = QueryBuilders.customBoostFactorQuery(query.builder)
-  def boostFactor(b: Double): CustomBoostFactorQueryDefinition = {
-    builder.boostFactor(b.toFloat)
     this
   }
 }

--- a/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
+++ b/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
@@ -537,22 +537,6 @@ class SearchDslTest extends FlatSpec with MockitoSugar with JsonSugar with OneIn
     req._builder.toString should matchJsonResource("/json/search/search_query_terms.json")
   }
 
-  it should "generate correct json for custom boost query" in {
-    val req = search in "music" types "bands" query {
-      customBoost query {
-        ElasticDsl.regex("place", "Lon.*")
-      } boostFactor 10.0
-    }
-    req._builder.toString should matchJsonResource("/json/search/search_query_customboost.json")
-  }
-
-  it should "generate correct json for custom score query" in {
-    val req = search in "music" types "bands" query {
-      customScore script "somescript" lang "java" query "coldplay" boost 45.4
-    }
-    req._builder.toString should matchJsonResource("/json/search/search_query_custom_score.json")
-  }
-
   it should "generate correct json for multi match query" in {
     val req = search in "music" types "bands" query {
       multiMatchQuery("this is my query") fields ("name", "location", "genre") analyzer WhitespaceAnalyzer boost 3.4 cutoffFrequency 1.7 fuzziness "something" prefixLength 4 minimumShouldMatch 2 useDisMax true tieBreaker 4.5 zeroTermsQuery


### PR DESCRIPTION
This removes the custom score and custom boost query APIs as they have now been removed from ES.
