### PR TITLE
Support Iterables on the termsQuery DSL

### DIFF
--- a/elastic4s-core-tests/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
+++ b/elastic4s-core-tests/src/test/scala/com/sksamuel/elastic4s/SearchDslTest.scala
@@ -300,6 +300,18 @@ class SearchDslTest extends FlatSpec with MockitoSugar with JsonSugar with OneIn
     req.show should matchJsonResource("/json/search/search_int_terms_lookup_filter.json")
   }
 
+  it should "generate json for iterable terms lookup filter" in {
+    val req1 = search in "music" types "bands" postFilter {
+      termsQuery("user", List("val", "vallllll")).queryName("namey")
+    }
+    req1.show should matchJsonResource("/json/search/search_terms_lookup_filter.json")
+
+    val req2 = search in "music" types "bands" postFilter {
+      termsQuery("formedYear", Set(2013, 2014))
+    }
+    req2.show should matchJsonResource("/json/search/search_int_terms_lookup_filter.json")
+  }
+
   it should "generate json for script filter" in {
     val req = search in "music" types "bands" postFilter {
       scriptQuery("doc['creationYear'].value > 2013")

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/queries.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/queries.scala
@@ -20,6 +20,31 @@ trait QueryDsl {
   implicit def string2query(string: String): SimpleStringQueryDefinition = new SimpleStringQueryDefinition(string)
   implicit def tuple2query(kv: (String, String)): TermQueryDefinition = new TermQueryDefinition(kv._1, kv._2)
 
+  implicit object IntBuildableTermsQuery extends BuildableTermsQuery[Int] {
+    def makeBuilder(field: String, values: Seq[Int]): TermsQueryBuilder =
+      QueryBuilders.termsQuery(field, values: _*)
+  }
+
+  implicit object LongBuildableTermsQuery extends BuildableTermsQuery[Long] {
+    def makeBuilder(field: String, values: Seq[Long]): TermsQueryBuilder =
+      QueryBuilders.termsQuery(field, values: _*)
+  }
+
+  implicit object FloatBuildableTermsQuery extends BuildableTermsQuery[Float] {
+    def makeBuilder(field: String, values: Seq[Float]): TermsQueryBuilder =
+      QueryBuilders.termsQuery(field, values: _*)
+  }
+
+  implicit object DoubleBuildableTermsQuery extends BuildableTermsQuery[Double] {
+    def makeBuilder(field: String, values: Seq[Double]): TermsQueryBuilder =
+      QueryBuilders.termsQuery(field, values: _*)
+  }
+
+  implicit object AnyRefBuildableTermsQuery extends BuildableTermsQuery[AnyRef] {
+    def makeBuilder(field: String, values: Seq[AnyRef]): TermsQueryBuilder =
+      QueryBuilders.termsQuery(field, (values.map(_.toString)): _*)
+  }
+
   def query = this
 
   def boostingQuery: BoostingQueryDefinition = new BoostingQueryDefinition
@@ -119,24 +144,11 @@ trait QueryDsl {
   def termQuery(tuple: (String, Any)): TermQueryDefinition = termQuery(tuple._1, tuple._2)
   def termQuery(field: String, value: Any): TermQueryDefinition = TermQueryDefinition(field, value)
 
-  def termsQuery(field: String, values: AnyRef*): TermsQueryDefinition = {
-    TermsQueryDefinition(field, values.map(_.toString))
+  def termsQuery[U: BuildableTermsQuery, T <: U](field: String, values: Iterable[T]): TermsQueryDefinition[U] = {
+    TermsQueryDefinition[U](field, values.toSeq)
   }
-
-  def termsQuery(field: String, values: Int*): IntTermsQueryDefinition = {
-    IntTermsQueryDefinition(field, values)
-  }
-
-  def termsQuery(field: String, values: Long*): LongTermsQueryDefinition = {
-    LongTermsQueryDefinition(field, values)
-  }
-
-  def termsQuery(field: String, values: Float*): FloatTermsQueryDefinition = {
-    FloatTermsQueryDefinition(field, values)
-  }
-
-  def termsQuery(field: String, values: Double*): DoubleTermsQueryDefinition = {
-    DoubleTermsQueryDefinition(field, values)
+  def termsQuery[U: BuildableTermsQuery, T <: U](field: String, value: T, rest: T*): TermsQueryDefinition[U] = {
+    TermsQueryDefinition[U](field, value +: rest)
   }
 
   def wildcardQuery(tuple: (String, Any)): WildcardQueryDefinition = wildcardQuery(tuple._1, tuple._2)
@@ -1158,8 +1170,10 @@ case class TermQueryDefinition(field: String, value: Any) extends QueryDefinitio
   }
 }
 
-trait GenericTermsQueryDefinition extends QueryDefinition {
-  def builder: TermsQueryBuilder
+case class TermsQueryDefinition[T](field: String, values: Seq[T])(implicit buildable: BuildableTermsQuery[T])
+  extends QueryDefinition {
+
+  val builder: TermsQueryBuilder = buildable.makeBuilder(field, values)
 
   def boost(boost: Double): this.type = {
     builder.boost(boost.toFloat)
@@ -1170,42 +1184,26 @@ trait GenericTermsQueryDefinition extends QueryDefinition {
     builder.queryName(queryName)
     this
   }
-}
-
-case class TermsQueryDefinition(field: String, values: Seq[String]) extends GenericTermsQueryDefinition {
-
-  val builder: TermsQueryBuilder = QueryBuilders.termsQuery(field, values: _*)
 
   @deprecated("deprecated in elasticsearch", "2.0.0")
-  def minimumShouldMatch(min: Int): TermsQueryDefinition = minimumShouldMatch(min.toString)
+  def minimumShouldMatch(min: Int): TermsQueryDefinition[T] = minimumShouldMatch(min.toString)
 
   @deprecated("deprecated in elasticsearch", "2.0.0")
-  def minimumShouldMatch(min: String): TermsQueryDefinition = {
+  def minimumShouldMatch(min: String): TermsQueryDefinition[T] = {
     builder.minimumShouldMatch(min)
     this
   }
 
   @deprecated("deprecated in elasticsearch", "2.0.0")
-  def disableCoord(disableCoord: Boolean): TermsQueryDefinition = {
+  def disableCoord(disableCoord: Boolean): TermsQueryDefinition[T] = {
     builder.disableCoord(disableCoord)
     this
   }
+
 }
 
-case class IntTermsQueryDefinition(field: String, values: Seq[Int]) extends GenericTermsQueryDefinition {
-  val builder: TermsQueryBuilder = QueryBuilders.termsQuery(field, values: _*)
-}
-
-case class LongTermsQueryDefinition(field: String, values: Seq[Long]) extends GenericTermsQueryDefinition {
-  val builder: TermsQueryBuilder = QueryBuilders.termsQuery(field, values: _*)
-}
-
-case class FloatTermsQueryDefinition(field: String, values: Seq[Float]) extends GenericTermsQueryDefinition {
-  val builder: TermsQueryBuilder = QueryBuilders.termsQuery(field, values: _*)
-}
-
-case class DoubleTermsQueryDefinition(field: String, values: Seq[Double]) extends GenericTermsQueryDefinition {
-  val builder: TermsQueryBuilder = QueryBuilders.termsQuery(field, values: _*)
+trait BuildableTermsQuery[-T] {
+  def makeBuilder(field: String, values: Seq[T]): TermsQueryBuilder
 }
 
 case class TypeQueryDefinition(`type`: String) extends QueryDefinition {


### PR DESCRIPTION
Fixes issue #597.

I needed to add some implicit objects and a new `BuildableTermsQuery` type class, but I'm not really fond of the name (`Buildable` sounds a bit weird for something that builds a builder).

I'm open to naming suggestions and other stylistic feedback (those implicit objects near the implicit definitions also look a bit out of place to me).
