### PR TITLE
Add timeout flag to cluster health request

### DIFF
--- a/src/main/scala/com/sksamuel/elastic4s/ClusterDsl.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/ClusterDsl.scala
@@ -18,5 +18,12 @@ trait ClusterDsl {
 }
 
 class ClusterHealthDefinition(indices: String*) {
-  def build = new ClusterHealthRequest(indices: _*)
+  val _builder = new ClusterHealthRequest(indices: _*)
+
+  def build = _builder
+
+  def timeout(value: String): this.type = {
+    _builder.timeout(value)
+    this
+  }
 }

--- a/src/test/scala/com/sksamuel/elastic4s/ClusterDslTest.scala
+++ b/src/test/scala/com/sksamuel/elastic4s/ClusterDslTest.scala
@@ -1,5 +1,6 @@
 package com.sksamuel.elastic4s
 
+import org.elasticsearch.common.unit.TimeValue
 import org.scalatest.{ Matchers, FlatSpec }
 import ElasticDsl._
 
@@ -13,5 +14,10 @@ class ClusterDslTest extends FlatSpec with Matchers {
   it should "accept a list of indices" in {
     val req = clusterHealth("index1", "index2")
     req.build.indices() should equal(Array("index1", "index2"))
+  }
+
+  it should "allow a timeout" in {
+    val req = clusterHealth timeout "1s"
+    req.build.timeout() should equal(TimeValue.timeValueSeconds(1))
   }
 }


### PR DESCRIPTION
Extends the `clusterHealth` request so you can set a timeout:

```scala
client.execute {
  clusterHealth timeout "2s"
}
``