### PR TITLE
Set keepalive on scroll requests.

### DIFF
--- a/elastic4s-streams/src/test/scala/com/sksamuel/elastic4s/streams/ScrollPublisherIntegrationTest.scala
+++ b/elastic4s-streams/src/test/scala/com/sksamuel/elastic4s/streams/ScrollPublisherIntegrationTest.scala
@@ -69,8 +69,8 @@ class ScrollPublisherIntegrationTest extends WordSpec with ElasticSugar with Mat
       })
       client
 
-      completionLatch.await(5, TimeUnit.SECONDS)
-      documentLatch.await(5, TimeUnit.SECONDS)
+      completionLatch.await(5, TimeUnit.SECONDS) should be (true)
+      documentLatch.await(5, TimeUnit.SECONDS) should be (true)
     }
   }
 }


### PR DESCRIPTION
Pulls the keepalive setting out of the original search request and supplies to the scroll request.

See #358 for discussion.
