### PR TITLE
Remove reference to "delete from" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,6 @@ the DSL closely mirrors the standard Java API / REST API.
 | [Create Snapshot](guide/snapshot.md)      | `createSnapshot(<name>) in <repo> ...` |
 | Create Template                           | `createTemplate(<name>) pattern <pattern> mappings {...} [settings]`|
 | [Delete by id](guide/delete.md)           | `delete id <id> from <index/type> [settings]`
-| [Delete by query](guide/delete.md)        | `delete from <index/type> query { <queryblock> } [settings]`
 | [Delete index](guide/delete.md)           | `deleteIndex(<index>) [settings]`
 | [Delete Snapshot](guide/snapshot.md)      | `deleteSnapshot(<name>).in(<repo>) ...` |
 | Delete Template                           | `deleteTemplate(<name>)` |


### PR DESCRIPTION
delete from" has been deprecated and removed from elastic4s
Other references in the docs have been removed too, seems like this one was forgotten

See also: #478 & commit 375c46f