### PR TITLE
Update ElasticSearch to latest & greatest 1.7.1

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -12,7 +12,7 @@ object Build extends Build {
   val JacksonVersion = "2.6.0"
   val Slf4jVersion = "1.7.12"
   val ScalaLoggingVersion = "2.1.2"
-  val ElasticsearchVersion = "1.7.0"
+  val ElasticsearchVersion = "1.7.1"
   val Log4jVersion = "1.2.17"
   val CommonsIoVersion = "2.4"
   val GroovyVersion = "2.3.7"


### PR DESCRIPTION
Someone asked for a new 1.7.x release so I thought it may be good to update the dependency of ES to 1.7.1.