### PR TITLE
Refactor Build.scala to AutoPlugin for future sbt 1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,66 @@
+lazy val root = Project("elastic4s", file("."))
+  .settings(publish := {})
+  .settings(publishArtifact := false)
+  .settings(name := "elastic4s")
+  .aggregate(
+    core,
+    testkit,
+    coreTests,
+    examples,
+    jackson,
+    json4s,
+    streams
+  )
+
+lazy val core = Project("elastic4s-core", file("elastic4s-core"))
+  .settings(name := "elastic4s-core")
+
+lazy val testkit = Project("elastic4s-testkit", file("elastic4s-testkit"))
+  .settings(
+    name := "elastic4s-testkit",
+    libraryDependencies ++= Seq(
+      "org.scalatest" %% "scalatest" % ScalatestVersion,
+      "org.elasticsearch.module" % "lang-groovy" % ElasticsearchVersion,
+      "org.elasticsearch" % "elasticsearch" % ElasticsearchVersion classifier "tests"
+    )
+  )
+  .dependsOn(core)
+
+lazy val coreTests = Project("elastic4s-core-tests", file("elastic4s-core-tests"))
+  .settings(name := "elastic4s-core-tests")
+  .settings(
+    libraryDependencies += "org.scalatest" %% "scalatest" % ScalatestVersion % "test",
+    libraryDependencies += "com.fasterxml.jackson.core" % "jackson-core" % JacksonVersion % "test",
+    libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % JacksonVersion % "test",
+    libraryDependencies += "com.fasterxml.jackson.module" %% "jackson-module-scala" % JacksonVersion % "test" exclude("org.scala-lang", "scala-library")
+  )
+  .dependsOn(core, testkit % "test")
+
+lazy val streams = Project("elastic4s-streams", file("elastic4s-streams"))
+  .settings(
+    name := "elastic4s-streams",
+    libraryDependencies += "com.typesafe.akka" %% "akka-actor" % "2.3.12",
+    libraryDependencies += "org.reactivestreams" % "reactive-streams" % "1.0.0",
+    libraryDependencies += "org.reactivestreams" % "reactive-streams-tck" % "1.0.0" % "test"
+  ).dependsOn(core, testkit % "test", jackson % "test")
+
+lazy val jackson = Project("elastic4s-jackson", file("elastic4s-jackson"))
+  .settings(
+    name := "elastic4s-jackson",
+    libraryDependencies += "com.fasterxml.jackson.core" % "jackson-core" % JacksonVersion,
+    libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % JacksonVersion,
+    libraryDependencies += "com.fasterxml.jackson.module" %% "jackson-module-scala" % JacksonVersion exclude("org.scala-lang", "scala-library"),
+    libraryDependencies += "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % JacksonVersion
+  ).dependsOn(core, testkit % "test")
+
+lazy val json4s = Project("elastic4s-json4s", file("elastic4s-json4s"))
+  .settings(
+    name := "elastic4s-json4s",
+    libraryDependencies += "org.json4s" %% "json4s-core" % "3.2.11",
+    libraryDependencies += "org.json4s" %% "json4s-jackson" % "3.2.11"
+  ).dependsOn(core, testkit % "test")
+
+lazy val examples = Project("elastic4s-examples", file("elastic4s-examples"))
+  .settings(publish := {})
+  .settings(name := "elastic4s-examples")
+  .dependsOn(core, jackson, streams)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,22 +1,30 @@
 import com.typesafe.sbt.pgp.PgpKeys
 import sbt._
+import sbt.plugins.JvmPlugin
 import sbt.Keys._
 
