### PR TITLE
geo bounds aggregation DSL

### DIFF
--- a/src/main/scala/com/sksamuel/elastic4s/aggregations.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/aggregations.scala
@@ -9,6 +9,7 @@ import org.elasticsearch.search.aggregations.bucket.range.geodistance.GeoDistanc
 import org.elasticsearch.search.aggregations.bucket.significant.SignificantTermsBuilder
 import org.elasticsearch.search.aggregations.bucket.terms.{ Terms, TermsBuilder }
 import org.elasticsearch.search.aggregations.metrics.cardinality.CardinalityBuilder
+import org.elasticsearch.search.aggregations.metrics.geobounds.GeoBoundsBuilder
 import org.elasticsearch.search.aggregations.metrics.{ MetricsAggregationBuilder, ValuesSourceMetricsAggregationBuilder }
 import org.elasticsearch.search.aggregations.{ AbstractAggregationBuilder, AggregationBuilder, AggregationBuilders, metrics }
 import org.elasticsearch.search.sort.SortBuilder
@@ -26,6 +27,7 @@ trait AggregationDsl {
     def histogram(name: String) = new HistogramAggregation(name)
     def datehistogram(name: String) = new DateHistogramAggregation(name)
     def filter(name: String) = new FilterAggregationDefinition(name)
+    def geobounds(name: String) = new GeoBoundsAggregationDefinition(name)
     def geodistance(name: String) = new GeoDistanceAggregationDefinition(name)
     def min(name: String) = new MinAggregationDefinition(name)
     def max(name: String) = new MaxAggregationDefinition(name)
@@ -313,6 +315,20 @@ class DateHistogramAggregation(name: String) extends AggregationDefinition[DateH
     this
   }
 
+}
+
+class GeoBoundsAggregationDefinition(name: String) extends AggregationDefinition[GeoBoundsAggregationDefinition, GeoBoundsBuilder] {
+  val aggregationBuilder = AggregationBuilders.geoBounds(name)
+
+  def field(field: String): GeoBoundsAggregationDefinition = {
+    builder.field(field)
+    this
+  }
+
+  def wrapLongitude(wrapLongitude: Boolean): GeoBoundsAggregationDefinition = {
+    builder.wrapLongitude(wrapLongitude)
+    this
+  }
 }
 
 class GeoDistanceAggregationDefinition(name: String) extends AggregationDefinition[GeoDistanceAggregationDefinition, GeoDistanceBuilder] {

--- a/src/test/resources/json/search/search_aggregations_geobounds.json
+++ b/src/test/resources/json/search/search_aggregations_geobounds.json
@@ -1,0 +1,10 @@
+{
+    "aggregations": {
+        "geo_agg": {
+            "geo_bounds": {
+                "field": "geo_point",
+                "wrap_longitude": true
+            }
+        }
+    }
+}

--- a/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
+++ b/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
@@ -743,6 +743,13 @@ class SearchDslTest extends FlatSpec with MockitoSugar with JsonSugar with OneIn
     req._builder.toString should matchJsonResource("/json/search/search_aggregations_top_hits.json")
   }
 
+  it should "generate correct json for geobounds aggregation" in {
+    val req = search in "music" types "bands" aggs {
+      aggregation geobounds "geo_agg" field "geo_point" wrapLongitude true
+    }
+    req._builder.toString should matchJsonResource("/json/search/search_aggregations_geobounds.json")
+  }
+
   it should "generate correct json for geodistance aggregation" in {
     val req = search in "music" types "bands" aggs {
       aggregation geodistance "geo_agg" field "geo_point" point (45.0, 27.0) geoDistance GeoDistance.ARC range (1.0, 1.0)


### PR DESCRIPTION
This PR adds a new aggregation DSL option: `geobounds filter <filterName> wrapLongitude <true/false>`. Elastic search reference: [geo bounds aggregation](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-aggregations-metrics-geobounds-aggregation.html).

Test case added & passes. I've used the new aggregation in a project I'm working on and it's all good. I'd appreciate you pulling this into elastic4s.
