### PR TITLE
Use match_all as default filter in filtered query

### DIFF
--- a/src/main/scala/com/sksamuel/elastic4s/queries.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/queries.scala
@@ -465,7 +465,7 @@ class DisMaxDefinition extends QueryDefinition {
 
 class FilteredQueryDefinition extends QueryDefinition {
   def builder = QueryBuilders.filteredQuery(_query, _filter).boost(_boost.toFloat)
-  private var _query: QueryBuilder = null
+  private var _query: QueryBuilder = QueryBuilders.matchAllQuery
   private var _filter: FilterBuilder = null
   private var _boost: Double = -1d
   def boost(boost: Double): FilteredQueryDefinition = {
@@ -473,7 +473,7 @@ class FilteredQueryDefinition extends QueryDefinition {
     this
   }
   def query(query: => QueryDefinition): FilteredQueryDefinition = {
-    _query = Option(query).map(_.builder).orNull
+    _query = Option(query).map(_.builder).getOrElse(_query)
     this
   }
   def filter(filter: => FilterDefinition): FilteredQueryDefinition = {

--- a/src/test/resources/json/search/search_default_query.json
+++ b/src/test/resources/json/search/search_default_query.json
@@ -1,0 +1,12 @@
+{
+  "filtered" : {
+    "query" : {
+      "match_all" : { }
+    },
+    "filter" : {
+      "term" : {
+        "singer" : "lemmy"
+      }
+    }
+  }
+}

--- a/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
+++ b/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
@@ -905,5 +905,11 @@ class SearchDslTest extends FlatSpec with MockitoSugar with JsonSugar with OneIn
     }
     req._builder.toString should matchJsonResource("/json/search/search_and_filter.json")
   }
+
+  it should "generate correct json for default filtered query" in {
+    val req = filteredQuery filter termFilter("singer", "lemmy")
+
+    req.builder.toString should matchJsonResource("/json/search/search_default_query.json")
+  }
 }
 


### PR DESCRIPTION
In the Elasticsearch JSON search DSL, using a filtered query without a
query will use the match_all query by default. This change mimics that
behaviour in the Scala DSL, which avoids an exception when not
specifying a query.

Fixes #186
