### PR TITLE
Fix runtime exception when 'getFields' returns null

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/GetDsl.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/GetDsl.scala
@@ -101,7 +101,7 @@ case class RichGetResponse(original: GetResponse) {
   def field(name: String): GetField = original.getField(name)
   def fieldOpt(name: String): Option[GetField] = Option(field(name))
 
-  def fields: Map[String, GetField] = original.getFields.asScala.toMap
+  def fields: Map[String, GetField] = Option(original.getFields).fold(Map.empty[String, GetField])(_.asScala.toMap)
 
   def id: String = original.getId
   def index: String = original.getIndex


### PR DESCRIPTION
It seems that `getFields` can be `null`, in which case the `fields` method throws a runtime exception:
```
scala.collection.convert.Wrappers$JMapWrapperLike$$anon$2.<init>(Wrappers.scala:281)
scala.collection.convert.Wrappers$JMapWrapperLike$class.iterator(Wrappers.scala:280)
scala.collection.convert.Wrappers$JMapWrapper.iterator(Wrappers.scala:298)
scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
scala.collection.AbstractIterable.foreach(Iterable.scala:54)
scala.collection.TraversableOnce$class.toMap(TraversableOnce.scala:314)
scala.collection.AbstractTraversable.toMap(Traversable.scala:104)
com.sksamuel.elastic4s.RichGetResponse$.fields$extension(GetDsl.scala:100)
```
I had the same issue in a previous version when I was wrapping the Java response objects directly; this is the fix.
