### PR TITLE
bugfix: Proper creation of synonyms filter.

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/TokenFilter.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/TokenFilter.scala
@@ -55,7 +55,7 @@ class SynonymTokenFilter(val name: String,
 
   override def build(source: XContentBuilder): Unit = {
     path.foreach(source.field("synonyms_path", _))
-    synonyms.foreach(source.field("synonyms", _))
+    source.field("synonyms", synonyms.toArray[String]: _*)
     format.foreach(source.field("format", _))
     ignoreCase.foreach(source.field("ignore_case", _))
     expand.foreach(source.field("expand", _))


### PR DESCRIPTION
It was creating one synonym field for each member in the set. ES would ignore all of them except the last one.