### PR TITLE
Pipeline aggregations do not extend abstract agg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ test-output/
 # Sublime Text specific
 *.sublime-project
 *.sublime-workspace
+
+# Intellij
+.DS_Store

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/PipelineAggDsl.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/PipelineAggDsl.scala
@@ -36,13 +36,14 @@ trait PipelineAggregationDsl {
 }
 
 
-abstract class PipelineDefinition {
+abstract class PipelineDefinition extends AbstractAggregationDefinition {
 
   type T <: PipelineAggregatorBuilder[T]
 
   def metadata: Map[String, AnyRef]
   def bucketPaths: Seq[String]
 
+  
   def build(builder: T): T = {
     import scala.collection.JavaConverters._
     if (bucketPaths.nonEmpty)
@@ -61,7 +62,7 @@ case class AvgBucketDefinition(name: String,
                                bucketPaths: Seq[String] = Nil) extends PipelineDefinition {
   type T = AvgBucketBuilder
 
-  def build: T = {
+  override def builder: T = {
     val builder = super.build(PipelineAggregatorBuilders.avgBucket(name))
     format.foreach(builder.format)
     gapPolicy.foreach(builder.gapPolicy)
@@ -85,7 +86,7 @@ case class BucketScriptDefinition(name: String,
                                   bucketPathsMap: Map[String, String] = Map.empty) extends PipelineDefinition {
   type T = BucketScriptBuilder
 
-  def build: T = {
+  override def builder: T = {
     import scala.collection.JavaConverters._
     val builder = super.build(PipelineAggregatorBuilders.bucketScript(name))
     format.foreach(builder.format)
@@ -112,7 +113,7 @@ case class CumulativeSumDefinition(name: String,
                                    bucketPaths: Seq[String] = Nil) extends PipelineDefinition {
   type T = CumulativeSumBuilder
 
-  def build: T = {
+  override def builder: T = {
     val builder = super.build(PipelineAggregatorBuilders.cumulativeSum(name))
     format.foreach(builder.format)
     builder
@@ -133,7 +134,7 @@ case class DerivativeDefinition(name: String,
                                 bucketPaths: Seq[String] = Nil) extends PipelineDefinition {
   type T = DerivativeBuilder
 
-  def build: T = {
+  override def builder: T = {
     val builder = super.build(PipelineAggregatorBuilders.derivative(name))
     format.foreach(builder.format)
     gapPolicy.foreach(builder.gapPolicy)
@@ -160,7 +161,7 @@ case class DiffDefinition(name: String,
                           bucketPaths: Seq[String] = Nil) extends PipelineDefinition {
   type T = SerialDiffBuilder
 
-  def build: T = {
+  override def builder: T = {
     val builder = super.build(PipelineAggregatorBuilders.diff(name))
     format.foreach(builder.format)
     gapPolicy.foreach(builder.gapPolicy)
@@ -182,7 +183,7 @@ case class ExtendedStatsBucketDefinition(name: String,
                                          bucketPaths: Seq[String] = Nil) extends PipelineDefinition {
   type T = ExtendedStatsBucketBuilder
 
-  def build: T = {
+  override def builder: T = {
     val builder = super.build(PipelineAggregatorBuilders.extendedStatsBucket(name))
     format.foreach(builder.format)
     gapPolicy.foreach(builder.gapPolicy)
@@ -204,7 +205,7 @@ case class BucketSelectorDefinition(name: String,
                                     bucketPathsMap: Map[String, String] = Map.empty) extends PipelineDefinition {
   type T = BucketSelectorBuilder
 
-  def build: T = {
+  override def builder: T = {
     import scala.collection.JavaConverters._
     val builder = super.build(PipelineAggregatorBuilders.having(name))
     script.foreach(builder.script)
@@ -229,7 +230,7 @@ case class MaxBucketDefinition(name: String,
                                bucketPaths: Seq[String] = Nil) extends PipelineDefinition {
   type T = MaxBucketBuilder
 
-  def build: T = {
+  override def builder: T = {
     val builder = super.build(PipelineAggregatorBuilders.maxBucket(name))
     format.foreach(builder.format)
     gapPolicy.foreach(builder.gapPolicy)
@@ -250,7 +251,7 @@ case class MinBucketDefinition(name: String,
                                bucketPaths: Seq[String] = Nil) extends PipelineDefinition {
   type T = MinBucketBuilder
 
-  def build: T = {
+  override def builder: T = {
     val builder = super.build(PipelineAggregatorBuilders.minBucket(name))
     format.foreach(builder.format)
     gapPolicy.foreach(builder.gapPolicy)
@@ -276,7 +277,7 @@ case class MovAvgDefinition(name: String,
                             bucketPaths: Seq[String] = Nil) extends PipelineDefinition {
   type T = MovAvgBuilder
 
-  def build: T = {
+  override def builder: T = {
     import scala.collection.JavaConverters._
     val builder = super.build(PipelineAggregatorBuilders.movingAvg(name))
     format.foreach(builder.format)
@@ -311,7 +312,7 @@ case class PercentilesBucketDefinition(name: String,
                                        bucketPaths: Seq[String] = Nil) extends PipelineDefinition {
   type T = PercentilesBucketBuilder
 
-  def build: T = {
+  override def builder: T = {
     val builder = super.build(PipelineAggregatorBuilders.percentilesBucket(name))
     format.foreach(builder.format)
     gapPolicy.foreach(builder.gapPolicy)
@@ -336,7 +337,7 @@ case class StatsBucketDefinition(name: String,
                                  bucketPaths: Seq[String] = Nil) extends PipelineDefinition {
   type T = StatsBucketBuilder
 
-  def build: T = {
+  override def builder: T = {
     val builder = super.build(PipelineAggregatorBuilders.statsBucket(name))
     format.foreach(builder.format)
     gapPolicy.foreach(builder.gapPolicy)
@@ -357,7 +358,7 @@ case class SumBucketDefinition(name: String,
                                bucketPaths: Seq[String] = Nil) extends PipelineDefinition {
   type T = SumBucketBuilder
 
-  def build: T = {
+  override def builder: T = {
     val builder = super.build(PipelineAggregatorBuilders.sumBucket(name))
     format.foreach(builder.format)
     gapPolicy.foreach(builder.gapPolicy)


### PR DESCRIPTION
I encountered this issue earlier today : https://github.com/sksamuel/elastic4s/issues/582

I therefore suggest a change @romainfage mentioned in his post. Is it also natural to include the pipeline aggregations in the case object in the ElasticDsl trait? 

Regards
Tarjei
