### PR TITLE
Restore missing 1.7.x commits

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticDsl.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticDsl.scala
@@ -27,6 +27,7 @@ trait ElasticDsl
   with IndexRefreshDsl
   with IndexRecoveryDsl
   with IndexStatusDsl
+  with IndexTemplateDsl
   with MappingDsl
   with MoreLikeThisDsl
   with MultiGetDsl
@@ -37,7 +38,7 @@ trait ElasticDsl
   with ScoreDsl
   with ScrollDsl
   with SnapshotDsl
-  with TemplateDsl
+  with TermVectorDsl
   with UpdateDsl
   with ValidateDsl
   with ElasticImplicits {
@@ -486,12 +487,12 @@ trait ElasticDsl
   def recoverIndex(indexes: Iterable[String]): IndexRecoveryDefinition = recover index indexes
 
   case object refresh {
-    def index(indexes: Iterable[String]): IndexRefreshDefinition = new IndexRefreshDefinition(indexes.toSeq)
-    def index(indexes: String*): IndexRefreshDefinition = new IndexRefreshDefinition(indexes)
+    def index(indexes: Iterable[String]): RefreshIndexDefinition = new RefreshIndexDefinition(indexes.toSeq)
+    def index(indexes: String*): RefreshIndexDefinition = new RefreshIndexDefinition(indexes)
   }
 
-  def refreshIndex(indexes: Iterable[String]): IndexRefreshDefinition = refresh index indexes
-  def refreshIndex(indexes: String*): IndexRefreshDefinition = refresh index indexes
+  def refreshIndex(indexes: Iterable[String]): RefreshIndexDefinition = refresh index indexes
+  def refreshIndex(indexes: String*): RefreshIndexDefinition = refresh index indexes
 
   case object remove {
     def alias(alias: String): RemoveAliasExpectsIndex = {

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/IndexType.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/IndexType.scala
@@ -21,7 +21,7 @@ object IndexesTypes {
     string.split("/") match {
       case Array(index) => IndexesTypes(Array(index), Nil)
       case Array(index, t) => IndexesTypes(List(index), List(t))
-      case _ => throw new RuntimeException("Could not parse into index/type")
+      case _ => throw new RuntimeException(s"Could not parse '$string' into index/type")
     }
   }
 }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/TermVectorDsl.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/TermVectorDsl.scala
@@ -1,0 +1,52 @@
+package com.sksamuel.elastic4s
+
+import org.elasticsearch.action.termvector.{TermVectorRequestBuilder, TermVectorResponse}
+import org.elasticsearch.client.Client
+
+import scala.concurrent.Future
+
+trait TermVectorDsl {
+
+  def termVector(index: String, `type`: String, id: String) = TermVectorDefinition(index, `type`, id)
+
+  implicit object TermVectorExecutable
+    extends Executable[TermVectorDefinition, TermVectorResponse, TermVectorResponse] {
+    override def apply(client: Client, t: TermVectorDefinition): Future[TermVectorResponse] = {
+      injectFuture(t.build(client.prepareTermVector).execute)
+    }
+  }
+}
+
+case class TermVectorDefinition(private val index: String,
+                                private val `type`: String,
+                                private val id: String,
+                                private val positions: Option[Boolean] = None,
+                                private val payloads: Option[Boolean] = None,
+                                private val offsets: Option[Boolean] = None,
+                                private val routing: Option[String] = None,
+                                private val termStatistics: Option[Boolean] = None,
+                                private val fieldStatistics: Option[Boolean] = None,
+                                private val fields: Option[Seq[String]] = None) {
+
+  def build(builder: TermVectorRequestBuilder): TermVectorRequestBuilder = {
+    builder.setIndex(index)
+    builder.setType(`type`)
+    builder.setId(id)
+    termStatistics.foreach(builder.setTermStatistics)
+    fieldStatistics.foreach(builder.setFieldStatistics)
+    positions.foreach(builder.setPositions)
+    payloads.foreach(builder.setPayloads)
+    offsets.foreach(builder.setOffsets)
+    routing.foreach(builder.setRouting)
+    fields.foreach(flds => builder.setSelectedFields(flds: _ *))
+    builder
+  }
+
+  def withTermStatistics(boolean: Boolean = true): TermVectorDefinition = copy(termStatistics = Option(boolean))
+  def withFieldStatistics(boolean: Boolean = true): TermVectorDefinition = copy(fieldStatistics = Option(boolean))
+  def withFields(fields: String*): TermVectorDefinition = copy(fields = Option(fields))
+  def withRouting(routing: String): TermVectorDefinition = copy(routing = Option(routing))
+  def withOffets(boolean: Boolean = true): TermVectorDefinition = copy(offsets = Option(boolean))
+  def withPayloads(boolean: Boolean = true): TermVectorDefinition = copy(payloads = Option(boolean))
+  def withPositions(boolean: Boolean = true): TermVectorDefinition = copy(positions = Option(boolean))
+}

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/TokenFilter.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/TokenFilter.scala
@@ -51,11 +51,13 @@ case class SynonymTokenFilter(name: String,
                          tokenizer: Option[Tokenizer])
     extends TokenFilterDefinition {
 
+  require(path.isDefined || synonyms.nonEmpty, "synonym requires either `synonyms` or `synonyms_path` to be configured")
+
   val filterType = "synonym"
 
   override def build(source: XContentBuilder): Unit = {
     path.foreach(source.field("synonyms_path", _))
-    synonyms.foreach(source.field("synonyms", _))
+    source.field("synonyms", synonyms.toArray[String]: _*)
     format.foreach(source.field("format", _))
     ignoreCase.foreach(source.field("ignore_case", _))
     expand.foreach(source.field("expand", _))

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/UpdateDsl.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/UpdateDsl.scala
@@ -97,7 +97,19 @@ class UpdateDefinition(indexesTypes: IndexesTypes, id: String)
 
   def params(entries: (String, Any)*): this.type = params(entries.toMap)
   def params(map: Map[String, Any]): this.type = {
-    map.foreach(arg => _builder.addScriptParam(arg._1, arg._2))
+    def asJava(param: Any): Any = {
+      import scala.collection.JavaConverters._
+      param match {
+        case l: List[_] => l.asJava
+        case s: Seq[_]  => s.asJava
+        case m: Map[_, _] => m.map {
+          case (k, v) => asJava(k) -> asJava(v)
+        }.asJava
+        case v => v
+      }
+    }
+
+    map.foreach(arg => _builder.addScriptParam(arg._1, asJava(arg._2)))
     this
   }
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/admin/IndexTemplateDsl.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/admin/IndexTemplateDsl.scala
@@ -10,7 +10,7 @@ import org.elasticsearch.client.Client
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.Future
 
-trait TemplateDsl {
+trait IndexTemplateDsl {
 
   class CreateIndexTemplateExpectsPattern(name: String) {
     def pattern(pat: String) = new CreateIndexTemplateDefinition(name, pat)

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/queries.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/queries.scala
@@ -741,7 +741,13 @@ class RegexQueryDefinition(field: String, regex: Any)
 }
 
 class TermQueryDefinition(field: String, value: Any) extends QueryDefinition {
-  val builder = QueryBuilders.termQuery(field, value.toString)
+
+  val builder = value match {
+    case str : String => QueryBuilders.termQuery(field, str)
+    case iter:Iterable[Any] => QueryBuilders.termQuery(field, iter.toArray)
+    case other => QueryBuilders.termQuery(field, other)
+  }
+
   def boost(boost: Double) = {
     builder.boost(boost.toFloat)
     this
@@ -749,15 +755,19 @@ class TermQueryDefinition(field: String, value: Any) extends QueryDefinition {
 }
 
 class TermsQueryDefinition(field: String, values: String*) extends QueryDefinition {
+
   val builder = QueryBuilders.termsQuery(field, values: _*)
+
   def boost(boost: Double): TermsQueryDefinition = {
     builder.boost(boost.toFloat)
     this
   }
+
   def minimumShouldMatch(minimumShouldMatch: Int): TermsQueryDefinition = {
     builder.minimumMatch(minimumShouldMatch)
     this
   }
+
   def disableCoord(disableCoord: Boolean): TermsQueryDefinition = {
     builder.disableCoord(disableCoord)
     this

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/TermVectorTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/TermVectorTest.scala
@@ -1,0 +1,43 @@
+package com.sksamuel.elastic4s
+
+import com.sksamuel.elastic4s.ElasticDsl._
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.SpanSugar._
+import org.scalatest.{Matchers, WordSpec}
+
+/** @author Stephen Samuel */
+class TermVectorTest
+  extends WordSpec
+  with ElasticSugar
+  with Matchers
+  with ScalaFutures {
+
+  override implicit def patienceConfig: PatienceConfig = PatienceConfig(timeout = 10.seconds, interval = 1.seconds)
+
+  client.execute {
+    bulk(
+      index into "termvectortest/startrek" fields("name" -> "james kirk", "rank" -> "captain") id 1,
+      index into "termvectortest/startrek" fields("name" -> "jean luc picard", "rank" -> "captain") id 2,
+      index into "termvectortest/startrek" fields("name" -> "will riker", "rank" -> "cmdr") id 3,
+      index into "termvectortest/startrek" fields("name" -> "data", "rank" -> "ltr cmdr") id 4,
+      index into "termvectortest/startrek" fields("name" -> "geordie la forge", "rank" -> "ltr cmdr") id 5
+    )
+  }.await
+
+  "term vector api " should {
+    "return number of terms for a field in " in {
+
+      val f = client.execute {
+        termVector("termvectortest", "startrek", "5")
+          .withTermStatistics(true)
+          .withFields("name", "rank")
+          .withFieldStatistics(true)
+      }
+
+      whenReady(f) { resp =>
+        val fields = resp.getFields
+        val terms = fields.terms("rank").size shouldBe 2 // ltr cmdr
+      }
+    }
+  }
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -9,7 +9,7 @@ object Build extends Build {
   val ScalaVersion = "2.11.7"
   val ScalatestVersion = "2.2.5"
   val MockitoVersion = "1.9.5"
-  val JacksonVersion = "2.6.0"
+  val JacksonVersion = "2.6.1"
   val Slf4jVersion = "1.7.12"
   val ScalaLoggingVersion = "2.1.2"
   val ElasticsearchVersion = "1.7.2"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -36,7 +36,8 @@ object Build extends Build {
       "org.mockito" % "mockito-all" % MockitoVersion % "test",
       "org.scalatest" %% "scalatest" % ScalatestVersion % "test",
       "org.codehaus.groovy" % "groovy" % GroovyVersion % "test",
-      "org.codehaus.groovy" % "groovy" % GroovyVersion % "test"
+      "org.codehaus.groovy" % "groovy" % GroovyVersion % "test",
+      "com.vividsolutions" % "jts" % "1.13" % "test"
     ),
     publishTo <<= version {
       (v: String) =>


### PR DESCRIPTION
This PR addresses https://github.com/sksamuel/elastic4s/issues/510, in which some commits from 1.7.1 were missing from future versions.

I accomplished this with a git merge onto `release/1.7.x`, specifically:

`git merge --strategy recursive -X patience 1.7.1` (although I don't think the `patience` really did anything different, it was suggested for branches that differ "wildly", according to http://git-scm.com/docs/merge-strategies).

I also had to manually resolve some merge conflicts in the process, favoring changes that:

a) showed up in later versions
b) were later version numbers
c) or were required to compile

I wasn't able to get tests to run successfully on my local environment, but it appears that tests are broken for the `release/1.7.x` branch anyways on [the Travis build](https://travis-ci.org/sksamuel/elastic4s/builds/106156660).

Please let me know if there's anything else I can do, looking forward to a fresh new release if not.