### PR TITLE
Fix index create/delete with http client against a https server by in…

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/IndexAdminImplicits.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/IndexAdminImplicits.scala
@@ -62,7 +62,7 @@ trait IndexAdminImplicits extends IndexShowImplicits {
                          format: JsonFormat[CreateIndexResponse]): Future[CreateIndexResponse] = {
 
       val method = "PUT"
-      val endpoint = request.name
+      val endpoint = "/" + request.name
 
       val params = scala.collection.mutable.Map.empty[String, Any]
       request.waitForActiveShards.foreach(params.put("wait_for_active_shards", _))
@@ -77,7 +77,7 @@ trait IndexAdminImplicits extends IndexShowImplicits {
                          request: DeleteIndexDefinition,
                          format: JsonFormat[DeleteIndexResponse]): Future[DeleteIndexResponse] = {
       val method = "DELETE"
-      val url = request.indexes.mkString(",")
+      val url = "/" + request.indexes.mkString(",")
       executeAsyncAndMapResponse(client.performRequestAsync(method, url, _), format)
     }
   }


### PR DESCRIPTION
…cluding leading forward slash on request endpoint

My test setup is running against a local node and AWS ES via HTTPS. 

Apparently there are some different semantics with leading / between HTTP vs HTTPS as the local node was fine while only HTTPS failed. 

Btw, thanks for the AWESOME library!