### PR TITLE
Helper test method to block until a document has an specific version.

### DIFF
--- a/elastic4s-testkit/src/main/scala/com/sksamuel/elastic4s/testkit/ElasticSugar.scala
+++ b/elastic4s-testkit/src/main/scala/com/sksamuel/elastic4s/testkit/ElasticSugar.scala
@@ -181,4 +181,13 @@ trait ElasticSugar extends ElasticNodeBuilder {
         }.await.isExists == false
     }
   }
+
+  def blockUntilDocumentHasVersion(index: String, `type`: String, id: String, version: Long): Unit = {
+    blockUntil(s"Expected document $id to have version $version") {
+      () =>
+        client.execute {
+          get id id from index -> `type`
+      }.await.getVersion == version
+    }
+  }
 }


### PR DESCRIPTION
Useful for integration tests that rely on updating a document.