### PR TITLE
Added a few lines to support min_doc_count, format, order, pre/post offs...

### DIFF
--- a/src/main/scala/com/sksamuel/elastic4s/CharFilter.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/CharFilter.scala
@@ -25,7 +25,7 @@ case class MappingCharFilter(name: String, mappings: (String, String)*)
   val filterType = "mapping"
 
   def build(source: XContentBuilder): Unit = {
-    source.field("mappings", mappings.map({ case (k, v) => s"$k=>$v"}).toArray: _*)
+    source.field("mappings", mappings.map({ case (k, v) => s"$k=>$v" }).toArray: _*)
   }
 
 }

--- a/src/main/scala/com/sksamuel/elastic4s/aggregations.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/aggregations.scala
@@ -3,7 +3,7 @@ package com.sksamuel.elastic4s
 import org.elasticsearch.search.aggregations.metrics.cardinality.CardinalityBuilder
 import org.elasticsearch.search.aggregations.{ AbstractAggregationBuilder, AggregationBuilder, AggregationBuilders }
 import org.elasticsearch.search.aggregations.bucket.terms.{ TermsBuilder, Terms }
-import org.elasticsearch.search.aggregations.bucket.histogram.{ DateHistogramBuilder, HistogramBuilder, DateHistogram }
+import org.elasticsearch.search.aggregations.bucket.histogram.{ Histogram, DateHistogramBuilder, HistogramBuilder, DateHistogram }
 import org.elasticsearch.common.geo.{ GeoPoint, GeoDistance }
 import org.elasticsearch.search.aggregations.bucket.range.RangeBuilder
 import org.elasticsearch.search.aggregations.bucket.range.date.DateRangeBuilder
@@ -250,6 +250,47 @@ class DateHistogramAggregation(name: String) extends AggregationDefinition[DateH
     builder.interval(interval)
     this
   }
+
+  def minDocCount(minDocCount: Long) = {
+    builder.minDocCount(minDocCount)
+    this
+  }
+
+  def preZone(preZone: String) = {
+    builder.preZone(preZone)
+    this
+  }
+
+  def postZone(postZone: String) = {
+    builder.postZone(postZone)
+    this
+  }
+
+  def preOffset(preOffset: Long) = {
+    builder.preOffset(preOffset)
+    this
+  }
+
+  def postOffset(postOffset: Long) = {
+    builder.preOffset(postOffset)
+    this
+  }
+
+  def order(order: Histogram.Order) = {
+    builder.order(order)
+    this
+  }
+
+  def preZoneAdjustLargeInterval(preZoneAdjustLargeInterval: Boolean) = {
+    builder.preZoneAdjustLargeInterval(preZoneAdjustLargeInterval)
+    this
+  }
+
+  def format(format: String) = {
+    builder.format(format)
+    this
+  }
+
 }
 
 class GeoDistanceAggregationDefinition(name: String) extends AggregationDefinition[GeoDistanceAggregationDefinition, GeoDistanceBuilder] {

--- a/src/test/resources/json/search/search_aggregations_datehistogram.json
+++ b/src/test/resources/json/search/search_aggregations_datehistogram.json
@@ -3,7 +3,8 @@
         "years": {
             "date_histogram": {
                 "field": "date",
-                "interval": "1y"
+                "interval": "1y",
+                "min_doc_count":0
             }
         }
     }

--- a/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
+++ b/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
@@ -656,7 +656,7 @@ class SearchDslTest extends FlatSpec with MockitoSugar with JsonSugar with OneIn
 
   it should "generate correct json for datehistogram aggregation" in {
     val req = search in "music" types "bands" aggs {
-      aggregation datehistogram "years" field "date" interval DateHistogram.Interval.YEAR
+      aggregation datehistogram "years" field "date" interval DateHistogram.Interval.YEAR minDocCount 0
     }
     req._builder.toString should matchJsonResource("/json/search/search_aggregations_datehistogram.json")
   }


### PR DESCRIPTION
Added a few lines to support [min_doc_count, format, order, pre/post offset/zone](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html)
