### PR TITLE
Add context queries to suggestions

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/suggestions.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/suggestions.scala
@@ -70,6 +70,11 @@ trait SuggestionDefinition {
     builder.addContextField(field, values.asJava)
     this
   }
+
+  def context(field: String, values: Iterable[String]): this.type = {
+    builder.addContextField(field, values.asJava)
+    this
+  }
 }
 
 case class TermSuggestionDefinition(name: String, indexes: Seq[String] = Nil)

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/suggestions.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/suggestions.scala
@@ -65,6 +65,11 @@ trait SuggestionDefinition {
     builder.shardSize(shardSize)
     this
   }
+
+  def context(field: String, values: String*): this.type = {
+    builder.addContextField(field, values.asJava)
+    this
+  }
 }
 
 case class TermSuggestionDefinition(name: String, indexes: Seq[String] = Nil)

--- a/elastic4s-core/src/test/resources/json/search/search_suggestions_context.json
+++ b/elastic4s-core/src/test/resources/json/search/search_suggestions_context.json
@@ -1,0 +1,15 @@
+{
+  "suggest": {
+    "my-suggestion-1": {
+      "text": "wildcats by ratatat",
+      "completion": {
+        "field": "colors",
+        "context": {
+          "genre": [
+            "electronic"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/elastic4s-core/src/test/resources/json/search/search_suggestions_context_multiple.json
+++ b/elastic4s-core/src/test/resources/json/search/search_suggestions_context_multiple.json
@@ -1,0 +1,13 @@
+{
+  "suggest": {
+    "my-suggestion-1": {
+      "text": "wildcats by ratatat",
+      "completion": {
+        "field": "colors",
+        "context": {
+          "genre": ["electronic", "alternative rock"]
+        }
+      }
+    }
+  }
+}

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
@@ -917,6 +917,13 @@ class SearchDslTest extends FlatSpec with MockitoSugar with JsonSugar with OneIn
     req._builder.toString should matchJsonResource("/json/search/search_suggestions_context.json")
   }
 
+  it should "generate correct json for context queries with an Iterable argument" in {
+    val req = search in "music" types "bands" suggestions(
+      completion suggestion "my-suggestion-1" text "wildcats by ratatat" field "colors" context("genre", Seq("electronic", "alternative rock"))
+    )
+    req._builder.toString should matchJsonResource("/json/search/search_suggestions_context.json")
+  }
+
   it should "generate correct json for nested query" in {
     val req = search in "music" types "bands" query {
       nestedQuery("obj1") query {

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
@@ -910,6 +910,13 @@ class SearchDslTest extends FlatSpec with MockitoSugar with JsonSugar with OneIn
     req._builder.toString should matchJsonResource("/json/search/search_suggestions_multiple_suggesters.json")
   }
 
+  it should "generate correct json for context queries" in {
+    val req = search in "music" types "bands" suggestions(
+      completion suggestion "my-suggestion-1" text "wildcats by ratatat" field "colors" context("genre", "electronic")
+    )
+    req._builder.toString should matchJsonResource("/json/search/search_suggestions_context.json")
+  }
+
   it should "generate correct json for nested query" in {
     val req = search in "music" types "bands" query {
       nestedQuery("obj1") query {

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
@@ -921,7 +921,7 @@ class SearchDslTest extends FlatSpec with MockitoSugar with JsonSugar with OneIn
     val req = search in "music" types "bands" suggestions(
       completion suggestion "my-suggestion-1" text "wildcats by ratatat" field "colors" context("genre", Seq("electronic", "alternative rock"))
     )
-    req._builder.toString should matchJsonResource("/json/search/search_suggestions_context.json")
+    req._builder.toString should matchJsonResource("/json/search/search_suggestions_context_multiple.json")
   }
 
   it should "generate correct json for nested query" in {


### PR DESCRIPTION
Context queries allow suggestions to be filtered in a limited way. Documentation is here: https://www.elastic.co/guide/en/elasticsearch/reference/current/suggester-context.html

I noticed that they are currently not supported, so I added them.

If there is anything that needs cleaning up, please let me know.