### PR TITLE
Change release version in dependency from 0.90.13.10 -> 0.90.13.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ For more information read [Using Elastic4s in your project](#using-elastic4s-in-
 |1.2.3.0|1.2.x|
 |1.1.2.0|1.1.x|
 |1.0.3.0|1.0.x|
-|0.90.13.10|0.90.x|
+|0.90.13.2|0.90.x|
 
 #### Dependencies
 


### PR DESCRIPTION
I don't know where 0.90.13.10 is coming from but `sbt compile` fails with com.sksamuel.elastic4s#elastic4s_2.11;0.90.13.10: not found.
I found here http://search.maven.org/#search%7Cgav%7C2%7Cg%3A%22com.sksamuel.elastic4s%22%20AND%20a%3A%22elastic4s_2.11%22 that there exist version 0.90.13.2 and it actually resolves