### PR TITLE
Add support for "missing" in all aggregations

### DIFF
--- a/elastic4s-core-tests/src/test/scala/com/sksamuel/elastic4s/AggregationsTest.scala
+++ b/elastic4s-core-tests/src/test/scala/com/sksamuel/elastic4s/AggregationsTest.scala
@@ -103,6 +103,21 @@ class AggregationsTest extends FreeSpec with Matchers with ElasticSugar {
       agg.getBucketByKey("dea agent").getDocCount shouldBe 2
       agg.getBucketByKey("heavy").getDocCount shouldBe 2
     }
+
+    "should group by field and return a missing value" in {
+      val resp = client.execute {
+        search in "aggregations/breakingbad" aggregations {
+          aggregation terms "agg1" field "actor" missing("no-name")
+        }
+      }.await
+      resp.totalHits shouldBe 10
+      val agg = resp.aggregations.getAsMap.get("agg1").asInstanceOf[StringTerms]
+      agg.getBuckets.size shouldBe 4
+      agg.getBucketByKey("lavell").getDocCount shouldBe 1
+      agg.getBucketByKey("bryan").getDocCount shouldBe 1
+      agg.getBucketByKey("dean").getDocCount shouldBe 1
+      agg.getBucketByKey("no-name").getDocCount shouldBe 7
+    }
   }
 
   "avg aggregation" - {

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/aggregations.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/aggregations.scala
@@ -98,6 +98,12 @@ trait ValuesSourceMetricsAggregationDefinition[+Self <: ValuesSourceMetricsAggre
     builder.script(script.toJavaAPI)
     this
   }
+
+  def missing(missing: String): Self = {
+    aggregationBuilder.missing(missing)
+    this
+  }
+
 }
 
 trait ValuesSourceAggregationDefinition[+Self <: ValuesSourceAggregationDefinition[Self, B], B <: ValuesSourceAggregationBuilder[B]]
@@ -113,9 +119,12 @@ trait ValuesSourceAggregationDefinition[+Self <: ValuesSourceAggregationDefiniti
     builder.script(script.toJavaAPI)
     this
   }
+
+  def missing(missing: String): Self = {
+    aggregationBuilder.missing(missing)
+    this
+  }
 }
-
-
 
 trait CardinalityMetricsAggregationDefinition[+Self <: CardinalityMetricsAggregationDefinition[Self]]
   extends MetricsAggregationDefinition[Self, CardinalityBuilder] {
@@ -450,11 +459,6 @@ case class GeoBoundsAggregationDefinition(name: String)
     this
   }
 
-  def missing(missing: String): GeoBoundsAggregationDefinition = {
-    aggregationBuilder.missing(missing)
-    this
-  }
-
   def wrapLongitude(wrapLongitude: Boolean): GeoBoundsAggregationDefinition = {
     builder.wrapLongitude(wrapLongitude)
     this
@@ -466,11 +470,6 @@ case class GeoCentroidAggregationDefinition(name: String)
   extends ValuesSourceMetricsAggregationDefinition[GeoCentroidAggregationDefinition, GeoCentroidBuilder] {
 
   val aggregationBuilder = AggregationBuilders.geoCentroid(name)
-
-  def missing(missing: String): GeoCentroidAggregationDefinition = {
-    aggregationBuilder.missing(missing)
-    this
-  }
 
   def format(format: String): GeoCentroidAggregationDefinition = {
     aggregationBuilder.format(format)


### PR DESCRIPTION
Move the definition of missing method from GeoBoundsAggregationDefinition to ValuesSourceAggregationDefinition; then all sub-class of ValuesSourceAggregationDefinition has the missing method. 