### PR TITLE
Update to Elasticsearch 5.1.1

### DIFF
--- a/elastic4s-core-tests/src/test/resources/json/search/search_boosting.json
+++ b/elastic4s-core-tests/src/test/resources/json/search/search_boosting.json
@@ -11,14 +11,13 @@
           "default_operator": "or",
           "auto_generate_phrase_queries": false,
           "max_determined_states": 10000,
-          "lowercase_expanded_terms": true,
           "enable_position_increment": true,
           "fuzziness": "AUTO",
           "fuzzy_prefix_length": 0,
           "fuzzy_max_expansions": 50,
           "phrase_slop": 0,
-          "locale": "und",
           "escape": false,
+          "split_on_whitespace": true,
           "boost": 1.0
         }
       },
@@ -31,14 +30,13 @@
           "default_operator": "or",
           "auto_generate_phrase_queries": false,
           "max_determined_states": 10000,
-          "lowercase_expanded_terms": true,
           "enable_position_increment": true,
           "fuzziness": "AUTO",
           "fuzzy_prefix_length": 0,
           "fuzzy_max_expansions": 50,
           "phrase_slop": 0,
-          "locale": "und",
           "escape": false,
+          "split_on_whitespace": true,
           "boost": 1.0
         }
       },

--- a/elastic4s-core-tests/src/test/resources/json/search/search_function_score.json
+++ b/elastic4s-core-tests/src/test/resources/json/search/search_function_score.json
@@ -6,10 +6,8 @@
           "query": "coldplay",
           "flags": -1,
           "default_operator": "or",
-          "lowercase_expanded_terms": true,
           "lenient": false,
           "analyze_wildcard": false,
-          "locale": "und",
           "boost": 1.0
         }
       },

--- a/elastic4s-core-tests/src/test/resources/json/search/search_haschild_query.json
+++ b/elastic4s-core-tests/src/test/resources/json/search/search_haschild_query.json
@@ -8,10 +8,8 @@
           "query": "coldplay",
           "flags": -1,
           "default_operator": "or",
-          "lowercase_expanded_terms": true,
           "lenient": false,
           "analyze_wildcard": false,
-          "locale": "und",
           "boost": 1.0
         }
       },

--- a/elastic4s-core-tests/src/test/resources/json/search/search_hasparent_query.json
+++ b/elastic4s-core-tests/src/test/resources/json/search/search_hasparent_query.json
@@ -7,10 +7,8 @@
           "query": "coldplay",
           "flags": -1,
           "default_operator": "or",
-          "lowercase_expanded_terms": true,
           "lenient": false,
           "analyze_wildcard": false,
-          "locale": "und",
           "boost": 1.0
         }
       },

--- a/elastic4s-core-tests/src/test/resources/json/search/search_indexboost.json
+++ b/elastic4s-core-tests/src/test/resources/json/search/search_indexboost.json
@@ -8,14 +8,13 @@
       "default_operator": "or",
       "auto_generate_phrase_queries": false,
       "max_determined_states": 10000,
-      "lowercase_expanded_terms": true,
       "enable_position_increment": true,
       "fuzziness": "AUTO",
       "fuzzy_prefix_length": 0,
       "fuzzy_max_expansions": 50,
       "phrase_slop": 0,
-      "locale": "und",
       "escape": false,
+      "split_on_whitespace": true,
       "boost": 1.0
     }
   },

--- a/elastic4s-core-tests/src/test/resources/json/search/search_minscore.json
+++ b/elastic4s-core-tests/src/test/resources/json/search/search_minscore.json
@@ -8,14 +8,13 @@
       "default_operator": "or",
       "auto_generate_phrase_queries": false,
       "max_determined_states": 10000,
-      "lowercase_expanded_terms": true,
       "enable_position_increment": true,
       "fuzziness": "AUTO",
       "fuzzy_prefix_length": 0,
       "fuzzy_max_expansions": 50,
       "phrase_slop": 0,
-      "locale": "und",
       "escape": false,
+      "split_on_whitespace": true,
       "boost": 1.0
     }
   },

--- a/elastic4s-core-tests/src/test/resources/json/search/search_preference_primary_first.json
+++ b/elastic4s-core-tests/src/test/resources/json/search/search_preference_primary_first.json
@@ -8,14 +8,13 @@
       "default_operator": "or",
       "auto_generate_phrase_queries": false,
       "max_determined_states": 10000,
