### PR TITLE
Added IterableSearch for iterating search results/search hits

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticClient.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticClient.scala
@@ -23,7 +23,7 @@ import scala.concurrent.duration._
 import scala.language.implicitConversions
 
 /** @author Stephen Samuel */
-class ElasticClient(val client: org.elasticsearch.client.Client) {
+class ElasticClient(val client: org.elasticsearch.client.Client) extends IterableSearch {
 
   def execute[T, R, Q](t: T)(implicit executable: Executable[T, R, Q]): Future[Q] = executable(client, t)
 
@@ -124,6 +124,10 @@ class ElasticClient(val client: org.elasticsearch.client.Client) {
 
   @deprecated("Use .await() on future of async client", "1.3.0")
   def sync(implicit duration: Duration = 10.seconds) = new SyncClient(this)(duration)
+
+  override def iterateSearch(query: SearchDefinition)(implicit timeout: Duration): Iterator[SearchResponse] = {
+    IterableSearch(this).iterateSearch(query)
+  }
 }
 
 object ElasticClient {
@@ -172,7 +176,6 @@ object ElasticClient {
   }
   @deprecated("timeout is no longer needed, it is ignored, so you can use the local(client) method instead", "1.4.2")
   def local(settings: Settings, timeout: Long): ElasticClient = local(settings)
-
 }
 
 object ElasticsearchClientUri {

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/IterableSearch.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/IterableSearch.scala
@@ -1,0 +1,115 @@
+package com.sksamuel.elastic4s
+
+import org.elasticsearch.action.search.SearchResponse
+import org.elasticsearch.search.SearchHit
+
+import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future}
+
+/**
+ * Represents something which can iterate the results from a query.
+ *
+ * In practice this means concatenating several requests into a single iterable, so that the next request is only
+ * made when required when the iterable is advanced.
+ *
+ * @define ONDEMAND_ITERATOR an iterator which makes requests on-demand as it is advanced
+ * @define QUERY the search queries over which to iterate
+ */
+trait IterableSearch {
+
+  /**
+   * This is the only abstract method for this trait.
+   *
+   * @param query $QUERY
+   * @return $ONDEMAND_ITERATOR
+   */
+  def iterateSearch(query: SearchDefinition)(implicit timeout: Duration): Iterator[SearchResponse]
+
+  /**
+   *
+   * @param queries $QUERY
+   * @return $ONDEMAND_ITERATOR
+   */
+  def iterateSearch(queries: Iterable[SearchDefinition])(implicit timeout: Duration): Iterator[SearchResponse] = {
+    queries.iterator.flatMap(iterateSearch)
+  }
+
+  /**
+   * Support for a var-args type invocation
+   *
+   * @param firstQuery $QUERY
+   * @param secondQuery $QUERY
+   * @param theRest $QUERY
+   * @return $ONDEMAND_ITERATOR
+   */
+  def iterateSearch(
+                     firstQuery : SearchDefinition,
+                     secondQuery : SearchDefinition,
+                     theRest : SearchDefinition*)(implicit timeout: Duration): Iterator[SearchResponse] = {
+    iterateSearch(firstQuery +: secondQuery +: theRest)
+  }
+
+  /** returns an $ONDEMAND_ITERATOR
+    * @param query $QUERY
+    * @return $ONDEMAND_ITERATOR
+    */
+  def iterate(query: SearchDefinition)(implicit timeout: Duration): Iterator[SearchHit] = {
+    iterate(query :: Nil)
+  }
+
+  /**
+   * @param queries $QUERY
+   * @return $ONDEMAND_ITERATOR
+   */
+  def iterate(queries: Iterable[SearchDefinition])(implicit timeout: Duration): Iterator[SearchHit] = {
+    iterateSearch(queries).flatMap(_.getHits.getHits)
+  }
+
+}
+
+
+object IterableSearch {
+
+  private class ElasticIterable(client: ElasticClient, keepAlive: String) extends IterableSearch {
+
+    override def iterateSearch(query: SearchDefinition)(implicit timeout: Duration): Iterator[SearchResponse] = {
+      iterateNext(query, keepAlive, None)
+    }
+
+    private def iterateNext(searchDef: SearchDefinition, keepAlive: String, scrollId: Option[String])(implicit timeout: Duration): Iterator[SearchResponse] = {
+      def next(future: Future[SearchResponse]): Iterator[SearchResponse] = {
+        val response = Await.result(future, timeout)
+        val hits = response.getHits.getHits
+
+        if (hits.isEmpty || response.getScrollId == null) {
+          Iterator.empty
+        } else {
+          Iterator(response) ++ iterateNext(searchDef, keepAlive, Option(response.getScrollId))
+        }
+      }
+
+      import ElasticDsl._
+
+      // we're either advancing a scroll id or issuing the first query w/ the keep alive set
+      val future: Future[SearchResponse] = scrollId.fold(client.execute(searchDef.scroll(keepAlive))) { scrollId =>
+        client.execute(search scroll scrollId keepAlive (keepAlive))
+      }
+
+      next(future)
+    }
+  }
+
+  /**
+   * Creates an IterableSearch using the elastic client and the optional keep alive (which is used for the cursor)
+   *
+   *
+   * @param client the elastic client used to make the queries
+   * @param keepAlive the keep alive used for the scrollId (e.g. "5m")
+   * @return an IterableSearch instance
+   */
+  def apply(client: ElasticClient, keepAlive: String = "5m"): IterableSearch = {
+    new ElasticIterable(client, keepAlive)
+  }
+
+
+}

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/IterableSearchTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/IterableSearchTest.scala
@@ -1,0 +1,90 @@
+package com.sksamuel.elastic4s
+
+import com.sksamuel.elastic4s.ElasticDsl.{index, _}
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{Matchers, WordSpec}
+import concurrent.duration._
+
+/**
+ * Tests for IterableSearch
+ */
+class IterableSearchTest extends WordSpec with MockitoSugar with ElasticSugar with Matchers {
+
+  val indexName = getClass.getSimpleName.toLowerCase
+
+  val expectedRecords = 100
+
+  // set up our data
+  {
+    val bulkResp = client.execute {
+      bulk(
+            (0 until expectedRecords).map { i =>
+              index into s"$indexName/foo" fields ("record" -> s"record $i")
+            }
+          )
+    }.await
+
+    require(!bulkResp.hasFailures, "test setup failed")
+    blockUntilCount(expectedRecords, indexName)
+
+  }
+
+  val query = search in indexName / "foo" query matchall
+
+  "IterableSearch.iterate" should {
+    "iterate all search results on demand" in {
+
+      // ------------------------------------------------------------------------------------------------
+      // setup - wrap the client to check when the calls are made
+      // ------------------------------------------------------------------------------------------------
+      val underlyingClient = client
+      var executeCount = 0
+      object TestClient extends ElasticClient(client.java) {
+        override def execute[T, R, Q](t: T)(implicit executable: Executable[T, R, Q]) = {
+          executeCount = executeCount + 1
+          underlyingClient.execute(t)
+        }
+      }
+
+      val querySize = 5
+      // ------------------------------------------------------------------------------------------------
+      // call our method under test
+      // ------------------------------------------------------------------------------------------------
+      implicit val timeout = (2 seconds)
+      val hitsIterable = IterableSearch(TestClient).iterate(query.size(querySize))
+
+      // ------------------------------------------------------------------------------------------------
+      // assert the iterable makes queries on-demand and produced the correct amount of results
+      // make a normal query to get our expected hits
+      // ------------------------------------------------------------------------------------------------
+      val expectedHits = client.execute(query).await.getHits.getTotalHits
+      expectedHits shouldBe expectedRecords // our query should retrieve the records we put in
+
+      // let's keep track of all the results in a lazy stream (so we can call .size)
+      val stream = hitsIterable.toStream
+      executeCount shouldBe 1
+
+      stream.drop(3)
+      executeCount shouldBe 1
+
+      stream.drop(9)
+      executeCount shouldBe 2
+
+      stream.drop(9)
+      executeCount shouldBe 2
+
+      stream.drop(10)
+      executeCount shouldBe 3
+
+      stream.drop(50)
+      executeCount shouldBe 11
+
+      stream.size shouldBe expectedRecords
+
+      // the + 1 is the last query which returns a null scroll id, showing us there are no more results
+      val totalQueries = (expectedRecords / querySize) + 1
+      executeCount shouldBe totalQueries
+    }
+
+  }
+}

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/query/MatchQueryTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/query/MatchQueryTest.scala
@@ -2,7 +2,7 @@ package com.sksamuel.elastic4s
 package query
 
 import org.elasticsearch.index.query.MatchQueryBuilder
-import org.scalatest.{ Matchers, WordSpec }
+import org.scalatest.WordSpec
 import org.scalatest.mock.MockitoSugar
 
 class MatchQueryTest extends WordSpec with MockitoSugar with ElasticSugar with ElasticDsl {


### PR DESCRIPTION
Let me know what you think about putting this into its own trait.

Initially it was totally separate from ElasticClient, but then I made elastic client mix it in.

There are many ways to slice it, of which this is just one, and it may go against the code style you want to keep