### PR TITLE
Add circe-json based HitAs and Indexable instances

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,6 +52,14 @@ lazy val jackson = Project("elastic4s-jackson", file("elastic4s-jackson"))
     libraryDependencies += "com.fasterxml.jackson.module" %% "jackson-module-scala" % JacksonVersion exclude("org.scala-lang", "scala-library"),
     libraryDependencies += "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % JacksonVersion
   ).dependsOn(core, testkit % "test")
+  
+lazy val circe = Project("elastic4s-circe", file("elastic4s-circe"))
+.settings(
+  name := "elastic4s-circe",
+  libraryDependencies += "io.circe" %% "circe-core" % CirceVersion,
+  libraryDependencies +=  "io.circe" %% "circe-generic" % CirceVersion,
+  libraryDependencies +=  "io.circe" %% "circe-parser" % CirceVersion
+).dependsOn(core, testkit % "test")
 
 lazy val json4s = Project("elastic4s-json4s", file("elastic4s-json4s"))
   .settings(

--- a/elastic4s-circe/src/main/scala/com/sksamuel/elastic4s/circe/package.scala
+++ b/elastic4s-circe/src/main/scala/com/sksamuel/elastic4s/circe/package.scala
@@ -1,0 +1,49 @@
+package com.sksamuel.elastic4s
+
+import io.circe._
+import io.circe.jawn._
+import io.circe.syntax._
+
+import com.sksamuel.elastic4s.source.Indexable
+import scala.annotation.implicitNotFound
+
+/**
+ * Automatic HitAs and Indexable derivation
+ * 
+ * == Usage ==
+ * 
+ * {{{
+ *  import io.circe.generic.auto._
+ *  import com.sksamuel.elastic4s.circe._
+ *  
+ *  case class City(id: Int, name: String)
+ *  
+ *  // index
+ *  index into "places" / "cities" id cityId source City(1, "munich")
+ *  
+ *  // search and parse
+ *  val resp = client.execute {
+ *    search in "places" / "cities"
+ *  }.await
+ *  
+ *  val cities = resp.as[City]
+ *  
+ * }}}
+ */
+package object circe {
+  
+  @implicitNotFound("No Decoder for type ${T} found. Use 'import io.circe.generic.auto._' or provide an implicit Decoder instance ")
+  implicit def hitAsWithCirce[T](
+    implicit decoder: Decoder[T]      
+  ): HitAs[T] = new HitAs[T] {
+    override def as(hit: RichSearchHit): T = decode[T](hit.sourceAsString)
+      .getOrElse(throw new IllegalArgumentException(s"Unable to parse ${hit.sourceAsString}"))
+  }
+  
+  @implicitNotFound("No Encoder for type ${T} found. Use 'import io.circe.generic.auto._' or provide an implicit Encoder instance ")
+  implicit def indexableWithCirce[T](
+    implicit encoder: Encoder[T]      
+  ): Indexable[T] = new Indexable[T] {
+    override def json(t: T): String = encoder(t).noSpaces
+  }
+}

--- a/elastic4s-circe/src/test/scala/com/sksamuel/elastic4s/circe/CodecDerivationTest.scala
+++ b/elastic4s-circe/src/test/scala/com/sksamuel/elastic4s/circe/CodecDerivationTest.scala
@@ -1,0 +1,47 @@
+package com.sksamuel.elastic4s.circe
+
+import com.sksamuel.elastic4s.{ RichSearchHit, HitAs }
+
+import org.scalatest.{ WordSpec, ShouldMatchers, GivenWhenThen }
+import org.scalatest.mock.MockitoSugar._
+import org.mockito.Mockito
+import org.elasticsearch.search.SearchHit
+
+import scala.collection.JavaConversions._
+
+class CodecDerivationTest extends WordSpec with ShouldMatchers with GivenWhenThen {
+
+  "A derived HitAs instances from a flat case class" should {
+    case class Place(id: Int, name: String)
+
+    "be implicitly found if circe.generic.auto is in imported" in {
+      import io.circe.generic.auto._
+      "implicitly[HitAs[Place]]" should compile
+    }
+    
+    "not compile if no decoder is in scope" in {
+      "implicitly[HitAs[Place]]" shouldNot compile
+    }
+    
+    "extract the correct values" in {
+      import io.circe.generic.auto._
+      Given("a search hit")
+      val javaHit = mock[SearchHit]
+      val hit = RichSearchHit(javaHit)
+      
+      val source = """
+        { "id": 3, "name": "Munich" }
+      """
+      
+      When("it is parsed with HitAs instances")
+      Mockito.when(javaHit.sourceAsString).thenReturn(source)
+      val places = hit.as[Place]
+      
+      Then("it contains the correct values")
+      places.id should be(3)
+      places.name should be("Munich")
+      
+    }
+  }
+
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -19,7 +19,8 @@ object Build extends AutoPlugin {
     val ScalaLoggingVersion = "2.1.2"
     val ElasticsearchVersion = "2.3.0"
     val Log4jVersion = "1.2.17"
-    val CommonsIoVersion = "2.4"  
+    val CommonsIoVersion = "2.4"
+    val CirceVersion = "0.4.1"
   }
   
   import autoImport._


### PR DESCRIPTION
This is an addition or alternative to #557

[Circe](https://github.com/travisbrown/circe) provides automatic json codec
derivation, which makes it suitable for HitAs and Indexable derivations.



```scala
import io.circe.generic.auto._
import com.sksamuel.elastic4s.circe._

case class City(id: Int, name: String)

// index
index into "places" / "cities" id cityId source City(1, "munich")

// search and parse
val resp = client.execute {
  search in "places" / "cities"
}.await

val cities = resp.as[City]
```