### PR TITLE
Add indices option to mapping, count and search dsl

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/CountDsl.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/CountDsl.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.elastic4s
 
 import org.elasticsearch.action.count.{ CountRequestBuilder, CountResponse }
-import org.elasticsearch.action.support.QuerySourceBuilder
+import org.elasticsearch.action.support.{ QuerySourceBuilder, IndicesOptions }
 import org.elasticsearch.client.Client
 import org.elasticsearch.index.query.{ QueryBuilder, QueryBuilders }
 
@@ -44,10 +44,16 @@ class CountDefinition(indexesTypes: IndexesTypes) {
     this
   }
 
-  /** The maximum count for each shard, upon reaching which the query execution will terminate early.
-    * If set, the response will have a boolean field terminated_early to indicate whether the query execution
-    * has actually terminated_early. Defaults to no terminate_after.
-    */
+  def indicesOptions(options: IndicesOptions): this.type = {
+    _builder.setIndicesOptions(options)
+    this
+  }
+
+  /**
+   * The maximum count for each shard, upon reaching which the query execution will terminate early.
+   * If set, the response will have a boolean field terminated_early to indicate whether the query execution
+   * has actually terminated_early. Defaults to no terminate_after.
+   */
   def terminateAfter(termAfter: Int): this.type = {
     _builder.setTerminateAfter(termAfter)
     this

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/SearchDsl.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/SearchDsl.scala
@@ -1,6 +1,7 @@
 package com.sksamuel.elastic4s
 
 import org.elasticsearch.action.search._
+import org.elasticsearch.action.support.IndicesOptions
 import org.elasticsearch.client.Client
 import org.elasticsearch.common.unit.TimeValue
 import org.elasticsearch.index.query.QueryBuilder
@@ -14,13 +15,13 @@ import scala.language.implicitConversions
 
 /** @author Stephen Samuel */
 trait SearchDsl
-  extends QueryDsl
-  with FilterDsl
-  with FacetDsl
-  with HighlightDsl
-  with ScriptFieldDsl
-  with SuggestionDsl
-  with IndexesTypesDsl {
+    extends QueryDsl
+    with FilterDsl
+    with FacetDsl
+    with HighlightDsl
+    with ScriptFieldDsl
+    with SuggestionDsl
+    with IndexesTypesDsl {
 
   implicit def toRichResponse(resp: SearchResponse): RichSearchResponse = new RichSearchResponse(resp)
 
@@ -35,14 +36,14 @@ trait SearchDsl
   def multi(searches: SearchDefinition*): MultiSearchDefinition = new MultiSearchDefinition(searches)
 
   implicit object SearchDefinitionExecutable
-    extends Executable[SearchDefinition, SearchResponse] {
+      extends Executable[SearchDefinition, SearchResponse] {
     override def apply(c: Client, t: SearchDefinition): Future[SearchResponse] = {
       injectFuture(c.search(t.build, _))
     }
   }
 
   implicit object MultiSearchDefinitionExecutable
-    extends Executable[MultiSearchDefinition, MultiSearchResponse] {
+      extends Executable[MultiSearchDefinition, MultiSearchResponse] {
     override def apply(c: Client, t: MultiSearchDefinition): Future[MultiSearchResponse] = {
       injectFuture(c.multiSearch(t.build, _))
     }
@@ -94,10 +95,11 @@ class SearchDefinition(indexesTypes: IndexesTypes) {
   private var includes: Array[String] = Array.empty
   private var excludes: Array[String] = Array.empty
 
-  /** Adds a single string query to this search
-    *
-    * @param string the query string
-    */
+  /**
+   * Adds a single string query to this search
+   *
+   * @param string the query string
+   */
   def query(string: String): SearchDefinition = query(new QueryStringQueryDefinition(string))
   def query(block: => QueryDefinition): SearchDefinition = query2(block.builder)
   def query2(block: => QueryBuilder): SearchDefinition = {
@@ -111,7 +113,7 @@ class SearchDefinition(indexesTypes: IndexesTypes) {
 
   def inner(inners: InnerHitDefinition*): this.type = inner(inners)
   def inner(inners: Iterable[InnerHitDefinition]): this.type = {
-    for ( inner <- inners )
+    for (inner <- inners)
       _builder.addInnerHit(inner.name, inner.inner)
     this
   }
@@ -157,11 +159,12 @@ class SearchDefinition(indexesTypes: IndexesTypes) {
     this
   }
 
-  /** This method introduces zero or more script field definitions into the search construction
-    *
-    * @param sfieldDefs zero or more [[ScriptFieldDefinition]] instances
-    * @return this, an instance of [[SearchDefinition]]
-    */
+  /**
+   * This method introduces zero or more script field definitions into the search construction
+   *
+   * @param sfieldDefs zero or more [[ScriptFieldDefinition]] instances
+   * @return this, an instance of [[SearchDefinition]]
+   */
   def scriptfields(sfieldDefs: ScriptFieldDefinition*): this.type = {
     import scala.collection.JavaConverters._
     sfieldDefs.foreach {
@@ -181,24 +184,26 @@ class SearchDefinition(indexesTypes: IndexesTypes) {
     this
   }
 
-  /** Adds a single prefix query to this search
-    *
-    * @param tuple - the field and prefix value
-    *
-    * @return this
-    */
+  /**
+   * Adds a single prefix query to this search
+   *
+   * @param tuple - the field and prefix value
+   *
+   * @return this
+   */
   def prefix(tuple: (String, Any)) = {
     val q = new PrefixQueryDefinition(tuple._1, tuple._2)
     _builder.setQuery(q.builder.buildAsBytes)
     this
   }
 
-  /** Adds a single regex query to this search
-    *
-    * @param tuple - the field and regex value
-    *
-    * @return this
-    */
+  /**
+   * Adds a single regex query to this search
+   *
+   * @param tuple - the field and regex value
+   *
+   * @return this
+   */
   def regex(tuple: (String, Any)) = {
     val q = new RegexQueryDefinition(tuple._1, tuple._2)
     _builder.setQuery(q.builder.buildAsBytes)
@@ -217,17 +222,18 @@ class SearchDefinition(indexesTypes: IndexesTypes) {
     this
   }
 
-  /** Expects a query in json format and sets the query of the search request.
-    * Query must be valid json beginning with '{' and ending with '}'.
-    * Field names must be double quoted.
-    *
-    * Example:
-    * {{{
-    * search in "*" types("users", "tweets") limit 5 rawQuery {
-    * """{ "prefix": { "bands": { "prefix": "coldplay", "boost": 5.0, "rewrite": "yes" } } }"""
-    * } searchType SearchType.Scan
-    * }}}
-    */
+  /**
+   * Expects a query in json format and sets the query of the search request.
+   * Query must be valid json beginning with '{' and ending with '}'.
+   * Field names must be double quoted.
+   *
+   * Example:
+   * {{{
+   * search in "*" types("users", "tweets") limit 5 rawQuery {
+   * """{ "prefix": { "bands": { "prefix": "coldplay", "boost": 5.0, "rewrite": "yes" } } }"""
+   * } searchType SearchType.Scan
+   * }}}
+   */
   def rawQuery(json: String): SearchDefinition = {
     _builder.setQuery(json)
     this
@@ -269,6 +275,11 @@ class SearchDefinition(indexesTypes: IndexesTypes) {
   def preference(pref: Preference): SearchDefinition = preference(pref.elastic)
   def preference(pref: String): SearchDefinition = {
     _builder.setPreference(pref)
+    this
+  }
+
+  def indicesOptions(options: IndicesOptions): this.type = {
+    _builder.setIndicesOptions(options)
     this
   }
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/fields.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/fields.scala
@@ -6,14 +6,6 @@ import org.elasticsearch.common.xcontent.XContentBuilder
 
 import scala.language.implicitConversions
 
-case class GetMappingDefinition(indexes: Iterable[String]) {
-  var types: Iterable[String] = Nil
-  def types(types: String*): this.type = {
-    this.types = types
-    this
-  }
-}
-
 case class DeleteMappingDefinition(indexes: Iterable[String]) {
   var types: Iterable[String] = Nil
   def types(types: String*): this.type = {
@@ -521,5 +513,5 @@ final class MultiFieldDefinition(name: String)
 }
 
 case class RoutingDefinition(required: Boolean,
-                             path: Option[String])
+  path: Option[String])
 

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/CountDslTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/CountDslTest.scala
@@ -2,6 +2,7 @@ package com.sksamuel.elastic4s
 
 import org.scalatest.FlatSpec
 import org.scalatest.mock.MockitoSugar
+import org.elasticsearch.action.support.IndicesOptions._
 import ElasticDsl._
 
 /** @author Stephen Samuel */
@@ -54,6 +55,11 @@ class CountDslTest extends FlatSpec with MockitoSugar with ElasticSugar {
     assert(req.build.indices() === Array("places"))
   }
 
+  it should "accept indices options" in {
+    val req = count from "places/cities" query "paris" indicesOptions lenientExpandOpen()
+    assert(req.build.indices() === Array("places"))
+  }
+  
   it should "parase method invocation as index type" in {
     val req = count("places/cities") query "paris"
     assert(req.build.indices() === Array("places"))

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
@@ -3,6 +3,7 @@ package com.sksamuel.elastic4s
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.Preference.Shards
 import com.sksamuel.elastic4s.SuggestMode.{ Missing, Popular }
+import org.elasticsearch.action.support.IndicesOptions._
 import org.elasticsearch.common.geo.GeoDistance
 import org.elasticsearch.common.unit.DistanceUnit
 import org.elasticsearch.index.query.MatchQueryBuilder.{ Operator, ZeroTermsQuery }
@@ -31,6 +32,11 @@ class SearchDslTest extends FlatSpec with MockitoSugar with JsonSugar with OneIn
 
   it should "accept sequences for type" in {
     val req = search in "*" types ("users", "tweets") from 5 query "sammy"
+    req._builder.toString should matchJsonResource("/json/search/search_test3.json")
+  }
+  
+  it should "accept indices options" in {
+    val req = search in "*" types ("users", "tweets") from 5 query "sammy"  indicesOptions lenientExpandOpen()
     req._builder.toString should matchJsonResource("/json/search/search_test3.json")
   }
 

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/mappings/MappingDslTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/mappings/MappingDslTest.scala
@@ -1,5 +1,6 @@
 package com.sksamuel.elastic4s.mappings
 
+import org.elasticsearch.action.support.IndicesOptions._
 import com.sksamuel.elastic4s.mappings.FieldType.{ DateType, GeoPointType }
 import com.sksamuel.elastic4s.{ ElasticDsl, ElasticSugar }
 import org.scalatest.FlatSpec
@@ -14,8 +15,7 @@ class MappingDslTest extends FlatSpec with MockitoSugar with ElasticSugar {
     client.execute {
       put mapping "index" / "type" as Seq(
         field name "name" withType GeoPointType,
-        field name "content" typed DateType nullValue "no content"
-      )
+        field name "content" typed DateType nullValue "no content")
     }
   }
 
@@ -28,6 +28,12 @@ class MappingDslTest extends FlatSpec with MockitoSugar with ElasticSugar {
   "the get mapping dsl" should "be accepted by the client" in {
     client.execute {
       get mapping "index" types "type"
+    }
+  }
+
+  it should "support specify indices options" in {
+    client.execute {
+      get mapping "index" types "type" indicesOptions lenientExpandOpen()
     }
   }
 


### PR DESCRIPTION
The indices option allow us to control how to deal with unavailable concrete indices (closed or missing), how wildcard expressions are expanded to actual indices (all, closed or open indices) and how to deal with wildcard expressions that resolve to no indices.