### PR TITLE
Fixed BulkDefinition execution to use existing BulkRequest

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/bulk.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/bulk.scala
@@ -35,13 +35,7 @@ trait BulkDsl {
   implicit object BulkDefinitionExecutable
     extends Executable[BulkDefinition, BulkResponse, BulkResponse] {
     override def apply(c: Client, t: BulkDefinition): Future[BulkResponse] = {
-      val bulk = c.prepareBulk()
-      t.requests.foreach {
-        case index: IndexDefinition => bulk.add(index.build)
-        case delete: DeleteByIdDefinition => bulk.add(delete.build)
-        case update: UpdateDefinition => bulk.add(update.build)
-      }
-      injectFuture(bulk.execute)
+      injectFuture(c.bulk(t.build, _))
     }
   }
 
@@ -49,6 +43,8 @@ trait BulkDsl {
 }
 
 class BulkDefinition(val requests: Seq[BulkCompatibleDefinition]) {
+
+  def build = _builder
 
   def timeout(value: String): this.type = {
     _builder.timeout(value)
@@ -80,7 +76,7 @@ class BulkDefinition(val requests: Seq[BulkCompatibleDefinition]) {
     this
   }
 
-  val _builder = new BulkRequest()
+  private val _builder = new BulkRequest()
   requests.foreach {
     case index: IndexDefinition => _builder.add(index.build)
     case delete: DeleteByIdDefinition => _builder.add(delete.build)


### PR DESCRIPTION
Accounts for a bug on #413 when refresh/timeout/etc options are not passed to the final BulkRequest.
I wanted to try and test this on my real project, but dealing with sbt, versions and artifacts is a special kind of hell.