### PR TITLE
Use Akka's Receive Timeout instead of the scheduler for forced bulk indexing

### DIFF
--- a/elastic4s-streams/src/main/scala/com/sksamuel/elastic4s/streams/ReactiveElastic.scala
+++ b/elastic4s-streams/src/main/scala/com/sksamuel/elastic4s/streams/ReactiveElastic.scala
@@ -18,7 +18,7 @@ object ReactiveElastic {
                       listener: ResponseListener = ResponseListener.noop,
                       completionFn: () => Unit = () => (),
                       errorFn: Throwable => Unit = _ => (),
-                      flushInterval: Option[FiniteDuration] = None)
+                      flushAfter: Option[FiniteDuration] = None)
                      (implicit builder: RequestBuilder[T], system: ActorSystem): BulkIndexingSubscriber[T] = {
       new BulkIndexingSubscriber[T](client,
         builder,
@@ -28,7 +28,7 @@ object ReactiveElastic {
         refreshAfterOp,
         completionFn,
         errorFn,
-        flushInterval)
+        flushAfter)
     }
 
     def publisher(indexType: IndexAndTypes, elements: Long = Long.MaxValue, keepAlive: String = "1m")

--- a/elastic4s-streams/src/test/scala/com/sksamuel/elastic4s/streams/BulkIndexingSubscriberIntegrationTest.scala
+++ b/elastic4s-streams/src/test/scala/com/sksamuel/elastic4s/streams/BulkIndexingSubscriberIntegrationTest.scala
@@ -41,9 +41,8 @@ class BulkIndexingSubscriberIntegrationTest extends WordSpec with ElasticSugar w
 
       import scala.concurrent.duration._
 
-      val completionLatch = new CountDownLatch(1)
       // The short interval is just for the sake of test execution time, it's not a recommendation
-      val subscriber = client.subscriber[Ship](8, 2, flushInterval = Some(500.millis))
+      val subscriber = client.subscriber[Ship](8, 2, flushAfter = Some(500.millis))
       ShipEndlessPublisher.subscribe(subscriber)
 
       blockUntilCount(ships.length, "bulkindexsubint")


### PR DESCRIPTION
The implementation of the forced bulk indexing causes useless scheduled operations during the normal operation of the BulkActor. This can be avoided using Akka's Receive Timeout feature (http://doc.akka.io/docs/akka/snapshot/scala/actors.html#Receive_timeout). Now forced bulk indexing is only performed when no messages arrive to the BulkActor in the specified timeout. Also, this allows to simplify the code (e.g. no need of BulkActor.ForceIndexing message anymore).