### PR TITLE
Fixing BulkIndexSubscriber failure behaviour

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/bulk.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/bulk.scala
@@ -51,8 +51,8 @@ case class BulkResult(original: BulkResponse) {
 
   def failureMessage: String = original.buildFailureMessage
   def took: FiniteDuration = original.getTook.millis.millis
-  def hasSuccesses: Boolean = !hasFailures
-  def hasFailures: Boolean = original.hasFailures
+  def hasFailures: Boolean = original.getItems.exists(_.isFailed)
+  def hasSuccesses: Boolean = original.getItems.exists(!_.isFailed)
   def items: Seq[BulkItemResult] = original.getItems.map(BulkItemResult.apply)
   def failures: Seq[BulkItemResult] = items.filter(_.isFailure)
   def successes: Seq[BulkItemResult] = items.filterNot(_.isFailure)

--- a/elastic4s-streams/src/test/scala/com/sksamuel/elastic4s/streams/BulkIndexingSubscriberIntegrationTest.scala
+++ b/elastic4s-streams/src/test/scala/com/sksamuel/elastic4s/streams/BulkIndexingSubscriberIntegrationTest.scala
@@ -3,42 +3,77 @@ package com.sksamuel.elastic4s.streams
 import java.util.concurrent.{CountDownLatch, TimeUnit}
 
 import akka.actor.ActorSystem
-import com.sksamuel.elastic4s.BulkCompatibleDefinition
-import com.sksamuel.elastic4s.ElasticDsl.index
+import com.sksamuel.elastic4s.{BulkCompatibleDefinition, BulkItemResult}
+import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.jackson.ElasticJackson
+import com.sksamuel.elastic4s.mappings.DynamicMapping.Strict
+import com.sksamuel.elastic4s.mappings.FieldType.{IntegerType, StringType}
 import com.sksamuel.elastic4s.testkit.ElasticSugar
 import org.reactivestreams.{Publisher, Subscriber, Subscription}
 import org.scalatest.{Matchers, WordSpec}
 
+import scala.util.Random
+
 class BulkIndexingSubscriberIntegrationTest extends WordSpec with ElasticSugar with Matchers {
 
   import ReactiveElastic._
+  import scala.concurrent.duration._
 
   implicit val system = ActorSystem()
-  implicit val builder = ShipRequestBuilder
 
-  ensureIndexExists("bulkindexsubint")
+  val indexName = "bulkindexsubint"
+  ensureIndexExists(indexName)
 
   "elastic-streams" should {
     "index all received data" in {
-
+      implicit val builder = new ShipRequestBuilder(indexName)
       val completionLatch = new CountDownLatch(1)
       val subscriber = client.subscriber[Ship](10, 2, completionFn = () => completionLatch.countDown)
       ShipPublisher.subscribe(subscriber)
       completionLatch.await(5, TimeUnit.SECONDS)
 
-      blockUntilCount(Ship.ships.length, "bulkindexsubint")
+      blockUntilCount(Ship.ships.length, indexName)
     }
 
     "index all received data even if the subscriber never completes" in {
+      implicit val builder = new ShipRequestBuilder(indexName)
 
-      import scala.concurrent.duration._
 
       // The short interval is just for the sake of test execution time, it's not a recommendation
       val subscriber = client.subscriber[Ship](8, 2, flushInterval = Some(500.millis))
       ShipEndlessPublisher.subscribe(subscriber)
 
-      blockUntilCount(Ship.ships.length, "bulkindexsubint")
+      blockUntilCount(Ship.ships.length, indexName)
+    }
+
+    "index all receveid data and ignore failures" in {
+      val strictIndex = "bulkindexfail"
+      client.execute {
+        createIndex(strictIndex) mappings ("ships" fields (
+            "name" typed StringType,
+            "description" typed IntegerType,
+            "size" typed IntegerType
+          ) dynamic Strict
+        )
+      }.await
+
+      val errorsExpected = 2
+
+      implicit val builder = new ShipRequestBuilder(strictIndex)
+      val completionLatch = new CountDownLatch(1)
+      val ackLatch = new CountDownLatch(Ship.ships.length - errorsExpected)
+      val errorLatch = new CountDownLatch(errorsExpected)
+      val subscriber = client.subscriber[Ship](10, 2, listener = new ResponseListener {
+        override def onAck(resp: BulkItemResult): Unit = ackLatch.countDown()
+        override def onFailure(resp: BulkItemResult): Unit = errorLatch.countDown()
+      }, completionFn = () => completionLatch.countDown(), maxAttempts = 2, failureWait = 100.millis)
+      ShipPublisher.subscribe(subscriber)
+      completionLatch.await(5, TimeUnit.SECONDS)
+
+      ackLatch.getCount should be (0)
+      errorLatch.getCount should be (0)
+
+      blockUntilCount(Ship.ships.length - errorsExpected, strictIndex)
     }
   }
 }
@@ -49,7 +84,7 @@ object Ship {
   val ships = Array(
     Ship("clipper"),
     Ship("anaconda"),
-    Ship("courier"),
+    Ship("courier", Some("Fast ship that delivers")),
     Ship("python"),
     Ship("fer-de-lance"),
     Ship("sidewinder"),
@@ -57,7 +92,7 @@ object Ship {
     Ship("viper"),
     Ship("eagle"),
     Ship("vulture"),
-    Ship("dropship"),
+    Ship("dropship", Some("Drop it while its hot")),
     Ship("orca"),
     Ship("type6"),
     Ship("type7"),
@@ -71,10 +106,10 @@ object Ship {
 }
 
 
-object ShipRequestBuilder extends RequestBuilder[Ship] {
+class ShipRequestBuilder(indexName: String = "bulkindexsubint") extends RequestBuilder[Ship] {
   import ElasticJackson.Implicits._
   override def request(ship: Ship): BulkCompatibleDefinition = {
-    index into "bulkindexsubint/ships" source ship
+    index into s"$indexName/ships" source ship
   }
 }
 
@@ -111,4 +146,4 @@ object ShipEndlessPublisher extends Publisher[Ship] {
 }
 
 
-case class Ship(name: String)
+case class Ship(name: String, description: Option[String] = None, size: Int = Random.nextInt(100))

--- a/elastic4s-streams/src/test/scala/com/sksamuel/elastic4s/streams/SubscriberListenerTest.scala
+++ b/elastic4s-streams/src/test/scala/com/sksamuel/elastic4s/streams/SubscriberListenerTest.scala
@@ -12,7 +12,7 @@ class SubscriberListenerTest extends WordSpec with Matchers with ElasticSugar {
   import ReactiveElastic._
 
   implicit val system = ActorSystem()
-  implicit val builder = ShipRequestBuilder
+  implicit val builder = new ShipRequestBuilder()
 
   ensureIndexExists("subscriberlistenertest")
 


### PR DESCRIPTION
Fix for issue #626

- Fixes the `hasSuccesses` functionality which was always false when there where failures but that doesn't have to be the case! Only a part of the BulkRequest can fail
- Instead of `RuntimeException` blowing it up `FailedResult` message is sent which will add to counter and call `onFailure` Response listener. This is also a change, now `onFailure` is only called when we give up. (e.g. after retries) instead of every retry, keeping it nice and clean for error handling.
- Added unittest to check for functionality (and that's why i found that the `hasSuccesses` was wrongly implemented)