### PR TITLE
Support for predefined language-specific stopwords

### DIFF
--- a/elastic4s-core-tests/src/test/scala/com/sksamuel/elastic4s/analyzers/PredefinedStopTokenFilterTest.scala
+++ b/elastic4s-core-tests/src/test/scala/com/sksamuel/elastic4s/analyzers/PredefinedStopTokenFilterTest.scala
@@ -1,0 +1,19 @@
+package com.sksamuel.elastic4s.analyzers
+
+import org.scalatest.{Matchers, WordSpec}
+
+class PredefinedStopTokenFilterTest extends WordSpec with TokenFilterDsl with Matchers {
+
+  "PredefinedStopTokenFilter builder" should {
+    "set stop words" in {
+      predefinedStopTokenFilter("testy").stopwords(NamedStopTokenFilter.Swedish).json.string shouldBe """{"type":"stop","stopwords":"_swedish_"}"""
+    }
+    "set ignore case" in {
+      stopTokenFilter("testy").ignoreCase(true).json.string shouldBe """{"type":"stop","ignore_case":true}"""
+    }
+    "set remove trailing" in {
+      stopTokenFilter("testy").removeTrailing(true).json.string shouldBe """{"type":"stop","remove_trailing":true}"""
+    }
+  }
+
+}

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/analyzers/TokenFilter.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/analyzers/TokenFilter.scala
@@ -193,6 +193,26 @@ case class StopTokenFilter(name: String,
   def stopwords(stopwords: String, rest: String*): StopTokenFilter = copy(stopwords = stopwords +: rest)
 }
 
+case class PredefinedStopTokenFilter(name: String,
+                                     stopwords: Option[String] = None,
+                                     removeTrailing: Option[Boolean] = None,
+                                     ignoreCase: Option[Boolean] = None)
+  extends TokenFilterDefinition {
+
+  val filterType = "stop"
+
+  override def build(source: XContentBuilder): Unit = {
+    stopwords.foreach(source.field("stopwords", _))
+    ignoreCase.foreach(source.field("ignore_case", _))
+    removeTrailing.foreach(source.field("remove_trailing", _))
+  }
+
+  def ignoreCase(boolean: Boolean): PredefinedStopTokenFilter = copy(ignoreCase = Option(boolean))
+  def removeTrailing(boolean: Boolean): PredefinedStopTokenFilter = copy(removeTrailing = Option(boolean))
+  def stopwords(stopwords: Option[String]): PredefinedStopTokenFilter = copy(stopwords = stopwords)
+  def stopwords(stopwords: String): PredefinedStopTokenFilter = copy(stopwords = Option(stopwords))
+}
+
 object NamedStopTokenFilter {
   val Arabic = "_arabic_"
   val Armenian = "_armenian_"

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/analyzers/TokenFilterDsl.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/analyzers/TokenFilterDsl.scala
@@ -17,6 +17,7 @@ trait TokenFilterDsl {
   def stemmerOverrideTokenFilter(name: String): StemmerOverrideTokenFilter = StemmerOverrideTokenFilter(name)
   def stemmerTokenFilter(name: String): StemmerTokenFilter = StemmerTokenFilter(name)
   def stopTokenFilter(name: String): StopTokenFilter = StopTokenFilter(name)
+  def predefinedStopTokenFilter(name: String): PredefinedStopTokenFilter = PredefinedStopTokenFilter(name)
   def synonymTokenFilter(name: String): SynonymTokenFilter = SynonymTokenFilter(name)
   def synonymTokenFilter(name: String, synonyms: Iterable[String]): SynonymTokenFilter = {
     SynonymTokenFilter(name).synonyms(synonyms)


### PR DESCRIPTION
In order to customize a language-specific analyzer we need to reimplement it and add our custom filters/tokenizers/etc. (e.g.  https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-lang-analyzer.html#swedish-analyzer)

Unfortunately, it cannot be done using existing `StopTokenFilter`, which doesn't allow assigning string values to the `stopwords` field (only Arrays are supported).

This PR is aimed to solve this problem by introducing a `PredefinedStopTokenFilter` that accepts a plain string as a stopwords value.

Probably it could be done as well by changing `stopwords` type from `Iterable[String]` to some algebraic data type (`Either[String, Iterable[String]]` ?) but this way we will brake compability of the API.

Any kind of feedback will be welcomed!
