### PR TITLE
Add docValuesFormat to timestamp mapping

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/TimestampDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/TimestampDefinition.scala
@@ -6,12 +6,14 @@ case class TimestampDefinition(enabled: Boolean,
                                path: Option[String] = None,
                                format: Option[String] = None,
                                default: Option[String] = None,
-                               store: Option[Boolean] = None) {
+                               store: Option[Boolean] = None,
+                               docValuesFormat: Option[Boolean] = None) {
 
   def path(path: String): TimestampDefinition = copy(path = Option(path))
   def format(format: String): TimestampDefinition = copy(format = Option(format))
   def default(default: String): TimestampDefinition = copy(default = Option(default))
   def store(store: Boolean): TimestampDefinition = copy(store = Option(store))
+  def docValuesFormat(b: Boolean): TimestampDefinition = copy(docValuesFormat = Option(b))
 
   private[elastic4s] def build(builder: XContentBuilder): Unit = {
     builder.startObject("_timestamp")
@@ -19,6 +21,7 @@ case class TimestampDefinition(enabled: Boolean,
     path.foreach(builder.field("path", _))
     store.foreach(s => builder.field("store", if (s) "yes" else "no"))
     format.foreach(builder.field("format", _))
+    docValuesFormat.foreach(builder.field("doc_values", _))
     default.foreach(builder.field("default", _))
     builder.endObject()
   }


### PR DESCRIPTION
Hi,

as `doc_values` format will be the default in 2.0 for NotAnalyzed fields which `DateType` is, I find it important to have a chance to set it for `_timestamp` too. Also in huge datasets `_timestamp` is n1 field to sort by and it is not possible without `doc_values` format... WDYT ?