### PR TITLE
Proposal: HitAs codec derivation at compile time

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,8 @@ lazy val root = Project("elastic4s", file("."))
     examples,
     jackson,
     json4s,
-    streams
+    streams,
+    shapeless
   )
 
 lazy val core = Project("elastic4s-core", file("elastic4s-core"))
@@ -58,6 +59,12 @@ lazy val json4s = Project("elastic4s-json4s", file("elastic4s-json4s"))
     name := "elastic4s-json4s",
     libraryDependencies += "org.json4s" %% "json4s-core" % "3.2.11",
     libraryDependencies += "org.json4s" %% "json4s-jackson" % "3.2.11"
+  ).dependsOn(core, testkit % "test")
+  
+lazy val shapeless = Project("elastic4s-shapeless", file("elastic4s-shapeless"))
+  .settings(
+    name := "elastic4s-shapeless",
+    libraryDependencies += "com.chuusai" %% "shapeless" % "2.3.0"
   ).dependsOn(core, testkit % "test")
 
 lazy val examples = Project("elastic4s-examples", file("elastic4s-examples"))

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/Reader.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/Reader.scala
@@ -1,10 +1,16 @@
 package com.sksamuel.elastic4s
 
+import scala.annotation.implicitNotFound
+
 @deprecated("use HitAs, this reader trait has a broken contravariance implementation", "1.6.1")
 trait Reader[-U] {
   def read[T <: U : Manifest](json: String): T
 }
 
+@implicitNotFound(
+  "No HitAs deserializer found for type ${T}." +
+  "Try to implement an implicit HitAs instances for this type or use the elastic4s-shapeless contrib."
+)
 trait HitAs[T] {
   def as(hit: RichSearchHit): T
 }

