### PR TITLE
Added support for int, long, float, double termsQuery

### DIFF
--- a/elastic4s-core-tests/src/test/resources/json/search/search_int_terms_lookup_filter.json
+++ b/elastic4s-core-tests/src/test/resources/json/search/search_int_terms_lookup_filter.json
@@ -1,0 +1,10 @@
+{
+  "post_filter": {
+    "terms": {
+      "formedYear": [
+        2013,
+        2014
+      ]
+    }
+  }
+}

--- a/elastic4s-core-tests/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
+++ b/elastic4s-core-tests/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
@@ -293,6 +293,13 @@ class SearchDslTest extends FlatSpec with MockitoSugar with JsonSugar with OneIn
     req.show should matchJsonResource("/json/search/search_terms_lookup_filter.json")
   }
 
+  it should "generate json for int terms lookup filter" in {
+    val req = search in "music" types "bands" postFilter {
+      termsQuery("formedYear", 2013, 2014)
+    }
+    req.show should matchJsonResource("/json/search/search_int_terms_lookup_filter.json")
+  }
+
   it should "generate json for regex query" in {
     val req = search in "music" types "bands" postFilter {
       regexQuery("singer", "chris martin")

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/queries.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/queries.scala
@@ -121,6 +121,22 @@ trait QueryDsl {
     TermsQueryDefinition(field, values.map(_.toString))
   }
 
+  def termsQuery(field: String, values: Int*): IntTermsQueryDefinition = {
+    IntTermsQueryDefinition(field, values)
+  }
+
+  def termsQuery(field: String, values: Long*): LongTermsQueryDefinition = {
+    LongTermsQueryDefinition(field, values)
+  }
+
+  def termsQuery(field: String, values: Float*): FloatTermsQueryDefinition = {
+    FloatTermsQueryDefinition(field, values)
+  }
+
+  def termsQuery(field: String, values: Double*): DoubleTermsQueryDefinition = {
+    DoubleTermsQueryDefinition(field, values)
+  }
+
   def wildcardQuery(tuple: (String, Any)): WildcardQueryDefinition = wildcardQuery(tuple._1, tuple._2)
   def wildcardQuery(field: String, value: Any): WildcardQueryDefinition = new WildcardQueryDefinition(field, value)
 
@@ -1140,11 +1156,10 @@ case class TermQueryDefinition(field: String, value: Any) extends QueryDefinitio
   }
 }
 
-case class TermsQueryDefinition(field: String, values: Seq[String]) extends QueryDefinition {
+trait GenericTermsQueryDefinition extends QueryDefinition {
+  def builder: TermsQueryBuilder
 
-  val builder = QueryBuilders.termsQuery(field, values: _*)
-
-  def boost(boost: Double): TermsQueryDefinition = {
+  def boost(boost: Double): this.type = {
     builder.boost(boost.toFloat)
     this
   }
@@ -1153,6 +1168,11 @@ case class TermsQueryDefinition(field: String, values: Seq[String]) extends Quer
     builder.queryName(queryName)
     this
   }
+}
+
+case class TermsQueryDefinition(field: String, values: Seq[String]) extends GenericTermsQueryDefinition {
+
+  val builder: TermsQueryBuilder = QueryBuilders.termsQuery(field, values: _*)
 
   @deprecated("deprecated in elasticsearch", "2.0.0")
   def minimumShouldMatch(min: Int): TermsQueryDefinition = minimumShouldMatch(min.toString)
@@ -1168,6 +1188,22 @@ case class TermsQueryDefinition(field: String, values: Seq[String]) extends Quer
     builder.disableCoord(disableCoord)
     this
   }
+}
+
+case class IntTermsQueryDefinition(field: String, values: Seq[Int]) extends GenericTermsQueryDefinition {
+  val builder: TermsQueryBuilder = QueryBuilders.termsQuery(field, values: _*)
+}
+
+case class LongTermsQueryDefinition(field: String, values: Seq[Long]) extends GenericTermsQueryDefinition {
+  val builder: TermsQueryBuilder = QueryBuilders.termsQuery(field, values: _*)
+}
+
+case class FloatTermsQueryDefinition(field: String, values: Seq[Float]) extends GenericTermsQueryDefinition {
+  val builder: TermsQueryBuilder = QueryBuilders.termsQuery(field, values: _*)
+}
+
+case class DoubleTermsQueryDefinition(field: String, values: Seq[Double]) extends GenericTermsQueryDefinition {
+  val builder: TermsQueryBuilder = QueryBuilders.termsQuery(field, values: _*)
 }
 
 case class TypeQueryDefinition(`type`: String) extends QueryDefinition {


### PR DESCRIPTION
Example:

    termsQuery("myField", 1, 2, 3)
    termsQuery("myField", 1L, 2L, 3L)

Note: the following line will raise a `QueryParsingException` ( query does not support array of values):

    termQuery("myField", Seq(1, 2, 3))