-      "lowercase_expanded_terms": true,
       "enable_position_increment": true,
       "fuzziness": "AUTO",
       "fuzzy_prefix_length": 0,
       "fuzzy_max_expansions": 50,
       "phrase_slop": 0,
-      "locale": "und",
       "escape": false,
+      "split_on_whitespace": true,
       "boost": 1.0
     }
   },

--- a/elastic4s-core-tests/src/test/resources/json/search/search_query_dismax.json
+++ b/elastic4s-core-tests/src/test/resources/json/search/search_query_dismax.json
@@ -8,10 +8,8 @@
             "query": "coldplay",
             "flags": -1,
             "default_operator": "or",
-            "lowercase_expanded_terms": true,
             "lenient": false,
             "analyze_wildcard": false,
-            "locale": "und",
             "boost": 1.0
           }
         },
@@ -20,10 +18,8 @@
             "query": "london",
             "flags": -1,
             "default_operator": "or",
-            "lowercase_expanded_terms": true,
             "lenient": false,
             "analyze_wildcard": false,
-            "locale": "und",
             "boost": 1.0
           }
         }

--- a/elastic4s-core-tests/src/test/resources/json/search/search_rescore.json
+++ b/elastic4s-core-tests/src/test/resources/json/search/search_rescore.json
@@ -8,10 +8,8 @@
             "query": "coldplay",
             "flags": -1,
             "default_operator": "or",
-            "lowercase_expanded_terms": true,
             "lenient": false,
             "analyze_wildcard": false,
-            "locale": "und",
             "boost": 1.0
           }
         },

--- a/elastic4s-core-tests/src/test/resources/json/search/search_script_field_poc.json
+++ b/elastic4s-core-tests/src/test/resources/json/search/search_script_field_poc.json
@@ -18,8 +18,7 @@
     "date": {
       "script": {
         "inline": "doc['date'].value",
-        "lang": "groovy",
-        "params": {}
+        "lang": "groovy"
       },
       "ignore_failure": false
     }

--- a/elastic4s-core-tests/src/test/resources/json/search/search_simple_string_query.json
+++ b/elastic4s-core-tests/src/test/resources/json/search/search_simple_string_query.json
@@ -8,10 +8,8 @@
       "analyzer": "whitespace",
       "flags": 548,
       "default_operator": "and",
-      "lowercase_expanded_terms": true,
       "lenient": false,
       "analyze_wildcard": false,
-      "locale": "und",
       "boost": 1.0
     }
   },

--- a/elastic4s-core-tests/src/test/resources/json/search/search_string.json
+++ b/elastic4s-core-tests/src/test/resources/json/search/search_string.json
@@ -12,7 +12,6 @@
       "auto_generate_phrase_queries": true,
       "max_determined_states": 10000,
       "allow_leading_wildcard": true,
-      "lowercase_expanded_terms": true,
       "enable_position_increment": true,
       "fuzziness": "AUTO",
       "fuzzy_prefix_length": 3,
@@ -21,8 +20,8 @@
       "analyze_wildcard": true,
       "rewrite": "writer",
       "lenient": true,
-      "locale": "und",
       "escape": false,
+      "split_on_whitespace": true,
       "boost": 6.5
     }
   },

--- a/elastic4s-core-tests/src/test/resources/json/search/search_suggestions_context.json
+++ b/elastic4s-core-tests/src/test/resources/json/search/search_suggestions_context.json
@@ -8,14 +8,13 @@
       "default_operator": "or",
       "auto_generate_phrase_queries": false,
       "max_determined_states": 10000,
-      "lowercase_expanded_terms": true,
       "enable_position_increment": true,
       "fuzziness": "AUTO",
       "fuzzy_prefix_length": 0,
       "fuzzy_max_expansions": 50,
       "phrase_slop": 0,
-      "locale": "und",
       "escape": false,
+      "split_on_whitespace": true,
       "boost": 1.0
     }
   },

