### PR TITLE
Bump lucene to 6.4.0, matching elasticsearch

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -19,7 +19,7 @@ object Build extends AutoPlugin {
     val JacksonVersion = "2.8.6"
     val Json4sVersion = "3.5.0"
     val Log4jVersion = "2.6.2"
-    val LuceneVersion = "6.3.0"
+    val LuceneVersion = "6.4.0"
     val MockitoVersion = "1.9.5"
     val PlayJsonVersion = "2.6.0-M1"
     val ReactiveStreamsVersion = "1.0.0"


### PR DESCRIPTION
It seems elasticsearch wants lucene 6.4 as of 5.2.  Depending on both elastic4s and elasticsearch directly will evict 6.4 leading to build/assembly errors.