### PR TITLE
Added missing _ttl fields to tests

### DIFF
--- a/src/test/resources/json/createindex/create_parent_mappings.json
+++ b/src/test/resources/json/createindex/create_parent_mappings.json
@@ -10,6 +10,10 @@
             "_parent": {
                 "type": "docs"
             },
+
+            "_ttl": {
+                "enabled": false
+            },
             "dynamic": "dynamic",
             "numeric_detection": true,
             "properties": {

--- a/src/test/resources/json/createindex/createindex_mappings.json
+++ b/src/test/resources/json/createindex/createindex_mappings.json
@@ -22,6 +22,9 @@
             "_size": {
                 "enabled": true
             },
+            "_ttl": {
+                "enabled": false
+            },
             "properties": {
                 "_id": {
                     "type": "string",
@@ -49,6 +52,9 @@
             },
             "_source": {
                 "enabled": true
+            },
+            "_ttl": {
+                "enabled": false
             },
             "dynamic_date_formats": [
                 "mm/yyyy",

--- a/src/test/resources/json/createindex/mapping_completion_type.json
+++ b/src/test/resources/json/createindex/mapping_completion_type.json
@@ -22,6 +22,9 @@
             "_size": {
                 "enabled": true
             },
+            "_ttl": {
+                "enabled": false
+            },
             "properties": {
                 "name": {
                     "type": "string",

--- a/src/test/resources/json/createindex/mapping_copy_to_multiple_fields.json
+++ b/src/test/resources/json/createindex/mapping_copy_to_multiple_fields.json
@@ -22,6 +22,9 @@
             "_size": {
                 "enabled": true
             },
+            "_ttl": {
+                "enabled": false
+            },
             "properties": {
                 "title": {
                     "type": "string",

--- a/src/test/resources/json/createindex/mapping_copy_to_single_field.json
+++ b/src/test/resources/json/createindex/mapping_copy_to_single_field.json
@@ -22,6 +22,9 @@
             "_size": {
                 "enabled": true
             },
+            "_ttl": {
+                "enabled": false
+            },
             "properties": {
                 "first_name": {
                     "type": "string",

--- a/src/test/resources/json/createindex/mapping_inner_object.json
+++ b/src/test/resources/json/createindex/mapping_inner_object.json
@@ -22,6 +22,9 @@
             "_size": {
                 "enabled": true
             },
+            "_ttl": {
+                "enabled": false
+            },
             "properties": {
                 "person": {
                     "type": "object",

--- a/src/test/resources/json/createindex/mapping_inner_object_disabled.json
+++ b/src/test/resources/json/createindex/mapping_inner_object_disabled.json
@@ -22,6 +22,9 @@
             "_size": {
                 "enabled": true
             },
+            "_ttl": {
+                "enabled": false
+            },
             "properties": {
                 "person": {
                     "type": "object",

--- a/src/test/resources/json/createindex/mapping_multi_field_type_1.json
+++ b/src/test/resources/json/createindex/mapping_multi_field_type_1.json
@@ -22,6 +22,9 @@
             "_size": {
                 "enabled": true
             },
+            "_ttl": {
+                "enabled": false
+            },
             "properties": {
                 "name": {
                     "type": "multi_field",

--- a/src/test/resources/json/createindex/mapping_multi_field_type_2.json
+++ b/src/test/resources/json/createindex/mapping_multi_field_type_2.json
@@ -22,6 +22,9 @@
         "_size": {
             "enabled": true
         },
+        "_ttl": {
+            "enabled": false
+        },
         "properties": {
             "first_name": {
               "type": "object",

--- a/src/test/resources/json/createindex/mapping_nested.json
+++ b/src/test/resources/json/createindex/mapping_nested.json
@@ -22,6 +22,9 @@
             "_size": {
                 "enabled": true
             },
+            "_ttl": {
+                "enabled": false
+            },
             "properties": {
                 "_id": {
                     "type": "string",


### PR DESCRIPTION
Unit tests were failing due to a missing "_ttl" field on the JSON resources.

This problem probably appeared due to an ElasticSearch API update.
