### PR TITLE
Forward timeout command in ElasticClient builder

### DIFF
--- a/src/main/scala/com/sksamuel/elastic4s/Client.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/Client.scala
@@ -341,6 +341,6 @@ object ElasticClient {
 
   def local: ElasticClient = local(ImmutableSettings.settingsBuilder().build())
   def local(settings: Settings, timeout: Long = DefaultTimeout): ElasticClient =
-    fromNode(NodeBuilder.nodeBuilder().local(true).data(true).settings(settings).node())
+    fromNode(NodeBuilder.nodeBuilder().local(true).data(true).settings(settings).node(), timeout)
 
 }


### PR DESCRIPTION
The timeout parameter to the `local` method of `ElasticClient` is not currently passed on the `fromNode`.
