### PR TITLE
new method sourceAsMutableMap in RichSearchHit class

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/RichSearchResponse.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/RichSearchResponse.scala
@@ -65,6 +65,7 @@ case class RichSearchHit(java: SearchHit) {
   }
 
   import scala.collection.JavaConverters._
+  import scala.collection.mutable
 
   // java method aliases
   @deprecated("use .java", "2.1.2")
@@ -92,6 +93,9 @@ case class RichSearchHit(java: SearchHit) {
   def isSourceEmpty: Boolean = java.isSourceEmpty
   def sourceAsString: String = if (java.sourceAsString == null) "" else java.sourceAsString
   def sourceAsMap: Map[String, AnyRef] = if (java.sourceAsMap == null) Map.empty else java.sourceAsMap.asScala.toMap
+  def sourceAsMutableMap: mutable.Map[String, AnyRef] = {
+    if (java.sourceAsMap == null) mutable.Map.empty else java.sourceAsMap.asScala
+  }
 
   @deprecated("use as[T]", "2.0.0")
   def mapTo[T](implicit reader: Reader[T], manifest: Manifest[T]): T = reader.read(sourceAsString)


### PR DESCRIPTION
One of the most common use cases in work with ES is to get response, change it and send to frontend. Elastic4s in RichSearchResponse has only sourceAsMap which return immutable Map. Immutable maps are good choice for most cases, but often to meet above use case, we need mutable version to mutate values in efficient way. There isn't other convenient way to do this, cause most json libraries in scala, also works on immutable manner (f.e. play-json). For being precise, I'll do more often workaround by .original and converting with null-check to mutable.Map, than use immutable version from RichSearchResponse. The new method save me from writing these boilerplate repeatedly, when I need to use mutable.Map