### PR TITLE
#192 top hits aggregation support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ parallelExecution in Test := false
 testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDF")
 
 libraryDependencies ++= Seq(
-  "org.elasticsearch"              %  "elasticsearch"               % "1.3.0",
+  "org.elasticsearch"              %  "elasticsearch"               % "1.3.2",
   "org.slf4j"                      %  "slf4j-api"                   % "1.7.7",
   "commons-io"                     %  "commons-io"                  % "2.4",
   "com.fasterxml.jackson.core"     %  "jackson-core"                % "2.4.1"  % "optional" ,

--- a/src/main/scala/com/sksamuel/elastic4s/aggregations.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/aggregations.scala
@@ -1,17 +1,17 @@
 package com.sksamuel.elastic4s
 
-import org.elasticsearch.search.aggregations.metrics.cardinality.CardinalityBuilder
-import org.elasticsearch.search.aggregations.{ AbstractAggregationBuilder, AggregationBuilder, AggregationBuilders }
-import org.elasticsearch.search.aggregations.bucket.terms.{ TermsBuilder, Terms }
-import org.elasticsearch.search.aggregations.bucket.histogram.{ Histogram, DateHistogramBuilder, HistogramBuilder, DateHistogram }
-import org.elasticsearch.common.geo.{ GeoPoint, GeoDistance }
+import org.elasticsearch.common.geo.{ GeoDistance, GeoPoint }
+import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder
+import org.elasticsearch.search.aggregations.bucket.histogram.{ DateHistogram, DateHistogramBuilder, Histogram, HistogramBuilder }
 import org.elasticsearch.search.aggregations.bucket.range.RangeBuilder
 import org.elasticsearch.search.aggregations.bucket.range.date.DateRangeBuilder
 import org.elasticsearch.search.aggregations.bucket.range.geodistance.GeoDistanceBuilder
-import org.elasticsearch.search.aggregations.bucket.filter.FilterAggregationBuilder
-import org.elasticsearch.search.aggregations.metrics
-import org.elasticsearch.search.aggregations.metrics.{ MetricsAggregationBuilder, ValuesSourceMetricsAggregationBuilder }
 import org.elasticsearch.search.aggregations.bucket.significant.SignificantTermsBuilder
+import org.elasticsearch.search.aggregations.bucket.terms.{ Terms, TermsBuilder }
+import org.elasticsearch.search.aggregations.metrics.cardinality.CardinalityBuilder
+import org.elasticsearch.search.aggregations.metrics.{ MetricsAggregationBuilder, ValuesSourceMetricsAggregationBuilder }
+import org.elasticsearch.search.aggregations.{ AbstractAggregationBuilder, AggregationBuilder, AggregationBuilders, metrics }
+import org.elasticsearch.search.sort.SortBuilder
 
 /** @author Nicolas Yzet */
 
@@ -36,6 +36,7 @@ trait AggregationDsl {
     def extendedstats(name: String) = new ExtendedStatsAggregationDefinition(name)
     def count(name: String) = new ValueCountAggregationDefinition(name)
     def cardinality(name: String) = new CardinalityAggregationDefinition(name)
+    def topHits(name: String) = new TopHitsAggregationDefinition(name)
   }
 }
 
@@ -430,4 +431,30 @@ class ValueCountAggregationDefinition(name: String) extends ValuesSourceMetricsA
 
 class CardinalityAggregationDefinition(name: String) extends CardinalityMetricsAggregationDefinition[CardinalityAggregationDefinition] {
   val aggregationBuilder = AggregationBuilders.cardinality(name)
+}
+
+class TopHitsAggregationDefinition(name: String) extends AbstractAggregationDefinition {
+  val builder = AggregationBuilders.topHits(name)
+
+  def from(from: Int): this.type = {
+    builder.setFrom(from)
+    this
+  }
+
+  def size(size: Int): this.type = {
+    builder.setSize(size)
+    this
+  }
+
+  def sort(sorts: SortDefinition*): this.type = sort2(sorts.map(_.builder): _*)
+  def sort2(sorts: SortBuilder*): this.type = {
+    sorts.foreach(builder addSort)
+    this
+  }
+
+  def fetchSource(includes: Array[String], excludes: Array[String]): this.type = {
+    builder.setFetchSource(includes, excludes)
+    this
+  }
+
 }

--- a/src/test/resources/json/search/search_aggregations_top_hits.json
+++ b/src/test/resources/json/search/search_aggregations_top_hits.json
@@ -1,0 +1,31 @@
+{
+    "aggregations": {
+        "top-tags": {
+            "terms": {
+                "field": "tags",
+                "size": 3,
+                "order":{"_count":"desc"}
+            },
+            "aggregations": {
+                "top_tag_hits": {
+                    "top_hits": {
+                        "size" : 1,
+                        "_source": {
+                            "includes": [
+                                "title"
+                            ],
+                            "excludes": []
+                        },
+                        "sort": [
+                            {
+                                "last_activity_date": {
+                                    "order": "desc"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
+++ b/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
@@ -720,6 +720,15 @@ class SearchDslTest extends FlatSpec with MockitoSugar with JsonSugar with OneIn
     req._builder.toString should matchJsonResource("/json/search/search_aggregations_terms.json")
   }
 
+  it should "generate correct json for top hits aggregation" in {
+    val req = search in "music" types "bands" aggs {
+      aggregation terms "top-tags" field "tags" size 3 order Terms.Order.count(false) aggregations (
+        aggregation topHits ("top_tag_hits") size 1 sort { by field "last_activity_date" order SortOrder.DESC } fetchSource (Array("title"), Array.empty)
+      )
+    }
+    req._builder.toString should matchJsonResource("/json/search/search_aggregations_top_hits.json")
+  }
+
   it should "generate correct json for geodistance aggregation" in {
     val req = search in "music" types "bands" aggs {
       aggregation geodistance "geo_agg" field "geo_point" point (45.0, 27.0) geoDistance GeoDistance.ARC range (1.0, 1.0)


### PR DESCRIPTION
I tried,

I feel that elasticsearch org.elasticsearch.search.aggregations.metrics.tophits.TopHitsBuilder https://github.com/elasticsearch/elasticsearch/blob/master/src/main/java/org/elasticsearch/search/aggregations/metrics/tophits/TopHitsBuilder.java#L35 should extend MetricsAggregationBuilder[B] or AggregationBuilder[B] and not just extend AbstractAggregationBuilder to easily fit into elastic4s. Currently I implemented just few methods from this builder, but AFAIS not all builders are fully implemented in elastic4s, e.g. CardinalityBuilder is not reflected.

Anyway - let me know if this PR needs some improvement to merge it
