### PR TITLE
Now delimiter and replacement PathHierarchyTokenizer parameters are pass...

### DIFF
--- a/src/main/scala/com/sksamuel/elastic4s/Tokenizer.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/Tokenizer.scala
@@ -92,8 +92,8 @@ case class PathHierarchyTokenizer(override val name: String,
                                   skip: Int = 0) extends CustomizedTokenizer(name) {
   override def build(source: XContentBuilder): Unit = {
     source.field("type", "path_hierarchy")
-    source.field("delimiter", delimiter)
-    source.field("replacement", replacement)
+    source.field("delimiter", delimiter.toString)
+    source.field("replacement", replacement.toString)
     if (bufferSize > 1024) source.field("buffer_size", bufferSize)
     if (reverse) source.field("reverse", reverse)
     if (skip > 0) source.field("skip", skip)


### PR DESCRIPTION
...ed to XContentBuilder as String (as expected), not as Number.

The generated object was:
"testTokenizer": {
                    "type": "path_hierarchy",
                    "delimiter": 47,
                    "replacement": 47
                }

With this change, now it is:
"testTokenizer": {
                    ""type": "path_hierarchy",
                    "delimiter": "/",
                    "replacement": "/"
                }

The first object was rejected by elasticsearch with:
org.elasticsearch.ElasticsearchIllegalArgumentException: delimiter can only be a one char value

With the second it works.
Thanks, hope it helps some people :)