--- a/elastic4s-shapeless/src/main/scala/com/sksamuel/elastic4s/shapeless/HitAsInstances.scala
+++ b/elastic4s-shapeless/src/main/scala/com/sksamuel/elastic4s/shapeless/HitAsInstances.scala
@@ -1,0 +1,230 @@
+package com.sksamuel.elastic4s.shapeless
+
+import shapeless._
+import shapeless.labelled._
+import shapeless.record._
+import shapeless.ops.record._
+import shapeless.ops.hlist.ToList
+import com.sksamuel.elastic4s.{ HitAs, RichSearchHit }
+import com.sksamuel.elastic4s.SearchDefinition
+
+/**
+ * This implementation requires the user to add the additional fields
+ *
+ * {{{
+ * client.execute {
+ *   search in "places" / "cities" fields("id", "name")
+ * }
+ * }}}
+ * 
+ * 
+ * TODO provide fields name derivation as well
+ * 
+ * {{{
+ * def fromDocument[T, Repr <: HList, KeysRepr <: HList](doc: T)(
+ *     implicit
+ *     gen: LabelledGeneric.Aux[T, Repr],
+ *     keys: Keys.Aux[Repr, KeysRepr],
+ *     ktl: ToList[KeysRepr, String]
+ * ): List[String] = {
+ *   gen.to(doc).keys.toList
+ *   // keys().toList
+ * }
+ * }}}
+ * 
+ */
+trait HitAsFromFieldsInstances {
+
+  /** base representation */
+  implicit def hitAsHNil: HitAs[HNil] = new HitAs[HNil] {
+    override def as(hit: RichSearchHit): HNil = HNil
+  }
+
+  // primitive types and String
+
+  implicit def stringHitAsHCons[K <: Symbol, Rest <: HList](
+    implicit key: Witness.Aux[K],
+    hitRest: HitAs[Rest]) = new HitAs[FieldType[K, String] :: Rest] {
+    override def as(hit: RichSearchHit) = {
+      val value = hit.field(key.value.name).getValue[String]
+      field[K](value) :: hitRest.as(hit)
+    }
+  }
+
+  implicit def anyValhitAsHCons[K <: Symbol, V <: AnyVal, Rest <: HList](
+    implicit key: Witness.Aux[K],
+    hitRest: HitAs[Rest]) = new HitAs[FieldType[K, V] :: Rest] {
+    override def as(hit: RichSearchHit) = {
+      val value = hit.field(key.value.name).value[V]
+      field[K](value) :: hitRest.as(hit)
+    }
+  }
+
+  // generic representation to case class
+
+  implicit def hitAsGeneric[T, Repr](
+    implicit gen: LabelledGeneric.Aux[T, Repr],
+    hitsRepr: HitAs[Repr]) = new HitAs[T] {
+    override def as(hit: RichSearchHit): T = gen.from(hitsRepr.as(hit))
+  }
+  
+}
+
+
+/**
+ * This implementation gets the information directly from the source map.
+ *
+ * - No need for additional fields in search query 
+ * - No need for field names derivation
+ */
+trait HitAsFromSourceInstances {
+
+  /** base representation */
+  implicit def hitAsHNil: HitAs[HNil] = new HitAs[HNil] {
+    override def as(hit: RichSearchHit): HNil = HNil
+  }
+
+  // primitive types and String
+
+  implicit def stringHitAsHCons[K <: Symbol, Rest <: HList](
+    implicit key: Witness.Aux[K],
+    hitRest: HitAs[Rest]) = new HitAs[FieldType[K, String] :: Rest] {
+    override def as(hit: RichSearchHit) = {
+      val value = hit.sourceAsMap(key.value.name).asInstanceOf[String]
+      field[K](value) :: hitRest.as(hit)
+    }
+  }
+
+  implicit def anyValhitAsHCons[K <: Symbol, V <: AnyVal, Rest <: HList](
+    implicit key: Witness.Aux[K],
+    hitRest: HitAs[Rest]) = new HitAs[FieldType[K, V] :: Rest] {
+    override def as(hit: RichSearchHit) = {
+      val value = hit.sourceAsMap(key.value.name).asInstanceOf[V]
+      field[K](value) :: hitRest.as(hit)
+    }
+  }
+
+  // generic representation to case class
+
+  implicit def hitAsGeneric[T, Repr](
+    implicit gen: LabelledGeneric.Aux[T, Repr],
+    hitsRepr: HitAs[Repr]) = new HitAs[T] {
+    override def as(hit: RichSearchHit): T = gen.from(hitsRepr.as(hit))
+  }
+}
+
+
+
+// ---------------------------
+// ------ Test Code ----------
+// ---------------------------
+object TestDerivation extends App {
+
+  // https://github.com/sksamuel/elastic4s
+  // https://github.com/sksamuel/elastic4s/blob/master/guide/search.md
+
+  import com.sksamuel.elastic4s.ElasticClient
+  import com.sksamuel.elastic4s.ElasticDsl._
+  import com.sksamuel.elastic4s.mappings.FieldType._
+  import com.sksamuel.elastic4s.source.Indexable
+  import org.elasticsearch.common.settings.Settings
+
+  import java.nio.file.{ Paths, Files }
+
+  // model class
+  case class City(id: Int, name: String)
+
+  // this will get shapelessed soon, too
+  implicit object CharacterIndexable extends Indexable[City] {
+    override def json(t: City): String = s""" { "id" : ${t.id}, "name" : "${t.name}" } """
+  }
+  // ---
+
+  val tmpDir = Files.createTempDirectory("es-test")
+
+  val settings = Settings.builder().put("path.home", tmpDir.toAbsolutePath.toString)
+  val client = ElasticClient.local(settings.build)
+
+  println("-- node started")
+
+  // create index
+  client.execute {
+    create index "places" mappings (
+      mapping name "cities" fields (
+        field name "id" typed IntegerType,
+        field name "name" typed StringType
+      )
+    )
+  }.await
+  println("-- index created")
+
+  // validate index is there
+  val mappings = client.execute {
+    getMapping("places" / "cities")
+  }.await
+
+  println("-- mappings for places/cities")
+  println("  " + mappings.mappings("places")("cities").getSourceAsMap)
+
+  // insert some documents
+  List((1, "Munich"), (2, "Manchester"), (3, "London")).foreach {
+    case (cityId, name) =>
+      val indexResult = client.execute {
+        index into "places" / "cities" id cityId source City(cityId, name)
+      }.await
+
+      println(s"  ${indexResult.index}/${indexResult.`type`}/${indexResult.id}: ${indexResult.created}")
+  }
+
+  // wait until ES persisted stuff
+  Thread.sleep(1000)
+
+  println("-- start search")
+
+  object FromSource extends HitAsFromSourceInstances {
+
+    def apply() = {
+      println("----- from source")
+      val resp = client.execute {
+        search in "places" / "cities"
+      }.await
+
+      println(s"  Found: ${resp.hits.length}")
+
+      val cities = resp.as[City]
+      cities.foreach(c => println("  " + c))
+    }
+  }
+
+  object FromFields extends HitAsFromFieldsInstances {
+
+    def apply() = {
+    	println("----- from fields")
+    	
+    	// TODO derive field names from document class as well
+      val resp = client.execute {
+        search in "places" / "cities" fields ("id", "name")
+      }.await
+
+      println(s"  Found: ${resp.hits.length}")
+
+      val cities = resp.as[City]
+      cities.foreach(c => println("  " + c))
+    }
+  }
+  
+  // demonstrate both variations
+  FromSource()
+  FromFields()
+
+  
+  // -------------------------------
+  // test implicits
+  
+  // implicitly[HitAs[HNil]]
+  // implicitly[HitAs[City]]
+
+  // this should never work
+  // implicitly[HitAs[Int :: HNil]]
+
+}

