### PR TITLE
Add support for providing minScore in function score query

### DIFF
--- a/elastic4s-core-tests/src/test/resources/json/search/search_function_score.json
+++ b/elastic4s-core-tests/src/test/resources/json/search/search_function_score.json
@@ -49,7 +49,8 @@
       "score_mode": "multiply",
       "boost_mode": "max",
       "max_boost": 1.9,
-      "boost": 1.4
+      "boost": 1.4,
+      "min_score": 1.2
     }
   }
 }

--- a/elastic4s-core-tests/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
+++ b/elastic4s-core-tests/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
@@ -542,7 +542,7 @@ class SearchDslTest extends FlatSpec with MockitoSugar with JsonSugar with OneIn
 
   it should "generate correct json for function score query" in {
     val req = search in "music" types "bands" query {
-      functionScoreQuery("coldplay").boost(1.4).maxBoost(1.9).scoreMode("multiply").boostMode("max").scorers(
+      functionScoreQuery("coldplay").boost(1.4).maxBoost(1.9).scoreMode("multiply").boostMode("max").minScore(1.2).scorers(
         randomScore(1234).weight(1.2),
         scriptScore("some script here").weight(0.5),
         gaussianScore("field1", "1m", "2m").filter(termQuery("band", "coldplay")),

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/DefinitionAttributes.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/DefinitionAttributes.scala
@@ -63,6 +63,15 @@ object DefinitionAttributes {
     }
   }
 
+  trait DefinitionAttributeMinScore {
+    val _builder: { def setMinScore(minScore: Float): Any }
+
+    def minScore(min: Double): this.type = {
+      _builder.setMinScore(min.toFloat)
+      this
+    }
+  }
+
   trait DefinitionAttributeMaxBoost {
     val _builder: { def maxBoost(maxBoost: Float): Any }
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/SearchDsl.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/SearchDsl.scala
@@ -2,6 +2,7 @@ package com.sksamuel.elastic4s
 
 import java.util
 
+import com.sksamuel.elastic4s.DefinitionAttributes._
 import org.elasticsearch.action.search._
 import org.elasticsearch.client.Client
 import org.elasticsearch.common.unit.TimeValue
@@ -128,7 +129,7 @@ case class RescoreDefinition(query: QueryDefinition) {
 }
 
 
-case class SearchDefinition(indexesTypes: IndexesAndTypes) {
+case class SearchDefinition(indexesTypes: IndexesAndTypes) extends DefinitionAttributeMinScore {
 
   val _builder = {
     new SearchRequestBuilder(ProxyClients.client, SearchAction.INSTANCE)
@@ -350,11 +351,6 @@ case class SearchDefinition(indexesTypes: IndexesAndTypes) {
   def indexBoost(map: Map[String, Double]): SearchDefinition = indexBoost(map.toList: _*)
   def indexBoost(tuples: (String, Double)*): SearchDefinition = {
     tuples.foreach(arg => _builder.addIndexBoost(arg._1, arg._2.toFloat))
-    this
-  }
-
-  def minScore(score: Double): SearchDefinition = {
-    _builder.setMinScore(score.toFloat)
     this
   }
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/queries.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/queries.scala
@@ -232,7 +232,8 @@ case class FunctionScoreQueryDefinition(query: QueryDefinition)
     with DefinitionAttributeBoost
     with DefinitionAttributeBoostMode
     with DefinitionAttributeMaxBoost
-    with DefinitionAttributeScoreMode {
+    with DefinitionAttributeScoreMode
+    with DefinitionAttributeMinScore {
 
   val builder = new FunctionScoreQueryBuilder(query.builder)
   val _builder = builder


### PR DESCRIPTION
Allows for specifying a "min_score" in a function score query without having to make calls directly on the builder instance.

