### PR TITLE
Fix typo in doc with `mapping` package

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ or multiple other options
 To do this we add mappings:
 
 ```scala
-import com.sksamuel.elastic4s.mapping.FieldType._
+import com.sksamuel.elastic4s.mappings.FieldType._
 import com.sksamuel.elastic4s.StopAnalyzer
 
 client.execute {

--- a/guide/createindex.md
+++ b/guide/createindex.md
@@ -13,7 +13,7 @@ Lets start by defining an index called `places` that has a single type (`city`) 
 ```scala
 // imports - will be omitted for other examples
 import com.sksamuel.elastic4s.ElasticDsl._
-import com.sksamuel.elastic4s.mapping.FieldType._
+import com.sksamuel.elastic4s.mappings.FieldType._
 
 client.execute {
   create index "places" mappings (


### PR DESCRIPTION
Just a fix for a very small typo in doc
