### PR TITLE
AttachmentType to support AttributeFields

### DIFF
--- a/src/main/scala/com/sksamuel/elastic4s/mappings/mappings.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/mappings/mappings.scala
@@ -596,11 +596,13 @@ final class IpFieldDefinition(name: String)
 }
 
 final class AttachmentFieldDefinition(name: String)
-  extends TypedFieldDefinition(AttachmentType, name) {
+    extends TypedFieldDefinition(AttachmentType, name)
+    with AttributeFields {
 
   def build(source: XContentBuilder): Unit = {
     source.startObject(name)
     insertType(source)
+    super[AttributeFields].insert(source)
     source.endObject()
   }
 }


### PR DESCRIPTION
We can specify `fields` for `attachment` type according to the doc:
https://github.com/elastic/elasticsearch-mapper-attachments