### PR TITLE
Support explicit field types in the update dsl

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/UpdateDsl.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/UpdateDsl.scala
@@ -61,6 +61,11 @@ class UpdateDefinition(indexesTypes: IndexesTypes, id: String)
     _builder.setDocAsUpsert(true)
     doc(map)
   }
+  def docAsUpsert(value: FieldValue): this.type = {
+    _builder.setDocAsUpsert(true)
+    doc(value)
+  }
+
   def doc(fields: (String, Any)*): this.type = doc(fields.toMap)
   def doc(iterable: Iterable[(String, Any)]): this.type = doc(iterable.toMap)
   def doc(map: Map[String, Any]): this.type = {
@@ -70,6 +75,11 @@ class UpdateDefinition(indexesTypes: IndexesTypes, id: String)
 
   def doc(source: DocumentSource) = {
     _builder.setDoc(source.json)
+    this
+  }
+
+  def doc(value: FieldValue): this.type = {
+    _builder.setDoc(_fieldsAsXContent(Seq(value)))
     this
   }
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/fields.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/fields.scala
@@ -18,6 +18,9 @@ object FieldsMapper {
         val values = arr.map(new SimpleFieldValue(None, _))
         ArrayFieldValue(name, values)
 
+      case (name: String, a: FieldValue) =>
+        NestedFieldValue(name,Seq(a))
+
       case (name: String, s: Iterable[_]) =>
         s.headOption match {
           case Some(m: Map[_, _]) =>

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/UpdateDslTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/UpdateDslTest.scala
@@ -53,6 +53,33 @@ class UpdateDslTest extends FlatSpec with MockitoSugar with OneInstancePerTest w
     sourceMap.get("captain").asInstanceOf[util.Map[String, String]] should contain(Entry("james", "kirk"))
   }
 
+  it should "should support docAsUpsert with explicit field types" in {
+    val updateDef = update id 14 in "scifi/startrek" docAsUpsert (
+      NestedFieldValue("captain", Seq(SimpleFieldValue("james", "kirk")))
+      )
+    val sourceMap: util.Map[String, AnyRef] = updateDef.build.doc().sourceAsMap()
+    sourceMap should contain key "captain"
+    sourceMap.get("captain").asInstanceOf[util.Map[String, String]] should contain(Entry("james", "kirk"))
+  }
+
+  it should "should support docAsUpsert with nested explicit field types" in {
+    val updateDef = update id 14 in "scifi/startrek" docAsUpsert (
+      "captain" -> SimpleFieldValue("james", "kirk")
+      )
+    val sourceMap: util.Map[String, AnyRef] = updateDef.build.doc().sourceAsMap()
+    sourceMap should contain key "captain"
+    sourceMap.get("captain").asInstanceOf[util.Map[String, String]] should contain(Entry("james", "kirk"))
+  }
+
+  it should "should support docAsUpsert with complex nested explicit field types" in {
+    val updateDef = update id 14 in "scifi/startrek" docAsUpsert (
+      "captain" -> NestedFieldValue("first", Seq(SimpleFieldValue("captain", "archer"), SimpleFieldValue("program","NX test")))
+      )
+    val sourceMap: util.Map[String, AnyRef] = updateDef.build.doc().sourceAsMap()
+    println(sourceMap.get("captain").asInstanceOf[util.Map[String, String]])
+    sourceMap.get("captain").asInstanceOf[util.Map[String, String]].get("first").asInstanceOf[util.Map[String,String]] should contain(Entry("captain", "archer"))
+  }
+
   it should "should support source" in {
     val updateDef = update id 65 in "scifi/startrek" doc new TestSource
     assert(updateDef.build.doc().sourceAsMap().containsKey("ship"))

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/UpdateDslTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/UpdateDslTest.scala
@@ -76,7 +76,6 @@ class UpdateDslTest extends FlatSpec with MockitoSugar with OneInstancePerTest w
       "captain" -> NestedFieldValue("first", Seq(SimpleFieldValue("captain", "archer"), SimpleFieldValue("program","NX test")))
       )
     val sourceMap: util.Map[String, AnyRef] = updateDef.build.doc().sourceAsMap()
-    println(sourceMap.get("captain").asInstanceOf[util.Map[String, String]])
     sourceMap.get("captain").asInstanceOf[util.Map[String, String]].get("first").asInstanceOf[util.Map[String,String]] should contain(Entry("captain", "archer"))
   }
 

--- a/guide/update.md
+++ b/guide/update.md
@@ -61,3 +61,13 @@ val resp = client.sync.execute {
   update id 98 in "scifi/battlestargalactica" script "ctx._source.tags += tag" params(Map("tag"->"space"))
 }
 ````
+
+Like index, you can use update with explicit field values.
+
+```scala
+val resp = client.execute {
+  update id 14 in "scifi/startrek" docAsUpsert (
+    NestedFieldValue("captain", Seq(SimpleFieldValue("james", "kirk")))
+  )
+}
+````


### PR DESCRIPTION
Hi Stephen, 

Your elastic4s library has been in use within our projects for quite a while and really love the way it works. 
I am using explicit types to render certain json field (spray json / json4s) in a proper way in the elasticsearch source. 
In order to update these fields, I need the support for explicit fields in the updateDSL. This pull request adds that support in 2 ways. 

First is to update the doc with a FieldValue that is not using the FieldsMapper, second is via the FieldsMapper (docAsUpsert ("captain" -> SimpleFieldValue("james", "kirk")) 

Tests and documentation is added for the addition. 

Kind regards, 

Olger
