### PR TITLE
Add GetDefinition parent() to scala DSL

### DIFF
--- a/src/main/scala/com/sksamuel/elastic4s/GetDsl.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/GetDsl.scala
@@ -30,6 +30,11 @@ case class GetDefinition(indexesTypes: IndexesTypes, id: String)
     this
   }
 
+  def parent(p: String) = {
+    _builder.parent(p)
+    this
+  }
+
   def realtime(r: Boolean) = {
     _builder.realtime(r)
     this

--- a/src/test/scala/com/sksamuel/elastic4s/GetDslTest.scala
+++ b/src/test/scala/com/sksamuel/elastic4s/GetDslTest.scala
@@ -46,4 +46,16 @@ class GetDslTest extends FlatSpec with Matchers with ElasticSugar {
     req.build.fields() should be(null)
     req.build.fetchSourceContext().fetchSource should be(false)
   }
+
+  it should "should support routing" in {
+    val req = get id 123 from "places/cities" routing "aroundwego"
+    assert(req.build.routing() === "aroundwego")
+  }
+
+  it should "should support parent" in {
+    val req = get id 123 from "places/cities" parent "whosyour"
+    // NOTE: parent just alternately sets "routing"
+    assert(req.build.routing() === "whosyour")
+  }
+
 }


### PR DESCRIPTION
This is a pretty minor change, but I am submitting it so the "next guy" doesn't get confused like I did.

When I first stumbled on the missing parent() method in the DSL, I implemented a workaround in my code to be able to get my child documents.  It was only when I went to add the parent() method to GetDefinition and implement the simple unit test that I noticed that setting parent() and routing() are really identical.  In fact there is no getter for parent(), so the unit test has to access routing() to check the value that was set.

So at this point I have a clean workaround in my application (use routing() rather than parent()), but I still feel this should be pushed into elastic to prevent confusion for others.
