### PR TITLE
Type is required in put mapping request

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticDsl.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticDsl.scala
@@ -389,9 +389,9 @@ trait ElasticDsl
   def phraseSuggestion(name: String): PhraseSuggestionDefinition = phrase suggestion name
 
   case object put {
-    def mapping(indexType: IndexAndTypes): PutMappingDefinition = new PutMappingDefinition(indexType)
+    def mapping(indexesAndType: IndexesAndType): PutMappingDefinition = new PutMappingDefinition(indexesAndType)
   }
-  def putMapping(indexType: IndexAndTypes): PutMappingDefinition = new PutMappingDefinition(indexType)
+  def putMapping(indexesAndType: IndexesAndType): PutMappingDefinition = new PutMappingDefinition(indexesAndType)
 
   case object recover {
     def index(indexes: Iterable[String]): IndexRecoveryDefinition = new IndexRecoveryDefinition(indexes.toSeq)

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticImplicits.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticImplicits.scala
@@ -2,7 +2,7 @@ package com.sksamuel.elastic4s
 
 trait ElasticImplicits {
   implicit class RichString(str: String) {
-    def /(`type`: String): IndexAndTypes = IndexAndTypes(str, `type`)
+    def /(`type`: String): IndexAndType = IndexAndType(str, `type`)
   }
 }
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/IndexAndTypes.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/IndexAndTypes.scala
@@ -2,13 +2,15 @@ package com.sksamuel.elastic4s
 
 import scala.language.implicitConversions
 
-case class Indexes(values: Seq[String]) extends AnyVal
+case class Indexes(values: Seq[String])
 
 object Indexes {
   implicit def apply(index: String): Indexes = Indexes(Seq(index))
   implicit def apply(first: String, rest: String*): Indexes = Indexes(first +: rest)
   implicit def apply(indexes: Iterable[String]): Indexes = Indexes(indexes.toSeq)
 }
+
+case class IndexAndType(index: String, `type`: String)
 
 case class IndexAndTypes(index: String, types: Seq[String])
 
@@ -20,6 +22,7 @@ object IndexAndTypes {
       case _ => sys.error(s"Could not parse '$string' into index/type1[,type2,...]")
     }
   }
+  implicit def apply(indexAndType: IndexAndType): IndexAndTypes = apply(indexAndType.index, indexAndType.`type`)
   implicit def apply(index: String, `type`: String): IndexAndTypes = IndexAndTypes(index, Seq(`type`))
   implicit def apply(indexAndType: (String, String)): IndexAndTypes = apply(indexAndType._1, indexAndType._2)
 }
@@ -36,6 +39,7 @@ object IndexesAndTypes {
     }
   }
 
+  implicit def apply(indexAndType: IndexAndType): IndexesAndTypes = apply(indexAndType.index, indexAndType.`type`)
   implicit def apply(indexType: IndexAndTypes): IndexesAndTypes = IndexesAndTypes(Seq(indexType.index), indexType.types)
 
   // iterables of strings are assumed to be lists of indexes with no types
@@ -45,4 +49,10 @@ object IndexesAndTypes {
   // a tuple is assumed to be an index and a type
   implicit def apply(indexAndType: (String, String)): IndexesAndTypes = apply(indexAndType._1, indexAndType._2)
   implicit def apply(index: String, `type`: String): IndexesAndTypes = IndexesAndTypes(Seq(index), Seq(`type`))
+}
+
+case class IndexesAndType(indexes: Seq[String], `type`: String)
+
+object IndexesAndType {
+  implicit def apply(indexAndType: IndexAndType): IndexesAndType = IndexesAndType(Seq(indexAndType.index), indexAndType.`type`)
 }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/MappingDsl.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/MappingDsl.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.elastic4s.mappings
 
-import com.sksamuel.elastic4s.{Executable, IndexesAndTypes, ProxyClients}
+import com.sksamuel.elastic4s.{IndexesAndType, Executable, IndexesAndTypes, ProxyClients}
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse
 import org.elasticsearch.action.admin.indices.mapping.put.{PutMappingAction, PutMappingRequest, PutMappingRequestBuilder, PutMappingResponse}
 import org.elasticsearch.client.Client
@@ -65,12 +65,12 @@ case class GetMappingsResult(original: GetMappingsResponse) {
   }
 }
 
-class PutMappingDefinition(indexesType: IndexesAndTypes) extends MappingDefinition(indexesType.types.head) {
+class PutMappingDefinition(indexesAndType: IndexesAndType) extends MappingDefinition(indexesAndType.`type`) {
 
   def request: PutMappingRequest = {
     val req = new PutMappingRequestBuilder(ProxyClients.indices, PutMappingAction.INSTANCE)
-      .setIndices(indexesType.indexes: _*)
-      .setType(indexesType.types.head)
+      .setIndices(indexesAndType.indexes: _*)
+      .setType(indexesAndType.`type`)
       .setSource(super.build)
     req.request()
   }


### PR DESCRIPTION
Following code compiles:
```
client.execute {
      put mapping "index"
}
``` 
but fails with error:
```
head of empty list
java.util.NoSuchElementException: head of empty list
	at scala.collection.immutable.Nil$.head(List.scala:420)
	at scala.collection.immutable.Nil$.head(List.scala:417)
	at com.sksamuel.elastic4s.mappings.PutMappingDefinition.<init>(MappingDsl.scala:68)
...
```

This PR fixes this. Now you can't create put mapping request without type.