--- a/elastic4s-core-tests/src/test/resources/json/search/search_suggestions_multiple.json
+++ b/elastic4s-core-tests/src/test/resources/json/search/search_suggestions_multiple.json
@@ -8,14 +8,13 @@
       "default_operator": "or",
       "auto_generate_phrase_queries": false,
       "max_determined_states": 10000,
-      "lowercase_expanded_terms": true,
       "enable_position_increment": true,
       "fuzziness": "AUTO",
       "fuzzy_prefix_length": 0,
       "fuzzy_max_expansions": 50,
       "phrase_slop": 0,
-      "locale": "und",
       "escape": false,
+      "split_on_whitespace": true,
       "boost": 1.0
     }
   },

--- a/elastic4s-core-tests/src/test/resources/json/search/search_test2.json
+++ b/elastic4s-core-tests/src/test/resources/json/search/search_test2.json
@@ -9,14 +9,13 @@
       "default_operator": "or",
       "auto_generate_phrase_queries": false,
       "max_determined_states": 10000,
-      "lowercase_expanded_terms": true,
       "enable_position_increment": true,
       "fuzziness": "AUTO",
       "fuzzy_prefix_length": 0,
       "fuzzy_max_expansions": 50,
       "phrase_slop": 0,
-      "locale": "und",
       "escape": false,
+      "split_on_whitespace": true,
       "boost": 1.0
     }
   },

--- a/elastic4s-core-tests/src/test/resources/json/search/search_test3.json
+++ b/elastic4s-core-tests/src/test/resources/json/search/search_test3.json
@@ -9,14 +9,13 @@
       "default_operator": "or",
       "auto_generate_phrase_queries": false,
       "max_determined_states": 10000,
-      "lowercase_expanded_terms": true,
       "enable_position_increment": true,
       "fuzziness": "AUTO",
       "fuzzy_prefix_length": 0,
       "fuzzy_max_expansions": 50,
       "phrase_slop": 0,
-      "locale": "und",
       "escape": false,
+      "split_on_whitespace": true,
       "boost": 1.0
     }
   },

--- a/elastic4s-core-tests/src/test/resources/json/search/search_test4.json
+++ b/elastic4s-core-tests/src/test/resources/json/search/search_test4.json
@@ -10,14 +10,13 @@
       "default_operator": "or",
       "auto_generate_phrase_queries": false,
       "max_determined_states": 10000,
-      "lowercase_expanded_terms": true,
       "enable_position_increment": true,
       "fuzziness": "AUTO",
       "fuzzy_prefix_length": 0,
       "fuzzy_max_expansions": 50,
       "phrase_slop": 0,
-      "locale": "und",
       "escape": false,
+      "split_on_whitespace": true,
       "boost": 1.0
     }
   },

--- a/elastic4s-core-tests/src/test/resources/json/search/search_test_fetch_source_false.json
+++ b/elastic4s-core-tests/src/test/resources/json/search/search_test_fetch_source_false.json
@@ -8,14 +8,13 @@
       "default_operator": "or",
       "auto_generate_phrase_queries": false,
       "max_determined_states": 10000,
-      "lowercase_expanded_terms": true,
       "enable_position_increment": true,
       "fuzziness": "AUTO",
       "fuzzy_prefix_length": 0,
       "fuzzy_max_expansions": 50,
       "phrase_slop": 0,
-      "locale": "und",
       "escape": false,
+      "split_on_whitespace": true,
       "boost": 1.0
     }
   },

--- a/elastic4s-core-tests/src/test/resources/json/search/search_test_fetch_source_true.json
+++ b/elastic4s-core-tests/src/test/resources/json/search/search_test_fetch_source_true.json
@@ -8,14 +8,13 @@
       "default_operator": "or",
       "auto_generate_phrase_queries": false,
       "max_determined_states": 10000,
-      "lowercase_expanded_terms": true,
       "enable_position_increment": true,
       "fuzziness": "AUTO",
       "fuzzy_prefix_length": 0,
       "fuzzy_max_expansions": 50,
       "phrase_slop": 0,
-      "locale": "und",
       "escape": false,
+      "split_on_whitespace": true,
       "boost": 1.0
     }
   },

--- a/elastic4s-core-tests/src/test/resources/json/search/search_test_terminate_after.json
+++ b/elastic4s-core-tests/src/test/resources/json/search/search_test_terminate_after.json
@@ -9,14 +9,13 @@
       "default_operator": "or",
       "auto_generate_phrase_queries": false,
       "max_determined_states": 10000,
