### PR TITLE
Replace implicit ActorSystem with ActorRefFactory (in ReactiveElastic)

### DIFF
--- a/elastic4s-streams/src/main/scala/com/sksamuel/elastic4s/streams/BulkIndexingSubscriber.scala
+++ b/elastic4s-streams/src/main/scala/com/sksamuel/elastic4s/streams/BulkIndexingSubscriber.scala
@@ -24,7 +24,7 @@ import scala.util.{Failure, Success}
 class BulkIndexingSubscriber[T] private[streams](client: ElasticClient,
                                                  builder: RequestBuilder[T],
                                                  config: SubscriberConfig)
-                                                (implicit system: ActorSystem) extends Subscriber[T] {
+                                                (implicit actorRefFactory: ActorRefFactory) extends Subscriber[T] {
 
   private var actor: ActorRef = _
 
@@ -33,7 +33,7 @@ class BulkIndexingSubscriber[T] private[streams](client: ElasticClient,
     // when the provided Subscriber is null in which case it MUST throw a java.lang.NullPointerException to the caller
     if (sub == null) throw new NullPointerException()
     if (actor == null) {
-      actor = system.actorOf(Props(new BulkActor(client, sub, builder, config)))
+      actor = actorRefFactory.actorOf(Props(new BulkActor(client, sub, builder, config)))
     } else {
       // rule 2.5, must cancel subscription if onSubscribe has been invoked twice
       // https://github.com/reactive-streams/reactive-streams-jvm#2.5

--- a/elastic4s-streams/src/main/scala/com/sksamuel/elastic4s/streams/ReactiveElastic.scala
+++ b/elastic4s-streams/src/main/scala/com/sksamuel/elastic4s/streams/ReactiveElastic.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.elastic4s.streams
 
-import akka.actor.ActorSystem
+import akka.actor.ActorRefFactory
 import com.sksamuel.elastic4s.{ElasticClient, ElasticDsl, IndexAndTypes, SearchDefinition}
 
 import scala.concurrent.duration._
@@ -14,7 +14,7 @@ object ReactiveElastic {
     import ElasticDsl._
 
     def subscriber[T](config: SubscriberConfig)
-                     (implicit builder: RequestBuilder[T], system: ActorSystem): BulkIndexingSubscriber[T] = {
+                     (implicit builder: RequestBuilder[T], actorRefFactory: ActorRefFactory): BulkIndexingSubscriber[T] = {
       new BulkIndexingSubscriber[T](client, builder, config)
     }
 
@@ -28,7 +28,7 @@ object ReactiveElastic {
                       flushAfter: Option[FiniteDuration] = None,
                       failureWait: FiniteDuration = 2.seconds,
                       maxAttempts: Int = 5)
-                     (implicit builder: RequestBuilder[T], system: ActorSystem): BulkIndexingSubscriber[T] = {
+                     (implicit builder: RequestBuilder[T], actorRefFactory: ActorRefFactory): BulkIndexingSubscriber[T] = {
       val config = SubscriberConfig(
         batchSize = batchSize,
         concurrentRequests = concurrentRequests,
@@ -45,13 +45,13 @@ object ReactiveElastic {
     }
 
     def publisher(indexType: IndexAndTypes, elements: Long = Long.MaxValue, keepAlive: String = "1m")
-                 (implicit system: ActorSystem): ScrollPublisher = {
+                 (implicit actorRefFactory: ActorRefFactory): ScrollPublisher = {
       publisher(search in indexType query "*:*" scroll keepAlive)
     }
 
-    def publisher(q: SearchDefinition)(implicit system: ActorSystem): ScrollPublisher = publisher(q, Long.MaxValue)
+    def publisher(q: SearchDefinition)(implicit actorRefFactory: ActorRefFactory): ScrollPublisher = publisher(q, Long.MaxValue)
     def publisher(q: SearchDefinition, elements: Long)
-                 (implicit system: ActorSystem): ScrollPublisher = {
+                 (implicit actorRefFactory: ActorRefFactory): ScrollPublisher = {
       new ScrollPublisher(client, q, elements)
     }
   }


### PR DESCRIPTION
This PR replaces the implicit `ActorSystem` required by `ReactiveElastic`with a `ActorRefFactory`.

This allows one to use either an `ActorSystem` or an `ActorContext`, which can be useful for some actor supervision strategies (i.e. the new actors can have a parent actor responsible for them).

Closes issue #562 