### PR TITLE
Prevent building of include/exclude when empty string is passed

### DIFF
--- a/elastic4s-core-tests/src/test/scala/com/sksamuel/elastic4s/search/aggs/TermsAggregationTest.scala
+++ b/elastic4s-core-tests/src/test/scala/com/sksamuel/elastic4s/search/aggs/TermsAggregationTest.scala
@@ -1,8 +1,6 @@
 package com.sksamuel.elastic4s.search.aggs
 
-import com.sksamuel.elastic4s.testkit.ElasticSugar
 import org.elasticsearch.search.aggregations.bucket.terms.StringTerms
-import org.scalatest.{FreeSpec, Matchers}
 
 class TermsAggregationTest extends AbstractAggregationTest {
 
@@ -16,7 +14,7 @@ class TermsAggregationTest extends AbstractAggregationTest {
       }.await
       resp.totalHits shouldBe 10
 
-      val agg = resp.aggregations.getAsMap.get("agg1").asInstanceOf[StringTerms]
+      val agg = resp.aggregations.map("agg1").asInstanceOf[StringTerms]
       agg.getBuckets.size shouldBe 5
       agg.getBucketByKey("meth kingpin").getDocCount shouldBe 2
       agg.getBucketByKey("meth sidekick").getDocCount shouldBe 3
@@ -28,12 +26,12 @@ class TermsAggregationTest extends AbstractAggregationTest {
     "should only include matching documents in the query" in {
       val resp = client.execute {
         // should match 3 documents: steven, saul, hank Schrader
-        search in "aggregations/breakingbad" query prefixQuery("name" -> "s") aggregations {
-          aggregation terms "agg1" field "job"
+        search("aggregations/breakingbad") query prefixQuery("name" -> "s") aggregations {
+          termsAggregation("agg1") field "job"
         }
       }.await
       resp.totalHits shouldBe 3
-      val aggs = resp.aggregations.getAsMap.get("agg1").asInstanceOf[StringTerms]
+      val aggs = resp.aggregations.map("agg1").asInstanceOf[StringTerms]
       aggs.getBuckets.size shouldBe 2
       aggs.getBucketByKey("dea agent").getDocCount shouldBe 2
       aggs.getBucketByKey("lawyer").getDocCount shouldBe 1
@@ -42,21 +40,49 @@ class TermsAggregationTest extends AbstractAggregationTest {
     "should only return included fields" in {
       val resp = client.execute {
         search("aggregations/breakingbad") aggregations {
-          aggregation terms "agg1" field "job" includeExclude(Seq("meth kingpin", "lawyer"), Nil)
+          termsAggregation("agg1") field "job" includeExclude("lawyer", "")
         }
       }.await
       resp.totalHits shouldBe 10
-      val agg = resp.aggregations.getAsMap.get("agg1").asInstanceOf[StringTerms]
+      val agg = resp.aggregations.map("agg1").asInstanceOf[StringTerms]
+      agg.getBuckets.size shouldBe 1
+      agg.getBucketByKey("lawyer").getDocCount shouldBe 1
+    }
+
+    "should not return excluded fields" in {
+      val resp = client.execute {
+        search("aggregations/breakingbad") aggregations {
+          termsAggregation("agg1") field "job" includeExclude("", "lawyer")
+        }
+      }.await
+      resp.totalHits shouldBe 10
+
+
+      val agg = resp.aggregations.stringTermsResult("agg1")
+      agg.getBuckets.size shouldBe 4
+      agg.getBucketByKey("meth sidekick").getDocCount shouldBe 3
+      agg.getBucketByKey("meth kingpin").getDocCount shouldBe 2
+      agg.getBucketByKey("dea agent").getDocCount shouldBe 2
+      agg.getBucketByKey("heavy").getDocCount shouldBe 2
+    }
+
+    "should only return included fields (given a seq)" in {
+      val resp = client.execute {
+        search("aggregations/breakingbad") aggregations {
+          termsAggregation("agg1") field "job" includeExclude(Seq("meth kingpin", "lawyer"), Nil)
+        }
+      }.await
+      resp.totalHits shouldBe 10
+      val agg = resp.aggregations.map("agg1").asInstanceOf[StringTerms]
       agg.getBuckets.size shouldBe 2
       agg.getBucketByKey("meth kingpin").getDocCount shouldBe 2
       agg.getBucketByKey("lawyer").getDocCount shouldBe 1
     }
 
-    "should not return excluded fields" in {
-
+    "should not return excluded fields (given a seq)" in {
       val resp = client.execute {
         search("aggregations/breakingbad") aggregations {
-          aggregation terms "agg1" field "job" includeExclude(Nil, Iterable("lawyer"))
+          termsAggregation("agg1") field "job" includeExclude(Nil, Iterable("lawyer"))
         }
       }.await
       resp.totalHits shouldBe 10

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/aggs/TermsAggregationDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/aggs/TermsAggregationDefinition.scala
@@ -1,5 +1,6 @@
 package com.sksamuel.elastic4s.searches.aggs
 
+import com.sksamuel.exts.OptionImplicits._
 import com.sksamuel.elastic4s.script.ScriptDefinition
 import org.elasticsearch.search.aggregations.bucket.terms.support.IncludeExclude
 import org.elasticsearch.search.aggregations.bucket.terms.{Terms, TermsAggregationBuilder, TermsAggregator}
@@ -77,7 +78,7 @@ case class TermsAggregationDefinition(name: String) extends AggregationDefinitio
   }
 
   def includeExclude(include: String, exclude: String): TermsAggregationDefinition = {
-    builder.includeExclude(new IncludeExclude(include, exclude))
+    builder.includeExclude(new IncludeExclude(include.some.orNull, exclude.some.orNull))
     this
   }
 


### PR DESCRIPTION
When using ` termsAggregation("agg1") field "job" includeExclude("something", "")` the exclude option would be built as well (and vice versa). I then realized that I have to pass "null" to not build that which I think should be abstracted away.

 This change was made to not build the include or exclude options when an empty string is passed. I did not change the parameters of the `def includeExclude(include: String, exclude: String): TermsAggregationDefinition` method to Option[String] because I did not find any other place in the DSL where this was a common practice.