-      "lowercase_expanded_terms": true,
       "enable_position_increment": true,
       "fuzziness": "AUTO",
       "fuzzy_prefix_length": 0,
       "fuzzy_max_expansions": 50,
       "phrase_slop": 0,
-      "locale": "und",
       "escape": false,
+      "split_on_whitespace": true,
       "boost": 1.0
     }
   },

--- a/elastic4s-core-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
+++ b/elastic4s-core-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
@@ -849,7 +849,7 @@ class SearchDslTest extends FlatSpec with MockitoSugar with JsonSugar with OneIn
         constantScoreQuery {
           termQuery("name", "sammy")
         }
-      } scoreMode "avg" inner innerHits("obj1").fetchSource(new FetchSourceContext("incme", "excme"))
+      } scoreMode "avg" inner innerHits("obj1").fetchSource(new FetchSourceContext(true, Seq("incme").toArray, Seq("excme").toArray))
     }
     req.show should matchJsonResource("/json/search/search_query_nested_inner_hits_source.json")
   }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/get/GetDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/get/GetDefinition.scala
@@ -19,7 +19,12 @@ case class GetDefinition(indexAndType: IndexAndType, id: String) {
   }
 
   def fetchSourceContext(include: Iterable[String], exclude: Iterable[String] = Nil) = {
-    _builder.fetchSourceContext(new FetchSourceContext(include.toArray, exclude.toArray))
+    _builder.fetchSourceContext(new FetchSourceContext(true, include.toArray, exclude.toArray))
+    this
+  }
+
+  def fetchSourceContext(context: Boolean, include: Iterable[String], exclude: Iterable[String]) = {
+    _builder.fetchSourceContext(new FetchSourceContext(context, include.toArray, exclude.toArray))
     this
   }
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/script/ScriptDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/script/ScriptDefinition.scala
@@ -1,8 +1,7 @@
 package com.sksamuel.elastic4s.script
 
 import com.sksamuel.elastic4s.FieldsMapper
-import org.elasticsearch.script.Script
-import org.elasticsearch.script.ScriptService.ScriptType
+import org.elasticsearch.script.{ Script, ScriptType }
 
 import scala.collection.JavaConverters._
 import scala.language.implicitConversions
@@ -10,7 +9,8 @@ import scala.language.implicitConversions
 case class ScriptDefinition(script: String,
                             lang: Option[String] = None,
                             scriptType: ScriptType = ScriptType.INLINE,
-                            params: Map[String, Any] = Map.empty) {
+                            params: Map[String, Any] = Map.empty,
+                            options: Map[String, String] = Map.empty) {
 
   def lang(lang: String): ScriptDefinition = copy(lang = Option(lang))
   def param(name: String, value: Any): ScriptDefinition = copy(params = params + (name -> value))
@@ -25,10 +25,12 @@ case class ScriptDefinition(script: String,
 
   def build: Script = {
     if (params.isEmpty) {
-      new Script(script, scriptType, lang.orNull, null)
+      new Script(scriptType, lang.getOrElse(Script.DEFAULT_SCRIPT_LANG), script,
+                 options.asJava, Map.empty.asJava)
     } else {
       val mappedParams = FieldsMapper.mapper(params).asJava
-      new Script(script, scriptType, lang.orNull, mappedParams)
+      new Script(scriptType, lang.getOrElse(Script.DEFAULT_SCRIPT_LANG), script,
+                 options.asJava, mappedParams)
     }
   }
 }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/script/ScriptFieldDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/script/ScriptFieldDefinition.scala
@@ -1,12 +1,13 @@
 package com.sksamuel.elastic4s.script
 
-import org.elasticsearch.script.ScriptService
+import org.elasticsearch.script.ScriptType
 
 case class ScriptFieldDefinition(field: String,
                                  script: String,
                                  language: Option[String] = None,
                                  parameters: Option[Map[String, AnyRef]] = None,
-                                 scriptType: ScriptService.ScriptType = ScriptService.ScriptType.INLINE) {
+                                 options: Option[Map[String, String]] = None,
+                                 scriptType: ScriptType = ScriptType.INLINE) {
 
   def lang(l: String): ScriptFieldDefinition = copy(language = Option(l))
 
@@ -18,5 +19,5 @@ case class ScriptFieldDefinition(field: String,
     copy(parameters = Some(ps.toMap.map(e => e._1 -> e._2.asInstanceOf[AnyRef])))
   }
 
-  def scriptType(scriptType: ScriptService.ScriptType): ScriptFieldDefinition = copy(scriptType = scriptType)
+  def scriptType(scriptType: ScriptType): ScriptFieldDefinition = copy(scriptType = scriptType)
 }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/queries/QueryStringQueryDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/queries/QueryStringQueryDefinition.scala
@@ -41,8 +41,13 @@ case class QueryStringQueryDefinition(query: String)
     this
   }
 
