### PR TITLE
Add periodic forced bulk indexing to BulkIndexingSubscriber

### DIFF
--- a/elastic4s-streams/src/main/scala/com/sksamuel/elastic4s/streams/ReactiveElastic.scala
+++ b/elastic4s-streams/src/main/scala/com/sksamuel/elastic4s/streams/ReactiveElastic.scala
@@ -3,6 +3,7 @@ package com.sksamuel.elastic4s.streams
 import akka.actor.ActorSystem
 import com.sksamuel.elastic4s.{ElasticClient, ElasticDsl, IndexType, SearchDefinition}
 
+import scala.concurrent.duration.FiniteDuration
 import scala.language.implicitConversions
 
 object ReactiveElastic {
@@ -15,9 +16,10 @@ object ReactiveElastic {
                       concurrentRequests: Int = 5,
                       listener: ResponseListener = ResponseListener.noop,
                       completionFn: () => Unit = () => (),
-                      errorFn: Throwable => Unit = _ => ())
+                      errorFn: Throwable => Unit = _ => (),
+                      flushInterval: Option[FiniteDuration] = None)
                      (implicit builder: RequestBuilder[T], system: ActorSystem): BulkIndexingSubscriber[T] = {
-      new BulkIndexingSubscriber[T](client, builder, listener, batchSize, concurrentRequests, completionFn, errorFn)
+      new BulkIndexingSubscriber[T](client, builder, listener, batchSize, concurrentRequests, completionFn, errorFn, flushInterval)
     }
 
     def publisher(indexType: IndexType, elements: Long = Long.MaxValue, keepAlive: String = "1m")

--- a/elastic4s-streams/src/test/scala/com/sksamuel/elastic4s/streams/BulkIndexingSubscriberWhiteboxTest.scala
+++ b/elastic4s-streams/src/test/scala/com/sksamuel/elastic4s/streams/BulkIndexingSubscriberWhiteboxTest.scala
@@ -33,7 +33,7 @@ class BulkIndexingSubscriberWhiteboxTest
   }
 
   override def createSubscriber(probe: WhiteboxSubscriberProbe[Item]): Subscriber[Item] = {
-    new BulkIndexingSubscriber[Item](client, ItemRequestBuilder, ResponseListener.noop, 10, 2, () => (), _ => ()) {
+    new BulkIndexingSubscriber[Item](client, ItemRequestBuilder, ResponseListener.noop, 10, 2, () => (), _ => (), None) {
 
       override def onSubscribe(s: Subscription): Unit = {
         super.onSubscribe(s)


### PR DESCRIPTION
Introduces optional periodic forced bulk indexing to BulkIndexingSubscriber. This ensures that all elements are indexed, even if the last batch size is lower than the specified batch size. This is important when the publisher will never complete (for example a Kafka consumer.)

A new test case demonstrating this new feature has been added to BulkIndexingSubscriberIntegrationTest.