### PR TITLE
Catch NoNodeAvailableException in ElasticClient

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticClient.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticClient.scala
@@ -3,7 +3,7 @@ package com.sksamuel.elastic4s
 import java.net.InetSocketAddress
 
 import org.elasticsearch.{ElasticsearchException, ElasticsearchWrapperException}
-import org.elasticsearch.client.transport.TransportClient
+import org.elasticsearch.client.transport.{TransportClient, NoNodeAvailableException}
 import org.elasticsearch.client.{AdminClient, Client}
 import org.elasticsearch.common.settings.Settings
 import org.elasticsearch.common.transport.InetSocketTransportAddress
@@ -25,6 +25,7 @@ class ElasticClient(val client: org.elasticsearch.client.Client,
     } catch {
       case e: ElasticsearchException => Future.failed(e)
       case e: ElasticsearchWrapperException => Future.failed(e)
+      case e: NoNodeAvailableException => Future.failed(e)
     }
   }
 


### PR DESCRIPTION
So this is a bit of an interesting issue. The exception above occurs sporadically on our system right now with the trace being that the Future produced by the client doesn't fail instead the exception happens.  It would appear from the modified code that the intent is to cleanly handle exceptions from the underlying elasticsearch.

Is this the correct place for this? If not, pointers on where to put this catch would be greatly appreciated.

Thanks,

Trevis