+  @deprecated("Lowercase expanded terms has been deprecated by Elasticsearch", "5.1.1")
   def lowercaseExpandedTerms(lowercaseExpandedTerms: Boolean): this.type = {
-    builder.lowercaseExpandedTerms(lowercaseExpandedTerms)
+    this
+  }
+
+  def splitOnWhitespace(splitOnWhitespace: Boolean): this.type = {
+    builder.splitOnWhitespace(splitOnWhitespace)
     this
   }
 

--- a/elastic4s-embedded/src/main/scala/com/sksamuel/elastic4s/embedded/LocalNode.scala
+++ b/elastic4s-embedded/src/main/scala/com/sksamuel/elastic4s/embedded/LocalNode.scala
@@ -103,7 +103,6 @@ object LocalNode {
 
     val mergedSettings = Settings.builder().put(settings)
       .put("transport.type", "local")
-      .put("discovery.type", "local")
       .put("http.type", "netty3")
       .build()
 

--- a/elastic4s-testkit/src/main/scala/com/sksamuel/elastic4s/testkit/ElasticSugar.scala
+++ b/elastic4s-testkit/src/main/scala/com/sksamuel/elastic4s/testkit/ElasticSugar.scala
@@ -1,9 +1,9 @@
 package com.sksamuel.elastic4s.testkit
 
 import com.sksamuel.elastic4s.{ElasticDsl, IndexAndTypes, Indexes}
+import org.elasticsearch.ResourceAlreadyExistsException
 import org.elasticsearch.action.admin.indices.refresh.RefreshResponse
 import org.elasticsearch.cluster.health.ClusterHealthStatus
-import org.elasticsearch.indices.IndexAlreadyExistsException
 import org.elasticsearch.transport.RemoteTransportException
 import org.scalatest.{BeforeAndAfterAll, Suite}
 import org.slf4j.LoggerFactory
@@ -71,7 +71,7 @@ trait AbstractElasticSugar extends ElasticDsl {
         createIndex(index)
       }.await
     } catch {
-      case _: IndexAlreadyExistsException => // Ok, ignore.
+      case _: ResourceAlreadyExistsException => // Ok, ignore.
       case _: RemoteTransportException => // Ok, ignore.
     }
   }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -14,7 +14,7 @@ object Build extends AutoPlugin {
     val CatsVersion = "0.8.1"
     val CirceVersion = "0.6.1"
     val CommonsIoVersion = "2.4"
-    val ElasticsearchVersion = "5.0.2"
+    val ElasticsearchVersion = "5.1.1"
     val ExtsVersion = "1.36.0"
     val JacksonVersion = "2.8.4"
     val Json4sVersion = "3.5.0"


### PR DESCRIPTION
Summary of changes:
- Deprecated `lowercaseExpandedTerms` on QueryStringQueryDefinition
- Added `splitOnWhitespace` to QueryStringQueryDefinition
- Adapted calls to the `Script` constructor:
  - Argument order has changed
  - Nulls are not allowed - used `Script.DEFAULT_SCRIPT_LANG` instead when
    `lang` is not supplied
- Adapted calls to `FetchSourceContext` constructor:
  - The overload with only `include` and `exclude` has been removed - the
    default is `true` for `fetchSource`
  - Added a corresponding overload to `GetDefinition`
- `IndexAlreadyExistsException` has been renamed to `ReasourceAlreadyExists`
  exception
- The `local` discovery type used in `LocalNode` has been removed
- Removed `locale` from the search fixtures

Resolves #689