### PR TITLE
added wrapperQuery

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/queries.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/queries.scala
@@ -205,6 +205,9 @@ trait QueryDsl {
   def should(queries: Iterable[QueryDefinition]): BoolQueryDefinition = new BoolQueryDefinition().should(queries)
   def not(queries: QueryDefinition*): BoolQueryDefinition = new BoolQueryDefinition().not(queries: _*)
   def not(queries: Iterable[QueryDefinition]): BoolQueryDefinition = new BoolQueryDefinition().not(queries)
+
+  def wrapperQuery(source : String) : WrapperQueryStringDefinition = new WrapperQueryStringDefinition(source)
+  def wrapperQuery(source : Array[Byte], offset : Int, length : Int) : WrapperQueryByteDefinition = new WrapperQueryByteDefinition(source, offset, length)
 }
 
 class BoolQueryDefinition extends QueryDefinition {
@@ -1298,6 +1301,16 @@ class NestedQueryDefinition(path: String) extends QueryDefinition {
     this
   }
 }
+
+
+class WrapperQueryStringDefinition(source : String) extends QueryDefinition {
+  val builder = QueryBuilders.wrapperQuery(source)
+}
+
+class WrapperQueryByteDefinition(source : Array[Byte], offset : Int, length : Int) extends QueryDefinition {
+  val builder = QueryBuilders.wrapperQuery(source, offset, length)
+}
+
 
 class QueryInnerHitsDefinition(private[elastic4s] val name: String) {
 


### PR DESCRIPTION
One of the QueryBuilders not implemented was the WrapperQuery. This allows us to include raw JSON for a specific query (for example, a new mapper definition defined in a script) while maintaining the DSL for the other parts of the search request.

btw -- is there a way to pull the latest snapshot from maven? Right now for the release/1.7.x branch I only pull 1.7.0 which was a fairly old commit. So currently I use elastic4s as an unmanaged dependency which is not ideal.