### PR TITLE
token filter available as extension point.

### DIFF
--- a/src/main/scala/com/sksamuel/elastic4s/TokenFilter.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/TokenFilter.scala
@@ -2,7 +2,7 @@ package com.sksamuel.elastic4s
 
 import org.elasticsearch.common.xcontent.XContentBuilder
 
-sealed trait TokenFilter extends AnalyzerFilter
+trait TokenFilter extends AnalyzerFilter
 
 sealed trait TokenFilterDefinition extends TokenFilter with AnalyzerFilterDefinition
 


### PR DESCRIPTION
Some token filters depends on elastic search plugins so they cannot be backported in elastic4s (not generic filters). Making the trait available from outside the file let the user define his own filters.
