### PR TITLE
response with failures results in HasFailuresException

### DIFF
--- a/elastic4s-streams/src/main/scala/com/sksamuel/elastic4s/streams/BulkIndexingSubscriber.scala
+++ b/elastic4s-streams/src/main/scala/com/sksamuel/elastic4s/streams/BulkIndexingSubscriber.scala
@@ -167,7 +167,7 @@ class BulkActor[T](client: ElasticClient,
     def send(req: BulkDefinition): Unit = {
       client.execute(req).onComplete {
         case Failure(e) => self ! e
-        case Success(resp: BulkResult) if resp.hasFailures => send(req)
+        case Success(resp: BulkResult) if resp.hasFailures => self ! new HasFailuresException("Bulk request has failures.", resp)
         case Success(resp: BulkResult) => self ! resp
       }
     }

--- a/elastic4s-streams/src/main/scala/com/sksamuel/elastic4s/streams/HasFailuresException.scala
+++ b/elastic4s-streams/src/main/scala/com/sksamuel/elastic4s/streams/HasFailuresException.scala
@@ -1,0 +1,12 @@
+package com.sksamuel.elastic4s.streams
+
+import com.sksamuel.elastic4s.BulkResult
+
+class HasFailuresException(message:String, val bulkResult: BulkResult) extends Exception(message) {
+  override def toString: String = {
+    message + " " +
+    "Failure messages: " +
+    bulkResult.failures.map(f=> f.failureMessage).mkString( ",") +
+    "."
+  }
+}


### PR DESCRIPTION
Instead of calling send with the same request again and create an infinite loop an exception is thrown and the subscription is cancelled.