### PR TITLE
Validating typeclass for hit deserialization

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/Reader.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/Reader.scala
@@ -1,5 +1,10 @@
 package com.sksamuel.elastic4s
 
+import org.scalactic._
+
+import scala.collection.{Seq, generic}
+import scala.reflect.ClassTag
+
 @deprecated("use HitAs, this reader trait has a broken contravariance implementation", "1.6.1")
 trait Reader[-U] {
   def read[T <: U : Manifest](json: String): T
@@ -8,3 +13,93 @@ trait Reader[-U] {
 trait HitAs[T] {
   def as(hit: RichSearchHit): T
 }
+
+trait HitRead[T] {
+  def as(hit: RichSearchHitLike): T Or Every[ErrorMessage]
+}
+
+trait HitFieldRead[T] {
+  def as(prefix:String)(hit: RichSearchHitField): T Or Every[ErrorMessage]
+  def as(hit: RichSearchHitField): T Or Every[ErrorMessage]=as("")(hit)
+}
+
+trait LPHitFieldReads{
+  implicit def hitRead2HitFieldRead[T](implicit hitRead:HitRead[T]) =new HitFieldRead[T] {
+    import scala.collection.JavaConverters._
+    override def as(prefix: String)(hit: RichSearchHitField): Or[T, Every[ErrorMessage]] = hit match {
+      case MissingRichSearchField(name)=> Bad(One(s"$prefix $name field is missing"))
+      case field=> field.value[Any] match {
+        case map:java.util.Map[_,_] => hitRead.as(RichMapSearchHit(map.asInstanceOf[java.util.Map[String,Any]].asScala.toMap))
+        case other => Bad(One(s"$prefix ${hit.name} expected a object (Map[String,Any]) got $other"))
+      }
+    }
+  }
+
+  implicit object stringHitFieldRead extends HitFieldRead[String] {
+    override def as(prefix:String)(hit: RichSearchHitField): String Or Every[ErrorMessage] = hit match {
+      case MissingRichSearchField(name)=> Bad(One(s"$prefix $name field is missing"))
+      case field => field.value[Any] match {
+        case v:String => Good(v)
+        case o => Bad(One(s"$prefix ${hit.name} expected a String got $o"))
+      }
+    }
+  }
+  implicit object intHitFieldRead extends HitFieldRead[Int] {
+    override def as(prefix:String)(hit: RichSearchHitField): Int Or Every[ErrorMessage] = hit match {
+      case MissingRichSearchField(name) => Bad(One(s"$prefix $name field is missing"))
+      case field => field.value[Any] match {
+        case v:Int => Good(v)
+        case v:Long => Good(v.toInt)
+        case v:BigInt => Good(v.intValue())
+        case o => Bad(One(s"$prefix ${hit.name} expected an Int got $o"))
+      }
+    }
+  }
+
+  implicit object BigDecimalHitFieldRead extends HitFieldRead[BigDecimal] {
+    override def as(prefix:String)(hit: RichSearchHitField): BigDecimal Or Every[ErrorMessage] = hit match {
+      case MissingRichSearchField(name) => Bad(One(s"$prefix $name field is missing"))
+      case field => field.value[Any] match {
+        case v:Int => Good(BigDecimal(v))
+        case v:Long => Good(BigDecimal(v))
+        case v:BigInt => Good(BigDecimal(v))
+        case v:Double=> Good(BigDecimal(v))
+        case v:Float=> Good(BigDecimal(v))
+        case v:BigDecimal=> Good(v)
+        case v:java.math.BigDecimal=> Good(v)
+        case v:java.math.BigInteger=> Good(BigDecimal(v.longValue()))
+        case o => Bad(One(s"$prefix ${hit.name} expected an Int got $o"))
+      }
+    }
+  }
+  implicit def optionRead[T ](implicit read:HitFieldRead[T]):HitFieldRead[Option[T]]=new HitFieldRead[Option[T]]{
+    override def as(prefix: String)(hit: RichSearchHitField): Option[T] Or Every[ErrorMessage] = hit match {
+        case MissingRichSearchField(name)=> Good(None)
+        case field => read.as(prefix)(hit).map(Some.apply)
+      }
+  }
+  /**
+   * Generic deserializer for collections types.
+   */
+  implicit def traversableReads[F[_], A](implicit bf: generic.CanBuildFrom[F[_], A, F[A]], ra: HitFieldRead[A]): HitFieldRead[F[A]] = new HitFieldRead[F[A]] {
+    import scala.collection.JavaConverters._
+    import Accumulation._
+    override def as(prefix: String)(hit: RichSearchHitField): F[A] Or Every[ErrorMessage]= hit match {
+      case MissingRichSearchField(name) => Bad(One(s"$prefix $name field is missing"))
+      case fields => val validations = fields.value[Any] match {
+        case list:java.util.List[_]=> list.asScala.toSeq.zipWithIndex.map{case (elt,idx)=> ra.as(SomeValueSearchHitField(s"${hit.name}[$idx]", elt))}
+        case list:scala.collection.Seq[_]=> list.zipWithIndex.map{case (elt,idx)=> ra.as(SomeValueSearchHitField(s"${hit.name}[$idx]", elt))}
+        case other => Seq.empty[Good[A,Every[ErrorMessage]]]
+      }
+      validations.combined.map(_.to(bf))
+    }
+  }
+
+  /**
+   * Deserializer for Array[T] types.
+   */
+  implicit def ArrayReads[T: HitFieldRead: ClassTag]: HitFieldRead[Array[T]] = new HitFieldRead[Array[T]] {
+    override def as(prefix: String)(hit: RichSearchHitField): Array[T] Or Every[ErrorMessage]= hit.validate[List[T]](prefix).map(_.toArray)
+  }
+}
+object HitFieldRead extends LPHitFieldReads

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/RichSearchResponse.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/RichSearchResponse.scala
@@ -1,5 +1,6 @@
 package com.sksamuel.elastic4s
 
+
 import org.apache.lucene.search.Explanation
 import org.elasticsearch.action.search.{SearchResponse, ShardSearchFailure}
 import org.elasticsearch.common.bytes.BytesReference
@@ -7,6 +8,7 @@ import org.elasticsearch.search.aggregations.Aggregations
 import org.elasticsearch.search.facet.Facets
 import org.elasticsearch.search.highlight.HighlightField
 import org.elasticsearch.search.{SearchHit, SearchHitField, SearchHits, SearchShardTarget}
+import org.scalactic._
 
 import scala.concurrent.duration._
 
@@ -20,6 +22,10 @@ case class RichSearchResponse(response: SearchResponse) {
   @deprecated("use as[T], which has a more powerful typeclass abstraction", "1.6.1")
   def hitsAs[T](implicit reader: Reader[T], manifest: Manifest[T]): Array[T] = hits.map(_.mapTo[T])
   def as[T](implicit hitas: HitAs[T], manifest: Manifest[T]): Array[T] = hits.map(_.as[T])
+  def validate[T](implicit hitread: HitRead[T], manifest: Manifest[T]): Array[T] Or Every[ErrorMessage] = {
+    import org.scalactic.Accumulation._
+    hits.toList.validatedBy(hitread.as).map(_.toArray)
+  }
 
   def scrollId: String = response.getScrollId
 
@@ -43,8 +49,11 @@ case class RichSearchResponse(response: SearchResponse) {
   def isTimedOut: Boolean = response.isTimedOut
   def isTerminatedEarly: Boolean = response.isTerminatedEarly
 }
+trait RichSearchHitLike{
+  def richFields:RichSearchHitFields
+}
 
-class RichSearchHit(hit: SearchHit) {
+case class RichSearchHit(hit: SearchHit) extends RichSearchHitLike {
 
   override def equals(other: Any): Boolean = other match {
     case hit: SearchHit => equals(new RichSearchHit(hit))
@@ -72,13 +81,14 @@ class RichSearchHit(hit: SearchHit) {
   @deprecated("use as[T], which has a more powerful typeclass abstraction", "1.6.1")
   def mapTo[T](implicit reader: Reader[T], manifest: Manifest[T]): T = reader.read(sourceAsString)
   def as[T](implicit hitas: HitAs[T], manifest: Manifest[T]): T = hitas.as(this)
+  def validate[T](implicit hitread: HitRead[T], manifest: Manifest[T]): T Or Every[ErrorMessage] = hitread.as(this)
 
   def explanation: Option[Explanation] = Option(hit.explanation)
 
   def field(fieldName: String): SearchHitField = fieldOpt(fieldName).get
   def fieldOpt(fieldName: String): Option[SearchHitField] = Option(hit.field(fieldName))
   def fields: Map[String, SearchHitField] = Option(hit.fields).map(_.asScala.toMap).getOrElse(Map.empty)
-
+  def richFields:RichSearchHitFields = RichSearchHitFields(sourceAsMap.map{case (k,v)=>(k,SomeValueSearchHitField(k,v))})
   def highlightFields: Map[String, HighlightField] = {
     Option(hit.highlightFields).map(_.asScala.toMap).getOrElse(Map.empty)
   }
@@ -88,3 +98,24 @@ class RichSearchHit(hit: SearchHit) {
   def innerHits: Map[String, SearchHits] = Option(hit.getInnerHits).map(_.asScala.toMap).getOrElse(Map.empty)
 }
 
+case class RichMapSearchHit(fields:Map[String,Any]) extends RichSearchHitLike{
+  override lazy val richFields: RichSearchHitFields = RichSearchHitFields(fields.map{case (k,v)=>(k,SomeValueSearchHitField(k,v))})
+}
+
+case class RichSearchHitFields(field: Map[String, RichSearchHitField]) {
+  def apply(name: String) = field.getOrElse(name, MissingRichSearchField(name))
+}
+
+sealed trait RichSearchHitField {
+  def name: String
+  def value[T]:T
+  def validate[T](prefix: String = "")(implicit read: HitFieldRead[T]): T Or Every[ErrorMessage] = read.as(prefix)(this)
+}
+
+case class SomeValueSearchHitField(name: String, _value:Any) extends RichSearchHitField{
+  override def value[T]: T = _value.asInstanceOf[T]
+}
+
+case class MissingRichSearchField(name: String) extends RichSearchHitField {
+  def value[T] = throw new UnsupportedOperationException
+}

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/RichSearchResponseTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/RichSearchResponseTest.scala
@@ -1,17 +1,19 @@
 package com.sksamuel.elastic4s
 
+import org.scalactic._
 import org.scalatest.{Matchers, WordSpec}
 
 class RichSearchResponseTest extends WordSpec with Matchers with ElasticSugar with JsonSugar {
 
   import ElasticDsl._
+
   import scala.concurrent.ExecutionContext.Implicits.global
 
   client.execute {
     bulk(
-      index into "cluedo/killers" fields ("name" -> "professor plum"),
-      index into "cluedo/killers" fields ("name" -> "scarlet"),
-      index into "cluedo/killers" fields ("name" -> "rev green")
+      index into "cluedo/killers" fields ("name" -> "professor plum", "weapons"->Array("revolver","knife")),
+      index into "cluedo/killers" fields ("name" -> "scarlet", "weapons"->Array("candlestick","spanner"),"character" -> Map("color"->"red", "sex"->"female","age"->26)),
+      index into "cluedo/killers" fields ("name" -> "rev green","weapons"->Array("lead pipe", "rope"), "character" -> Map("color"->"green", "sex"->"male","age"->45))
     )
   }.await
 
@@ -22,14 +24,86 @@ class RichSearchResponseTest extends WordSpec with Matchers with ElasticSugar wi
     override def read[T <: Killer : Manifest](json: String): T = mapper.readValue[T](json)
   }
 
+  implicit object KillerHitAs extends HitAs[Killer] {
+    import scala.collection.JavaConverters._
+    override def as(hit: RichSearchHit): Killer = {
+      val name= hit.sourceAsMap("name").toString
+      val characterMapO = hit.sourceAsMap.get("character").map(_.asInstanceOf[java.util.Map[String,Any]].asScala.toMap)
+      val characterO=characterMapO.map( characterMap=>
+        Character(
+          characterMap("color").toString,
+          characterMap("sex").toString,
+          characterMap("age").toString.toInt
+        )
+      )
+
+      val weapons:Seq[String]=hit.sourceAsMap("weapons").asInstanceOf[java.util.ArrayList[String]].asScala.toList
+      Killer(name, weapons,characterO)
+    }
+  }
+
+  implicit object CharacterHitRead extends HitRead[Character] {
+    import HitFieldRead._
+    override def as(hit: RichSearchHitLike): Character Or Every[ErrorMessage] = {
+      import Accumulation._
+      val color= hit.richFields("color").validate[String]("Reading Character,")
+      val sex= hit.richFields("sex").validate[String]("Reading Character,")
+      val age= hit.richFields("age").validate[Int]("Reading Character,")
+      withGood(color,sex,age)(Character)
+    }
+  }
+
+  implicit object KillerHitRead extends HitRead[Killer] {
+    import HitFieldRead._
+    override def as(hit: RichSearchHitLike): Killer Or Every[ErrorMessage] = {
+      import Accumulation._
+      val badName= hit.richFields("name").validate[String]("Reading Killer,")
+      val weapons: Seq[String] Or Every[ErrorMessage]= hit.richFields("weapons").validate[Seq[String]]("Reading Killer,")
+      val character: Option[Character] Or Every[ErrorMessage]= hit.richFields("character").validate[Option[Character]]("Reading Killer,")
+      withGood(badName,weapons,character)(Killer)
+    }
+  }
+  implicit object BadKillerHitRead extends HitRead[BadKiller] {
+    import HitFieldRead._
+    override def as(hit: RichSearchHitLike): BadKiller Or Every[ErrorMessage] = {
+      import Accumulation._
+      val badName= hit.richFields("badName").validate[String]("Reading BadKiller,")
+      withGood(badName)(BadKiller)
+    }
+  }
+
+  val professorPlum = Killer("professor plum", Seq("revolver", "knife"))
+  val scarlet = Killer("scarlet", Seq("candlestick", "spanner"), Some(Character("red", "female", 26)))
+  val revGreen = Killer("rev green", Seq("lead pipe", "rope"), Some(Character("green", "male", 45)))
+
   "rich response" should {
     "convert using an implicit reader to Seq[T]" in {
       val killers = client.execute {
         search in "cluedo" / "killers" query "*:*"
       }.map { resp => resp.hitsAs[Killer] }.await
-      killers.toSet shouldBe Set(Killer("professor plum"), Killer("scarlet"), Killer("rev green"))
+      killers.toSet shouldBe Set(professorPlum, scarlet ,revGreen )
+    }
+    "convert using an implicit HitAs to Seq[T]" in {
+      val killers = client.execute {
+        search in "cluedo" / "killers" query "*:*"
+      }.map { resp => resp.as[Killer] }.await
+      killers.toSet shouldBe Set(professorPlum, scarlet ,revGreen)
+    }
+    "convert using an implicit HitRead to Seq[T]" in {
+      val killers = client.execute {
+        search in "cluedo" / "killers" query "*:*"
+      }.map { resp => resp.validate[Killer] }.await
+      killers.get.toSet shouldBe Set(professorPlum, scarlet ,revGreen)
+    }
+    "accumulate conversion error using an implicit HitRead to Seq[T] " in {
+      val killers = client.execute {
+        search in "cluedo" / "killers" query "*:*"
+      }.map { resp => resp.validate[BadKiller] }.await
+      killers shouldBe Bad(Every("Reading BadKiller, badName field is missing","Reading BadKiller, badName field is missing","Reading BadKiller, badName field is missing"))
     }
   }
 }
 
-case class Killer(name: String)
+case class Character(color:String, sex:String, age:Int)
+case class Killer(name: String,weapons:Seq[String], character:Option[Character]=None)
+case class BadKiller(badName: String)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -13,6 +13,7 @@ object Build extends Build {
   val Slf4jVersion = "1.7.12"
   val ScalaLoggingVersion = "2.1.2"
   val ElasticsearchVersion = "1.6.0"
+  val ScalacticVersion = "2.2.4"
   val Log4jVersion = "1.2.17"
   val CommonsIoVersion = "2.4"
   val GroovyVersion = "2.3.7"
@@ -29,6 +30,7 @@ object Build extends Build {
     javacOptions := Seq("-source", "1.7", "-target", "1.7"),
     libraryDependencies ++= Seq(
       "org.elasticsearch" % "elasticsearch" % ElasticsearchVersion,
+      "org.scalactic" %% "scalactic" % ScalacticVersion,
       "org.slf4j" % "slf4j-api" % Slf4jVersion,
       "commons-io" % "commons-io" % CommonsIoVersion % "test",
       "log4j" % "log4j" % Log4jVersion % "test",
@@ -36,7 +38,6 @@ object Build extends Build {
       "org.mockito" % "mockito-all" % MockitoVersion % "test",
       "org.scalatest" %% "scalatest" % ScalatestVersion % "test",
       "org.codehaus.groovy" % "groovy" % GroovyVersion % "test"
-
     ),
     publishTo <<= version {
       (v: String) =>


### PR DESCRIPTION
Introduces a 2-level type class for deserializing Hits 

HitRead reads a RichSearchHit into a type T
HitFieldRead reads a RichSearchHitField into a type T

An implicit conversion is provided to automatically create a HitFieldRead if a HitRead is available for the type. 

A test case demonstrating usage is provided in RichSearchResponseTest, in include basic type conversion, sequence conversion and nested object conversion
