### PR TITLE
Create index using raw source

### DIFF
--- a/src/main/scala/com/sksamuel/elastic4s/CreateIndexDsl.scala
+++ b/src/main/scala/com/sksamuel/elastic4s/CreateIndexDsl.scala
@@ -52,7 +52,10 @@ class CreateIndexDefinition(name: String) {
   val _settings = new IndexSettings
   var _analysis: Option[AnalysisDefinition] = None
 
-  def build = new CreateIndexRequest(name).source(_source)
+  def build = _rawSource match {
+    case Some(s) => new CreateIndexRequest(name).source(s)
+    case None => new CreateIndexRequest(name).source(_source)
+  }
 
   def shards(shards: Int): CreateIndexDefinition = {
     _settings.shards = shards
@@ -87,7 +90,14 @@ class CreateIndexDefinition(name: String) {
 
   def analysis(analyzers: AnalyzerDefinition*): this.type = analysis(analyzers)
 
-  def _source: XContentBuilder = {
+  var _rawSource: Option[String] = None
+
+  def source(source: String): CreateIndexDefinition = {
+    _rawSource = Some(source)
+    this
+  }
+
+  private[elastic4s] def _source: XContentBuilder = {
     val source = XContentFactory.jsonBuilder().startObject()
 
     if (_settings.settings.nonEmpty || _analysis.nonEmpty) {

--- a/src/test/scala/com/sksamuel/elastic4s/CreateIndexDslTest.scala
+++ b/src/test/scala/com/sksamuel/elastic4s/CreateIndexDslTest.scala
@@ -2,10 +2,12 @@ package com.sksamuel.elastic4s
 
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.mappings.FieldType._
-import com.sksamuel.elastic4s.mappings.{ DynamicMapping, Strict, PrefixTree }
+import com.sksamuel.elastic4s.mappings.{ DynamicMapping, PrefixTree }
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{ FlatSpec, Matchers, OneInstancePerTest }
+
 import scala.concurrent.duration._
+import scala.io.Source
 
 /** @author Stephen Samuel */
 class CreateIndexDslTest extends FlatSpec with MockitoSugar with JsonSugar with Matchers with OneInstancePerTest {
@@ -271,4 +273,13 @@ class CreateIndexDslTest extends FlatSpec with MockitoSugar with JsonSugar with 
     req._source.string should matchJsonResource("/json/createindex/createindex_timestamp_3.json")
   }
 
+  it should "accept pre-built mapping JSON" in {
+    val source = Source.fromInputStream(getClass.getResourceAsStream("/json/createindex/createindex_mappings.json")).mkString
+
+    val req = create.index("tweets").source(source).build
+
+    req.mappings().size() should equal(2)
+    req.mappings().containsKey("tweets") === true
+    req.mappings().containsKey("users") === true
+  }
 }


### PR DESCRIPTION
This allows you to supply a raw mapping JSON file to the create index request:

```scala
val mappingJson = // load source from file...
client.execute {
  create.index("tenants") source mappingJson
}
```

We need this as we create our mappings manually in production and auto-create them for tests using the same mapping files.