### PR TITLE
Weight parameter per function in function score

### DIFF
--- a/src/main/scala/com/sksamuel/elastic4s/scorers.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/scorers.scala
@@ -41,8 +41,8 @@ trait ScoreDefinition[T] {
     this._filter = Option(filter)
     this.asInstanceOf[T]
   }
-  def weight(weight: Double): T = {
-    builder.setWeight(weight.toFloat)
+  def weight(boost: Double): T = {
+    builder.setWeight(boost.toFloat)
     this.asInstanceOf[T]
   }
 }

--- a/src/main/scala/com/sksamuel/elastic4s/scorers.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/scorers.scala
@@ -41,6 +41,10 @@ trait ScoreDefinition[T] {
     this._filter = Option(filter)
     this.asInstanceOf[T]
   }
+  def weight(weight: Double): T = {
+    builder.setWeight(weight.toFloat)
+    this.asInstanceOf[T]
+  }
 }
 
 class FieldValueFactorDefinition(fieldName: String) extends ScoreDefinition[FieldValueFactorDefinition] {

--- a/src/test/resources/json/search/search_function_score.json
+++ b/src/test/resources/json/search/search_function_score.json
@@ -38,7 +38,7 @@
                             "band": "taylor swift"
                         }
                     },
-                    "weight": 1.2
+                    "boost_factor": 1.2
                 }
             ],
             "score_mode": "multiply",

--- a/src/test/resources/json/search/search_function_score.json
+++ b/src/test/resources/json/search/search_function_score.json
@@ -10,12 +10,14 @@
                 {
                     "random_score": {
                         "seed": 1234
-                    }
+                    },
+                    "weight": 1.2
                 },
                 {
                     "script_score": {
                         "script": "some script here"
-                    }
+                    },
+                    "weight": 0.5
                 },
                 {
                     "filter": {
@@ -36,7 +38,7 @@
                             "band": "taylor swift"
                         }
                     },
-                    "boost_factor": 1.2
+                    "weight": 1.2
                 }
             ],
             "score_mode": "multiply",

--- a/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
+++ b/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
@@ -625,7 +625,7 @@ class SearchDslTest extends FlatSpec with MockitoSugar with JsonSugar with OneIn
         randomScore(1234).weight(1.2),
         scriptScore("some script here").weight(0.5),
         gaussianScore("field1", "1m", "2m").filter(termFilter("band", "coldplay")),
-        weightScore(1.2).filter(termFilter("band", "taylor swift"))
+        factorScore(1.2).filter(termFilter("band", "taylor swift"))
       )
     }
     req._builder.toString should matchJsonResource("/json/search/search_function_score.json")

--- a/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
+++ b/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
@@ -622,10 +622,10 @@ class SearchDslTest extends FlatSpec with MockitoSugar with JsonSugar with OneIn
   it should "generate correct json for function score query" in {
     val req = search in "music" types "bands" query {
       functionScoreQuery("coldplay").boost(1.4).maxBoost(1.9).scoreMode("multiply").boostMode("max").scorers(
-        randomScore(1234),
-        scriptScore("some script here"),
+        randomScore(1234).weight(1.2),
+        scriptScore("some script here").weight(0.5),
         gaussianScore("field1", "1m", "2m").filter(termFilter("band", "coldplay")),
-        factorScore(1.2).filter(termFilter("band", "taylor swift"))
+        weightScore(1.2).filter(termFilter("band", "taylor swift"))
       )
     }
     req._builder.toString should matchJsonResource("/json/search/search_function_score.json")


### PR DESCRIPTION
[By es1.4](https://github.com/elasticsearch/elasticsearch/commit/c5ff70bf430a81702c6e429942a8a56d0287f468):
Weights can be defined per function like this:

```
"function_score": {
    "functions": [
        {
            "filter": {},
            "FUNCTION": {},
            "weight": number
        }
        ...
```
If `weight` is given without `FUNCTION` then `weight` behaves like `boost_factor`.
This commit deprecates `boost_factor`.