### PR TITLE
Update ElasticSearch to 2.3.3

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -17,7 +17,7 @@ object Build extends AutoPlugin {
     val JacksonVersion = "2.6.1"
     val Slf4jVersion = "1.7.12"
     val ScalaLoggingVersion = "2.1.2"
-    val ElasticsearchVersion = "2.3.0"
+    val ElasticsearchVersion = "2.3.3"
     val Log4jVersion = "1.2.17"
     val CommonsIoVersion = "2.4"
     val CirceVersion = "0.4.1"


### PR DESCRIPTION
ElasticSearch Java client 2.3.0 cannot connect to my 2.3.3 cluster (NoNodeAvailableException). Using client version 2.3.3 works.