### PR TITLE
Add support for scripted agg metrics

### DIFF
--- a/elastic4s-core-tests/src/test/resources/json/search/search_aggregations_avg.json
+++ b/elastic4s-core-tests/src/test/resources/json/search/search_aggregations_avg.json
@@ -5,8 +5,7 @@
         "field": "grade",
         "script": {
           "inline": "doc['grade'].value",
-          "lang": "lua",
-          "params": {}
+          "lang": "lua"
         }
       }
     }

--- a/elastic4s-core-tests/src/test/resources/json/search/search_aggregations_count.json
+++ b/elastic4s-core-tests/src/test/resources/json/search/search_aggregations_count.json
@@ -5,8 +5,7 @@
         "field": "grade",
         "script": {
           "inline": "doc['grade'].value",
-          "lang": "lua",
-          "params": {}
+          "lang": "lua"
         }
       }
     }

--- a/elastic4s-core-tests/src/test/resources/json/search/search_aggregations_extendedstats.json
+++ b/elastic4s-core-tests/src/test/resources/json/search/search_aggregations_extendedstats.json
@@ -5,8 +5,7 @@
         "field": "grade",
         "script": {
           "inline": "doc['grade'].value",
-          "lang": "lua",
-          "params": {}
+          "lang": "lua"
         }
       }
     }

--- a/elastic4s-core-tests/src/test/resources/json/search/search_aggregations_max.json
+++ b/elastic4s-core-tests/src/test/resources/json/search/search_aggregations_max.json
@@ -5,8 +5,7 @@
         "field": "grade",
         "script": {
           "inline": "doc['grade'].value",
-          "lang": "lua",
-          "params": {}
+          "lang": "lua"
         }
       }
     }

--- a/elastic4s-core-tests/src/test/resources/json/search/search_aggregations_stats.json
+++ b/elastic4s-core-tests/src/test/resources/json/search/search_aggregations_stats.json
@@ -5,8 +5,7 @@
         "field": "grade",
         "script": {
           "inline": "doc['grade'].value",
-          "lang": "lua",
-          "params": {}
+          "lang": "lua"
         }
       }
     }

--- a/elastic4s-core-tests/src/test/resources/json/search/search_function_score.json
+++ b/elastic4s-core-tests/src/test/resources/json/search/search_function_score.json
@@ -17,8 +17,7 @@
           "weight": 0.5,
           "script_score": {
             "script": {
-              "inline": "some script here",
-              "params": {}
+              "inline": "some script here"
             }
           }
         },

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticDsl.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticDsl.scala
@@ -87,6 +87,7 @@ trait ElasticDsl
     def percentiles(name: String) = new PercentilesAggregationDefinition(name)
     def percentileranks(name: String) = new PercentileRanksAggregationDefinition(name)
     def range(name: String) = new RangeAggregationDefinition(name)
+    def scriptedMetric(name: String) = new ScriptedMetricAggregationDefinition(name)
     def sigTerms(name: String) = new SigTermsAggregationDefinition(name)
     def stats(name: String) = new StatsAggregationDefinition(name)
     def sum(name: String) = new SumAggregationDefinition(name)

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ScriptDsl.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ScriptDsl.scala
@@ -25,8 +25,12 @@ case class ScriptDefinition(script: String,
   def scriptType(scriptType: ESScriptType): ScriptDefinition = copy(scriptType = scriptType)
 
   def toJavaAPI: Script = {
-    val mappedParams = FieldsMapper.mapper(params).asJava
-    new Script(script, scriptType, lang.orNull, mappedParams)
+    if(params.isEmpty) {
+      new Script(script, scriptType, lang.orNull, null)
+    } else {
+      val mappedParams = FieldsMapper.mapper(params).asJava
+      new Script(script, scriptType, lang.orNull, mappedParams)
+    }
   }
 }
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/aggregations.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/aggregations.scala
@@ -682,6 +682,38 @@ case class GlobalAggregationDefinition(name: String)
   val aggregationBuilder = AggregationBuilders.global(name)
 }
 
+class ScriptedMetricAggregationDefinition(name: String) extends AbstractAggregationDefinition {
+
+  import scala.collection.JavaConverters._
+  
+  val builder = AggregationBuilders.scriptedMetric(name)
+
+  def initScript(script: ScriptDefinition): ScriptedMetricAggregationDefinition = {
+    builder.initScript(script.toJavaAPI)
+    this
+  }
+
+  def mapScript(script: ScriptDefinition): ScriptedMetricAggregationDefinition = {
+    builder.mapScript(script.toJavaAPI)
+    this
+  }
+
+  def combineScript(script: ScriptDefinition): ScriptedMetricAggregationDefinition = {
+    builder.combineScript(script.toJavaAPI)
+    this
+  }
+
+  def reduceScript(script: ScriptDefinition): ScriptedMetricAggregationDefinition = {
+    builder.reduceScript(script.toJavaAPI)
+    this
+  }
+
+  def params(params: Map[String, Any]): ScriptedMetricAggregationDefinition = {
+    val mappedParams = FieldsMapper.mapper(params).asJava
+    builder.params(mappedParams)
+    this
+  }
+}
 
 case class TopHitsAggregationDefinition(name: String) extends AbstractAggregationDefinition {
   val builder = AggregationBuilders.topHits(name)


### PR DESCRIPTION
https://www.elastic.co/guide/en/elasticsearch/reference/2.1/search-aggregations-metrics-scripted-metric-aggregation.html

- Change Script handling to not provide params when Map is empty.
This was causing:

org.elasticsearch.search.SearchParseException: init_script params are
not supported. Parameters for the init_script must be specified in the
params field on the scripted_metric aggregator not inside the
init_script object

- Update tests resources according to previous change

NB: I had a pull request merged in branch 1.7 for the same feature. Can you release version 1.7.5 as many of us are sticked to ES 1.7.x ?

Thanks