### PR TITLE
get request ignores type when using IndexType as param

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/GetDsl.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/GetDsl.scala
@@ -13,7 +13,7 @@ trait GetDsl extends IndexesTypesDsl {
 
   class GetWithIdExpectsFrom(id: String) {
     def from(index: IndexesTypes): GetDefinition = new GetDefinition(index, id)
-    def from(index: IndexType): GetDefinition = new GetDefinition(index.index, id)
+    def from(index: IndexType): GetDefinition = new GetDefinition(IndexesTypes(index), id)
     def from(index: String, `type`: String): GetDefinition = from(IndexesTypes(index, `type`))
     def from(index: String): GetDefinition = new GetDefinition(index, id)
   }

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/GetDslTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/GetDslTest.scala
@@ -58,4 +58,9 @@ class GetDslTest extends FlatSpec with Matchers with ElasticSugar {
     assert(req.build.routing() === "whosyour")
   }
 
+  it should "accept indextype" in {
+    val req = get id 123 from "places" / "cities"
+    assert(req.build.index() === "places")
+    assert(req.build.`type`() === "cities")
+  }
 }


### PR DESCRIPTION
When using IndexType as a parameter for from method, index type is being ignored in Get requests.