### PR TITLE
Add operator keyword to multi-match queries

### DIFF
--- a/src/main/scala/com/sksamuel/elastic4s/queries.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/queries.scala
@@ -303,16 +303,21 @@ class MultiMatchQueryDefinition(text: String)
     builder.maxExpansions(maxExpansions)
     this
   }
+
   def fields(_fields: Iterable[String]) = {
     for (f <- _fields) builder.field(f)
     this
   }
+
   def fields(_fields: String*): MultiMatchQueryDefinition = fields(_fields.toIterable)
+
   def boost(boost: Double): MultiMatchQueryDefinition = {
     builder.boost(boost.toFloat)
     this
   }
+
   def analyzer(a: Analyzer): MultiMatchQueryDefinition = analyzer(a.name)
+
   def analyzer(a: String): MultiMatchQueryDefinition = {
     builder.analyzer(a)
     this
@@ -322,21 +327,38 @@ class MultiMatchQueryDefinition(text: String)
     builder.minimumShouldMatch(minimumShouldMatch.toString)
     this
   }
+
   @deprecated("@deprecated use a tieBreaker of 1.0f to disable dis-max query or select the appropriate Type", "1.2.0")
   def useDisMax(useDisMax: Boolean): MultiMatchQueryDefinition = {
     builder.useDisMax(java.lang.Boolean.valueOf(useDisMax))
     this
   }
+
   def lenient(l: Boolean): MultiMatchQueryDefinition = {
     builder.lenient(l)
     this
   }
+
   def zeroTermsQuery(q: MatchQueryBuilder.ZeroTermsQuery): MultiMatchQueryDefinition = {
     builder.zeroTermsQuery(q)
     this
   }
+
   def tieBreaker(tieBreaker: Double): MultiMatchQueryDefinition = {
     builder.tieBreaker(java.lang.Float.valueOf(tieBreaker.toFloat))
+    this
+  }
+
+  def operator(op: MatchQueryBuilder.Operator): MultiMatchQueryDefinition = {
+    builder.operator(op)
+    this
+  }
+
+  def operator(op: String): MultiMatchQueryDefinition = {
+    op match {
+      case "AND" => builder.operator(org.elasticsearch.index.query.MatchQueryBuilder.Operator.AND)
+      case _ => builder.operator(org.elasticsearch.index.query.MatchQueryBuilder.Operator.OR)
+    }
     this
   }
 }

--- a/src/test/resources/json/search/search_query_multi_match.json
+++ b/src/test/resources/json/search/search_query_multi_match.json
@@ -18,7 +18,8 @@
             "tie_breaker": 4.5,
             "lenient": true,
             "cutoff_frequency": 1.7,
-            "zero_terms_query": "ALL"
+            "zero_terms_query": "ALL",
+            "operator": "AND"
         }
     }
 }

--- a/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
+++ b/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
@@ -11,7 +11,7 @@ import org.elasticsearch.search.facet.terms.TermsFacet
 import org.elasticsearch.common.geo.GeoDistance
 import org.elasticsearch.common.unit.DistanceUnit
 import com.sksamuel.elastic4s.Preference.Shards
-import org.elasticsearch.index.query.MatchQueryBuilder.ZeroTermsQuery
+import org.elasticsearch.index.query.MatchQueryBuilder.{ Operator, ZeroTermsQuery }
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogram
 import org.elasticsearch.search.aggregations.bucket.terms.Terms
 
@@ -570,7 +570,7 @@ class SearchDslTest extends FlatSpec with MockitoSugar with JsonSugar with OneIn
   it should "generate correct json for multi match query" in {
     val req = search in "music" types "bands" query {
       multiMatchQuery("this is my query") fields ("name", "location", "genre") analyzer WhitespaceAnalyzer boost 3.4 cutoffFrequency 1.7 fuzziness "something" prefixLength 4 minimumShouldMatch 2 useDisMax true tieBreaker 4.5 zeroTermsQuery
-        MatchQueryBuilder.ZeroTermsQuery.ALL fuzzyRewrite "some-rewrite" maxExpansions 4 lenient true prefixLength 4
+        MatchQueryBuilder.ZeroTermsQuery.ALL fuzzyRewrite "some-rewrite" maxExpansions 4 lenient true prefixLength 4 operator Operator.AND
     }
     req._builder.toString should matchJsonResource("/json/search/search_query_multi_match.json")
   }


### PR DESCRIPTION
Brings `MultiMatchQueryDefinition` in line with `MatchQueryDefinition` and the ES API:

Example:

``` scala
client.execute {
  search in "index/type" query {
    multiMatchQuery("query") fields ("a", "b") operator Operator.AND
  }
}
```