--- a/elastic4s-shapeless/src/main/scala/com/sksamuel/elastic4s/shapeless/HitAsInstances.scala
+++ b/elastic4s-shapeless/src/main/scala/com/sksamuel/elastic4s/shapeless/HitAsInstances.scala
@@ -9,72 +9,9 @@ import com.sksamuel.elastic4s.{ HitAs, RichSearchHit }
 import com.sksamuel.elastic4s.SearchDefinition
 
 /**
- * This implementation requires the user to add the additional fields
- *
- * {{{
- * client.execute {
- *   search in "places" / "cities" fields("id", "name")
- * }
- * }}}
- * 
- * 
- * TODO provide fields name derivation as well
- * 
- * {{{
- * def fromDocument[T, Repr <: HList, KeysRepr <: HList](doc: T)(
- *     implicit
- *     gen: LabelledGeneric.Aux[T, Repr],
- *     keys: Keys.Aux[Repr, KeysRepr],
- *     ktl: ToList[KeysRepr, String]
- * ): List[String] = {
- *   gen.to(doc).keys.toList
- *   // keys().toList
- * }
- * }}}
- * 
- */
-trait HitAsFromFieldsInstances {
-
-  /** base representation */
-  implicit def hitAsHNil: HitAs[HNil] = new HitAs[HNil] {
-    override def as(hit: RichSearchHit): HNil = HNil
-  }
-
-  // primitive types and String
-
-  implicit def stringHitAsHCons[K <: Symbol, Rest <: HList](
-    implicit key: Witness.Aux[K],
-    hitRest: HitAs[Rest]) = new HitAs[FieldType[K, String] :: Rest] {
-    override def as(hit: RichSearchHit) = {
-      val value = hit.field(key.value.name).getValue[String]
-      field[K](value) :: hitRest.as(hit)
-    }
-  }
-
-  implicit def anyValhitAsHCons[K <: Symbol, V <: AnyVal, Rest <: HList](
-    implicit key: Witness.Aux[K],
-    hitRest: HitAs[Rest]) = new HitAs[FieldType[K, V] :: Rest] {
-    override def as(hit: RichSearchHit) = {
-      val value = hit.field(key.value.name).value[V]
-      field[K](value) :: hitRest.as(hit)
-    }
-  }
-
-  // generic representation to case class
-
-  implicit def hitAsGeneric[T, Repr](
-    implicit gen: LabelledGeneric.Aux[T, Repr],
-    hitsRepr: HitAs[Repr]) = new HitAs[T] {
-    override def as(hit: RichSearchHit): T = gen.from(hitsRepr.as(hit))
-  }
-  
-}
-
-
-/**
  * This implementation gets the information directly from the source map.
  *
- * - No need for additional fields in search query 
+ * - No need for additional fields in search query
  * - No need for field names derivation
  */
 trait HitAsFromSourceInstances {
@@ -113,12 +50,12 @@ trait HitAsFromSourceInstances {
   }
 }
 
-
+object HitAsFromSourceInstances extends HitAsFromSourceInstances
 
 // ---------------------------
 // ------ Test Code ----------
 // ---------------------------
