### PR TITLE
Make the library compatible with ES 1.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,7 +34,7 @@ parallelExecution in Test := false
 testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDF")
 
 libraryDependencies ++= Seq(
-  "org.elasticsearch"              %  "elasticsearch"               % "1.4.4",
+  "org.elasticsearch"              %  "elasticsearch"               % "1.5.0",
   "org.slf4j"                      %  "slf4j-api"                   % "1.7.7",
   "commons-io"                     %  "commons-io"                  % "2.4",
   "com.fasterxml.jackson.core"     %  "jackson-core"                % "2.4.4"  % "optional" ,

--- a/src/main/scala/com/sksamuel/elastic4s/OptimizeDsl.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/OptimizeDsl.scala
@@ -43,9 +43,4 @@ class OptimizeDefinition(indexes: String*) {
     builder.force(force)
     this
   }
-  def waitForMerge(waitForMerge: Boolean): OptimizeDefinition = {
-    if (waitForMerge)
-      builder.waitForMerge()
-    this
-  }
 }

--- a/src/main/scala/com/sksamuel/elastic4s/admin/SnapshotDsl.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/admin/SnapshotDsl.scala
@@ -12,12 +12,12 @@ import scala.concurrent.Future
 
 /** @author Stephen Samuel
   *
-  *    DSL Syntax:
+  *   DSL Syntax:
   *
-  *    repository create <repo> settings <settings>
-  *    snapshot create <name> in <repo>
-  *    snapshot delete <name> in <repo>
-  *    snapshot restore <name> from <repo>
+  *   repository create <repo> settings <settings>
+  *   snapshot create <name> in <repo>
+  *   snapshot delete <name> in <repo>
+  *   snapshot restore <name> from <repo>
   *
   */
 trait SnapshotDsl {

--- a/src/main/scala/com/sksamuel/elastic4s/queries.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/queries.scala
@@ -273,12 +273,6 @@ class MoreLikeThisQueryDefinition(fields: String*) extends QueryDefinition {
     this
   }
 
-  @deprecated(message = "use include instead", since = "1.3.2")
-  def notExclude() = {
-    _builder.exclude(false)
-    this
-  }
-
   def include() = {
     _builder.include(true)
     this


### PR DESCRIPTION
With this PR it is possible to use elastic4s when running ES 1.5. There were two minor issues that were caused by the removal of the methods `waitForMerge` and `exclude`. These are relevant commits in the ES repository:

https://github.com/elastic/elasticsearch/commit/a29b4a800dbac84a4aa89b19e0a4100e8d8507ce

https://github.com/elastic/elasticsearch/commit/f735baf306571ec9949514a14828f18058972044