### PR TITLE
Fixing GET with slash notation: get id "id" from "index"/"type" now works.

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/GetDsl.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/GetDsl.scala
@@ -13,7 +13,7 @@ trait GetDsl extends IndexesTypesDsl {
 
   class GetWithIdExpectsFrom(id: String) {
     def from(index: IndexesTypes): GetDefinition = new GetDefinition(index, id)
-    def from(index: IndexType): GetDefinition = new GetDefinition(index.index, id)
+    def from(index: IndexType): GetDefinition = new GetDefinition(IndexesTypes(index), id)
     def from(index: String, `type`: String): GetDefinition = from(IndexesTypes(index, `type`))
     def from(index: String): GetDefinition = new GetDefinition(index, id)
   }

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/GetDslTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/GetDslTest.scala
@@ -25,6 +25,12 @@ class GetDslTest extends FlatSpec with Matchers with ElasticSugar {
     assert(req.build.`type`() === "cities")
   }
 
+  it should """parse "index"/"type" combinations """ in {
+    val req = get id 123 from "places"/"cities"
+    assert(req.build.index() === "places")
+    assert(req.build.`type`() === "cities")
+  }
+
   it should "accept one field" in {
     val req = get id 123 from "places/cities" fields "name"
     assert(req.build.index() === "places")


### PR DESCRIPTION
There was a bug when specifying the type as "index"/"type" (the type was ignored).