### PR TITLE
Added support for fetchSource on MutliGet

### DIFF
--- a/elastic4s-core-tests/src/test/scala/com/sksamuel/elastic4s/MultiGetTest.scala
+++ b/elastic4s-core-tests/src/test/scala/com/sksamuel/elastic4s/MultiGetTest.scala
@@ -3,7 +3,6 @@ package com.sksamuel.elastic4s
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.testkit.ElasticSugar
 import org.elasticsearch.index.VersionType
-import org.elasticsearch.search.fetch.source.FetchSourceContext
 import org.scalatest.FlatSpec
 import org.scalatest.Matchers._
 import org.scalatest.mock.MockitoSugar
@@ -84,8 +83,8 @@ class MultiGetTest extends FlatSpec with MockitoSugar with ElasticSugar {
 
     val resp = client.execute(
       multiget(
-        get id 3 from "coldplay/albums" fetchSourceContext new FetchSourceContext(Array("name", "year")),
-        get id 5 from "coldplay/albums" fields "name" fetchSourceContext new FetchSourceContext(Array("name"))
+        get id 3 from "coldplay/albums" fetchSourceContext Seq("name", "year"),
+        get id 5 from "coldplay/albums" fields "name" fetchSourceContext Seq("name")
       ) preference Preference.Local refresh true realtime true
     ).await
     assert(2 === resp.responses.size)

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/GetDsl.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/GetDsl.scala
@@ -33,6 +33,11 @@ case class GetDefinition(indexTypes: IndexAndTypes, id: String) {
     this
   }
 
+  def fetchSourceContext(include: Iterable[String], exclude: Iterable[String] = Nil) = {
+    _builder.fetchSourceContext(new FetchSourceContext(include.toArray, exclude.toArray))
+    this
+  }
+
   def fetchSourceContext(context: FetchSourceContext) = {
     _builder.fetchSourceContext(context)
     this

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/MultiGetApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/MultiGetApi.scala
@@ -57,6 +57,7 @@ case class MultiGetDefinition(gets: Iterable[GetDefinition])
 
   gets foreach { get =>
     val item = new MultiGetRequest.Item(get.indexTypes.index, get.indexTypes.types.headOption.orNull, get.id)
+    item.fetchSourceContext(get.build.fetchSourceContext)
     item.routing(get.build.routing)
     item.fields(get.build.fields: _*)
     item.version(get.build.version)


### PR DESCRIPTION
The following code was not working as expected because `fetchSourceContext` was ignored.

    multiget(
       get id 3 from "coldplay/albums" fetchSourceContext new FetchSourceContext(Array("name"))
    )


Futhermore I've added a shortcut to be able to do something like:

    get id 3 from "coldplay/albums" fetchSourceContext Seq("name"))

