### PR TITLE
added highlighting, fetchSource, explain to TopHitsAggregator

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/aggregations.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/aggregations.scala
@@ -712,6 +712,31 @@ class TopHitsAggregationDefinition(name: String) extends AbstractAggregationDefi
     this
   }
 
+  def fetchSource(fetch : Boolean): this.type = {
+    builder.setFetchSource(fetch)
+    this
+  }
+
+  def explain(isExplain : Boolean): this.type = {
+    builder.setExplain(isExplain)
+    this
+  }
+
+  def highlighting(options : HighlightOptionsDefinition, highlights: HighlightDefinition*): this.type = {
+    options._encoder.foreach(encoder => builder.setHighlighterEncoder(encoder.elastic))
+    options._tagSchema.foreach(arg => builder.setHighlighterTagsSchema(arg.elastic))
+    options._order.foreach(arg => builder.setHighlighterOrder(arg.elastic))
+    builder.setHighlighterPostTags(options._postTags: _*)
+    builder.setHighlighterPreTags(options._preTags: _*)
+    builder.setHighlighterRequireFieldMatch(options._requireFieldMatch)
+    highlights.foreach(highlight => builder.addHighlightedField(highlight.builder))
+    this
+  }
+
+  def highlighting(highlights: HighlightDefinition*): this.type = {
+    highlights.foreach(highlight => builder.addHighlightedField(highlight.builder))
+    this
+  }
 }
 
 class NestedAggregationDefinition(name: String)


### PR DESCRIPTION
TopHits aggregation allows for _explain and highlighting but this wasn't included in the API. I added these features. With highlighting I followed the highlighting method from the search api, so highlighting syntax is the same whether you are highlighting a search or a top hits aggregation.