### PR TITLE
Allow any field type inside multi fields

### DIFF
--- a/src/main/scala/com/sksamuel/elastic4s/mapping/mappings.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/mapping/mappings.scala
@@ -188,7 +188,7 @@ private[mapping] class FieldDefinition(val name: String) {
 
   def nested(fields: TypedFieldDefinition*) = new NestedFieldDefinition(name).as(fields: _*)
   def inner(fields: TypedFieldDefinition*) = new ObjectFieldDefinition(name).as(fields: _*)
-  def multi(fields: StringFieldDefinition*) = new MultiFieldDefinition(name).as(fields: _*)
+  def multi(fields: TypedFieldDefinition*) = new MultiFieldDefinition(name).as(fields: _*)
 }
 
 abstract class TypedFieldDefinition(val `type`: FieldType, name: String) extends FieldDefinition(name) {


### PR DESCRIPTION
I stumbled upon this small issue that isn't allowing me to add arbitrarily typed fields to a multi-field using the DSL. I can add them at the moment by using:

```
new MultiFieldDefinition("fieldName") as ( /* field definitions with arbitrary types */ )
```

This PR should fix this so you can define:

```
"fieldName" multi ( /* field definitions with arbitrary types */ )
```

At the moment the syntax above will only work if putting just string fields in the multi.
