### PR TITLE
Allow text-based minimum-should-match params to multi-match query

### DIFF
--- a/src/main/scala/com/sksamuel/elastic4s/queries.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/queries.scala
@@ -372,6 +372,11 @@ class MultiMatchQueryDefinition(text: String)
     this
   }
 
+  def minimumShouldMatch(minimumShouldMatch: String): MultiMatchQueryDefinition = {
+    builder.minimumShouldMatch(minimumShouldMatch: String)
+    this
+  }
+
   @deprecated("@deprecated use a tieBreaker of 1.0f to disable dis-max query or select the appropriate Type", "1.2.0")
   def useDisMax(useDisMax: Boolean): MultiMatchQueryDefinition = {
     builder.useDisMax(java.lang.Boolean.valueOf(useDisMax))

--- a/src/test/resources/json/search/search_query_multi_match_minimum_should_match.json
+++ b/src/test/resources/json/search/search_query_multi_match_minimum_should_match.json
@@ -1,0 +1,14 @@
+{
+    "query": {
+        "multi_match": {
+            "query" : "this is my query",
+            "fields":[
+                "name",
+                "location",
+                "genre"
+            ],
+            "type": "best_fields",
+            "minimum_should_match": "2<-1 5<80%"
+        }
+   }
+}

--- a/src/test/scala/com/sksamuel/elastic4s/GetTest.scala
+++ b/src/test/scala/com/sksamuel/elastic4s/GetTest.scala
@@ -10,7 +10,7 @@ class GetTest extends FlatSpec with Matchers with ScalaFutures with MockitoSugar
 
   client.execute {
     bulk(
-      index into "beer/lager" fields("name" -> "coors light", "brand" -> "coors", "ingredients" -> Seq("hops",
+      index into "beer/lager" fields ("name" -> "coors light", "brand" -> "coors", "ingredients" -> Seq("hops",
         "barley",
         "water",
         "yeast")) id 4,

--- a/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
+++ b/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
@@ -590,6 +590,13 @@ class SearchDslTest extends FlatSpec with MockitoSugar with JsonSugar with OneIn
     req._builder.toString should matchJsonResource("/json/search/search_query_multi_match.json")
   }
 
+  it should "generate correct json for multi match query with minimum should match text clause" in {
+    val req = search in "music" types "bands" query {
+      multiMatchQuery("this is my query") fields ("name", "location", "genre") minimumShouldMatch "2<-1 5<80%" matchType "best_fields"
+    }
+    req._builder.toString should matchJsonResource("/json/search/search_query_multi_match_minimum_should_match.json")
+  }
+
   it should "generate correct json for geo distance filter" in {
     val req = search in "music" types "bands" filter {
       bool(


### PR DESCRIPTION
Currently only integer based minimum-should-match params are supported in multi-match query, adding another method to support the full range of minimum-should-match configurations.
