### PR TITLE
Replaced term and regex with termQuery and regexQuery

### DIFF
--- a/guide/search.md
+++ b/guide/search.md
@@ -20,7 +20,7 @@ search in "places"->"cities" query "paris" start 5 limit 10
 
 One of the great features of Elasticsearch is the number of queries it provides. Here we can use the term query to limit the search to just the state of Georgia rather than the country of Georgia.
 ```scala
-search in "places"->"cities" query { term("state", "georgia") }
+search in "places"->"cities" query { termQuery("state", "georgia") }
 ```
 
 We wouldn't be able to do very much if we couldn't combine queries. So here we combine three queries, 2 "musts" that must match the documents and 1 "not" that must not match the documents. This is what ElasticSearch calls a [boolean query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html). You'll see in this example that I don't like to vacation anywhere that is too hot, and I want to only vacation somewhere that is awesome and that where the name ends with 'cester' like Gloucester or Leicester.
@@ -28,10 +28,10 @@ We wouldn't be able to do very much if we couldn't combine queries. So here we c
 search in "places"->"cities" query {
    bool {
        must(
-           regex("name", ".*cester"),
-           term("status", "Awesome")
+           regexQuery("name", ".*cester"),
+           termQuery("status", "Awesome")
        ) not (
-            term("weather", "hot")
+            termQuery("weather", "hot")
        )
    }
 }


### PR DESCRIPTION
`term` and `regex` are deprecated