### PR TITLE
QueryDSL improvements

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/queries.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/queries.scala
@@ -3,6 +3,7 @@ package com.sksamuel.elastic4s
 import com.sksamuel.elastic4s.DefinitionAttributes._
 import com.sksamuel.elastic4s.analyzers.Analyzer
 import org.elasticsearch.common.geo.GeoDistance
+import org.elasticsearch.common.unit.DistanceUnit.Distance
 import org.elasticsearch.common.unit.{DistanceUnit, Fuzziness}
 import org.elasticsearch.index.query.CommonTermsQueryBuilder.Operator
 import org.elasticsearch.index.query._
@@ -568,6 +569,11 @@ case class GeoDistanceQueryDefinition(field: String)
 
   def distance(distance: Double, unit: DistanceUnit): GeoDistanceQueryDefinition = {
     builder.distance(distance, unit)
+    this
+  }
+
+  def distance(distance: Distance): GeoDistanceQueryDefinition = {
+    builder.distance(distance.value, distance.unit)
     this
   }
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/queries.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/queries.scala
@@ -52,6 +52,7 @@ trait QueryDsl {
   def geoDistanceQuery(field: String): GeoDistanceQueryDefinition = GeoDistanceQueryDefinition(field)
   def geoHashCell(field: String, value: String): GeoHashCellQuery = new GeoHashCellQuery(field).geohash(value)
   def geoPolygonQuery(field: String) = GeoPolygonQueryDefinition(field)
+  def geoDistanceRangeQuery(field: String) = GeoDistanceRangeQueryDefinition(field)
 
   def indicesQuery(indices: String*) = new {
     def query(query: QueryDefinition): IndicesQueryDefinition = new IndicesQueryDefinition(indices, query)


### PR DESCRIPTION
- support `org.elasticsearch.common.unit.DistanceUnit.Distance` as argument for GeoDistanceQueryDefinition
- add geoDistanceRangeQuery to QueryDSL