### PR TITLE
abstract out ElasticSugar.blockUntil so it can be reused for other predicates

### DIFF
--- a/src/test/scala/com/sksamuel/elastic4s/ElasticSugar.scala
+++ b/src/test/scala/com/sksamuel/elastic4s/ElasticSugar.scala
@@ -57,7 +57,7 @@ trait ElasticSugar extends BeforeAndAfterAll with Logging {
       try {
         done = predicate()
       } catch {
-        case e: Throwable ⇒ //ignore
+        case e: Throwable ⇒ logger.warn("problem while testing predicate", e)
       }
     }
 


### PR DESCRIPTION
ElasticSugar used to have only `blockUntilCount`, now we have `blockUntil which takes a message and a predicate` and `blockUntilCount` which uses the former.
This way we can reuse it to assert other things than counts. 