### PR TITLE
Prevent overrunning elasticsearch

### DIFF
--- a/elastic4s-streams/src/main/scala/com/sksamuel/elastic4s/streams/BulkIndexingSubscriber.scala
+++ b/elastic4s-streams/src/main/scala/com/sksamuel/elastic4s/streams/BulkIndexingSubscriber.scala
@@ -125,7 +125,7 @@ class BulkActor[T](client: ElasticClient,
       shutdownIfAllAcked()
 
     case BulkActor.ForceIndexing =>
-      if (buffer.nonEmpty)
+      if (pending == 0 && buffer.nonEmpty)
         index()
 
     case r: BulkResponse =>


### PR DESCRIPTION
When indexing is (very) busy but the interval is firing earlier than the BulkResponse returns this might cause the ForceIndexing command to execute while still processing. This will overrun elasticsearch (bulk.index.queue_size)