-object TestDerivation extends App {
+object TestDerivation extends App with HitAsFromSourceInstances {
 
   // https://github.com/sksamuel/elastic4s
   // https://github.com/sksamuel/elastic4s/blob/master/guide/search.md
@@ -135,7 +72,7 @@ object TestDerivation extends App {
   case class City(id: Int, name: String)
 
   // this will get shapelessed soon, too
-  implicit object CharacterIndexable extends Indexable[City] {
+  implicit object CityIndexable extends Indexable[City] {
     override def json(t: City): String = s""" { "id" : ${t.id}, "name" : "${t.name}" } """
   }
   // ---
@@ -156,17 +93,20 @@ object TestDerivation extends App {
       )
     )
   }.await
-  println("-- index created")
 
-  // validate index is there
-  val mappings = client.execute {
-    getMapping("places" / "cities")
-  }.await
+  println("-- indices created")
 
-  println("-- mappings for places/cities")
-  println("  " + mappings.mappings("places")("cities").getSourceAsMap)
+  // show mappings
+  println("-- show mappings")
+  List(getMapping("places" / "cities")).foreach { cmd =>
+    val mappings = client.execute(cmd).await
+    mappings.mappings("places").foreach {
+      case (mType, mapping) => println(s"  ${mType}: ${mapping.sourceAsMap}")
+    }
+  }
+  
 
-  // insert some documents
+  // insert some cities
   List((1, "Munich"), (2, "Manchester"), (3, "London")).foreach {
     case (cityId, name) =>
       val indexResult = client.execute {
@@ -179,52 +119,23 @@ object TestDerivation extends App {
   // wait until ES persisted stuff
   Thread.sleep(1000)
 
-  println("-- start search")
-
-  object FromSource extends HitAsFromSourceInstances {
-
-    def apply() = {
-      println("----- from source")
-      val resp = client.execute {
-        search in "places" / "cities"
-      }.await
-
-      println(s"  Found: ${resp.hits.length}")
-
-      val cities = resp.as[City]
-      cities.foreach(c => println("  " + c))
-    }
-  }
-
-  object FromFields extends HitAsFromFieldsInstances {
-
-    def apply() = {
-    	println("----- from fields")
-    	
-    	// TODO derive field names from document class as well
-      val resp = client.execute {
-        search in "places" / "cities" fields ("id", "name")
-      }.await
-
-      println(s"  Found: ${resp.hits.length}")
-
-      val cities = resp.as[City]
-      cities.foreach(c => println("  " + c))
-    }
-  }
-  
-  // demonstrate both variations
-  FromSource()
-  FromFields()
-
-  
+  println("-- start city search")
   // -------------------------------
   // test implicits
-  
+
   // implicitly[HitAs[HNil]]
-  // implicitly[HitAs[City]]
+  implicitly[HitAs[City]]
 
   // this should never work
   // implicitly[HitAs[Int :: HNil]]
+
+  val resp = client.execute {
+    search in "places" / "cities"
+  }.await
+
+  println(s"  Found: ${resp.hits.length}")
+
+  val cities = resp.as[City]
+  cities.foreach(c => println("  " + c))
 
 }

--- a/elastic4s-shapeless/src/test/scala/com/sksamuel/elastic4s/shapeless/HitAsFromSourceInstancesTest.scala
+++ b/elastic4s-shapeless/src/test/scala/com/sksamuel/elastic4s/shapeless/HitAsFromSourceInstancesTest.scala
@@ -1,0 +1,49 @@
+package com.sksamuel.elastic4s.shapeless
+
+import com.sksamuel.elastic4s.{RichSearchHit, HitAs}
+
+import org.scalatest.{WordSpec, ShouldMatchers, GivenWhenThen}
+import org.scalatest.mock.MockitoSugar._
+import org.mockito.Mockito
+import org.elasticsearch.search.SearchHit
+
+import scala.collection.JavaConversions._
+
+import HitAsFromSourceInstances._
+
+class HitAsFromSourceInstancesTest extends WordSpec with ShouldMatchers with GivenWhenThen {
+  
+  "A derived HitAs instances from a flat case class" should {
+    case class Place(id: Int, name: String)
+    
+    "be implicitly found" in {
+      "implicitly[HitAs[Place]]" should compile
+    }
+    
+    "not compile for nested case classes" in {
+      case class Bar(name: String, place: Place)
+      "implicitly[HitAs[Bar]]" shouldNot compile
+    }
+    
+    "extract the correct values" in {
+      Given("a search hit")
+      val javaHit = mock[SearchHit]
+      val hit = RichSearchHit(javaHit)
+      
+      val source: java.util.Map[String, Object] = Map(
+          "id" -> new java.lang.Integer(3),
+          "name" -> "Munich"         
+      )
+      
+      When("it is parsed with HitAs instances")
+      Mockito.when(javaHit.sourceAsMap).thenReturn(source)
+      val places = hit.as[Place]
+      
+      Then("it contains the correct values")
+      places.id should be(3)
+      places.name should be("Munich")
+      
+    }
+  }
+  
+}


### PR DESCRIPTION
This is a small draft on how code derivation for `elastic4s` could look like. Disclaimer: I'm a shapeless beginner and I am totally fine if this is too maintenance heavy and should be developed separately.

## The idea

Writing `HitAs` instances for each custom type is cumbersome ( same goes for `Indexable` ). So why not derive these type instances from case classes, so we can write:

```scala
import com.sksamuel.elastic4s.shapeless._
val resp = client.execute {
  search in "places" / "cities"
}.await
val cities: Array[City] = resp.as[City]
```

## Implementation

This compile time derivation can be done with shapeless. This initial draft has two versions and some limitations (which I would work on, if this has a chance of being merged)

### Limitations

- Nested objects can not be derived. The `sourceMap` is flat structure, thus the case classes need to be mapped to flat structure as well, building the correct map keys.
- No compile time verification that the defined `mappings` and `ADT` match
- No tests
- No docs

### The two versions:

The are two implementations `HitAsFromFieldsInstances` and `HitAsFromSourceInstances`.

- `HitAsFromFieldsInstances`
-- uses the `field` value to load values
-- needs fields specified in the query, e.g. `search in "places" / "cities" fields("id", "name")`
- `HitAsFromSourceInstances`
-- uses the `sourceMap` to parse values
-- needs no fields