### PR TITLE
Support for include_in_root|parent

### DIFF
--- a/elastic4s-core-tests/src/test/resources/json/createindex/mapping_nested.json
+++ b/elastic4s-core-tests/src/test/resources/json/createindex/mapping_nested.json
@@ -38,6 +38,8 @@
                 },
                 "user": {
                     "type": "nested",
+                    "include_in_root": "yes",
+                    "include_in_parent": "yes",
                     "properties": {
                         "name": {
                             "type": "string"

--- a/elastic4s-core-tests/src/test/scala/com/sksamuel/elastic4s/CreateIndexDslTest.scala
+++ b/elastic4s-core-tests/src/test/scala/com/sksamuel/elastic4s/CreateIndexDslTest.scala
@@ -153,7 +153,7 @@ class CreateIndexDslTest extends FlatSpec with MockitoSugar with JsonSugar with 
           "last" nested {
             "lastLogin" typed DateType
           }
-          )
+          ) includeInRoot(true) includeInParent(true)
         ) size true numericDetection true boostNullValue 1.2 boost "myboost"
     )
     req._source.string should matchJsonResource("/json/createindex/mapping_nested.json")

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/attributes.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/attributes.scala
@@ -612,4 +612,23 @@ object attributes {
     }
   }
 
+  trait AttributeIncludeInParent extends Attribute { self: TypedFieldDefinition =>
+
+    private[this] var _includeInParent: Option[String] = None
+
+    def includeInParent(includeInParent: YesNo): this.type = {
+      _includeInParent = Some(includeInParent.value)
+      this
+    }
+
+    def includeInParent(param: Boolean): this.type = {
+      includeInParent(YesNo(param))
+      this
+    }
+
+    protected override def insert(source: XContentBuilder): Unit = {
+      _includeInParent.foreach(source.field("include_in_parent", _))
+    }
+  }
+
 }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/attributes.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/attributes.scala
@@ -593,4 +593,23 @@ object attributes {
     }
   }
 
+  trait AttributeIncludeInRoot extends Attribute { self: TypedFieldDefinition =>
+
+    private[this] var _includeInRoot: Option[String] = None
+
+    def includeInRoot(includeInRoot: YesNo): this.type = {
+      _includeInRoot = Some(includeInRoot.value)
+      this
+    }
+
+    def includeInRoot(param: Boolean): this.type = {
+      includeInRoot(YesNo(param))
+      this
+    }
+
+    protected override def insert(source: XContentBuilder): Unit = {
+      _includeInRoot.foreach(source.field("include_in_root", _))
+    }
+  }
+
 }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/fields.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/fields.scala
@@ -73,7 +73,8 @@ abstract class TypedFieldDefinition(val `type`: FieldType, name: String) extends
 
 /** @author Fehmi Can Saglam */
 final class NestedFieldDefinition(name: String)
-  extends TypedFieldDefinition(NestedType, name) {
+  extends TypedFieldDefinition(NestedType, name)
+  with AttributeIncludeInRoot {
 
   var _fields: Seq[TypedFieldDefinition] = Nil
 
@@ -87,6 +88,7 @@ final class NestedFieldDefinition(name: String)
       source.startObject(name)
 
     insertType(source)
+    super[AttributeIncludeInRoot].insert(source)
     source.startObject("properties")
     for ( field <- _fields ) {
       field.build(source)

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/fields.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/fields.scala
@@ -74,7 +74,8 @@ abstract class TypedFieldDefinition(val `type`: FieldType, name: String) extends
 /** @author Fehmi Can Saglam */
 final class NestedFieldDefinition(name: String)
   extends TypedFieldDefinition(NestedType, name)
-  with AttributeIncludeInRoot {
+    with AttributeIncludeInRoot
+    with AttributeIncludeInParent {
 
   var _fields: Seq[TypedFieldDefinition] = Nil
 
@@ -89,6 +90,7 @@ final class NestedFieldDefinition(name: String)
 
     insertType(source)
     super[AttributeIncludeInRoot].insert(source)
+    super[AttributeIncludeInParent].insert(source)
     source.startObject("properties")
     for ( field <- _fields ) {
       field.build(source)


### PR DESCRIPTION
This PR is to support `include_in_root` and `include_in_parent` even though they might be deprecated soon.
https://github.com/elastic/elasticsearch/issues/12461