-object Build extends Build {
+object Build extends AutoPlugin {
 
-  val org = "com.sksamuel.elastic4s"
+  override def trigger = AllRequirements
+  override def requires = JvmPlugin
+  
+  object autoImport {
+    val org = "com.sksamuel.elastic4s"
+  
+    val ScalaVersion = "2.11.7"
+    val ScalatestVersion = "2.2.5"
+    val MockitoVersion = "1.9.5"
+    val JacksonVersion = "2.6.1"
+    val Slf4jVersion = "1.7.12"
+    val ScalaLoggingVersion = "2.1.2"
+    val ElasticsearchVersion = "2.3.0"
+    val Log4jVersion = "1.2.17"
+    val CommonsIoVersion = "2.4"  
+  }
+  
+  import autoImport._
 
-  val ScalaVersion = "2.11.7"
-  val ScalatestVersion = "2.2.5"
-  val MockitoVersion = "1.9.5"
-  val JacksonVersion = "2.6.1"
-  val Slf4jVersion = "1.7.12"
-  val ScalaLoggingVersion = "2.1.2"
-  val ElasticsearchVersion = "2.3.0"
-  val Log4jVersion = "1.2.17"
-  val CommonsIoVersion = "2.4"
-
-  val rootSettings = Seq(
+  override def projectSettings = Seq(
     organization := org,
     scalaVersion := ScalaVersion,
     crossScalaVersions := Seq("2.11.7", "2.10.5"),
@@ -70,79 +78,4 @@ object Build extends Build {
         </developers>
     }
   )
-
-  lazy val root = Project("elastic4s", file("."))
-    .settings(rootSettings: _*)
-    .settings(publish := {})
-    .settings(publishArtifact := false)
-    .settings(name := "elastic4s")
-    .aggregate(
-      core,
-      testkit,
-      coreTests,
-      examples,
-      jackson,
-      json4s,
-      streams
-    )
-
-  lazy val core = Project("elastic4s-core", file("elastic4s-core"))
-    .settings(rootSettings: _*)
-    .settings(name := "elastic4s-core")
-
-  lazy val testkit = Project("elastic4s-testkit", file("elastic4s-testkit"))
-    .settings(rootSettings: _*)
-    .settings(
-      name := "elastic4s-testkit",
-      libraryDependencies ++= Seq(
-        "org.scalatest" %% "scalatest" % ScalatestVersion,
-        "org.elasticsearch.module" % "lang-groovy" % ElasticsearchVersion,
-        "org.elasticsearch" % "elasticsearch" % ElasticsearchVersion classifier "tests"
-      )
-    )
-    .dependsOn(core)
-
-  lazy val coreTests = Project("elastic4s-core-tests", file("elastic4s-core-tests"))
-    .settings(rootSettings: _*)
-    .settings(name := "elastic4s-core-tests")
-    .settings(
-      libraryDependencies += "org.scalatest" %% "scalatest" % ScalatestVersion % "test",
-      libraryDependencies += "com.fasterxml.jackson.core" % "jackson-core" % JacksonVersion % "test",
-      libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % JacksonVersion % "test",
-      libraryDependencies += "com.fasterxml.jackson.module" %% "jackson-module-scala" % JacksonVersion % "test" exclude("org.scala-lang", "scala-library")
-    )
-    .dependsOn(core, testkit % "test")
-
-  lazy val streams = Project("elastic4s-streams", file("elastic4s-streams"))
-    .settings(rootSettings: _*)
-    .settings(
-      name := "elastic4s-streams",
-      libraryDependencies += "com.typesafe.akka" %% "akka-actor" % "2.3.12",
-      libraryDependencies += "org.reactivestreams" % "reactive-streams" % "1.0.0",
-      libraryDependencies += "org.reactivestreams" % "reactive-streams-tck" % "1.0.0" % "test"
-    ).dependsOn(core, testkit % "test", jackson % "test")
-
-  lazy val jackson = Project("elastic4s-jackson", file("elastic4s-jackson"))
-    .settings(rootSettings: _*)
-    .settings(
-      name := "elastic4s-jackson",
-      libraryDependencies += "com.fasterxml.jackson.core" % "jackson-core" % JacksonVersion,
-      libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % JacksonVersion,
-      libraryDependencies += "com.fasterxml.jackson.module" %% "jackson-module-scala" % JacksonVersion exclude("org.scala-lang", "scala-library"),
-      libraryDependencies += "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % JacksonVersion
-    ).dependsOn(core, testkit % "test")
-
-  lazy val json4s = Project("elastic4s-json4s", file("elastic4s-json4s"))
-    .settings(rootSettings: _*)
-    .settings(
-      name := "elastic4s-json4s",
-      libraryDependencies += "org.json4s" %% "json4s-core" % "3.2.11",
-      libraryDependencies += "org.json4s" %% "json4s-jackson" % "3.2.11"
-    ).dependsOn(core, testkit % "test")
-
-  lazy val examples = Project("elastic4s-examples", file("elastic4s-examples"))
-    .settings(rootSettings: _*)
-    .settings(publish := {})
-    .settings(name := "elastic4s-examples")
-    .dependsOn(core, jackson, streams)
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8.3")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.0.2")
 


### PR DESCRIPTION
SBT 1.0 will remove Build.scala support.

This pull request refactors the Build into an AutoPlugin and upgrade the pgp plugin