### PR TITLE
Add support for named filters in FiltersAggregation

### DIFF
--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/aggs/FiltersAggregationDefinition.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/aggs/FiltersAggregationDefinition.scala
@@ -4,9 +4,20 @@ import com.sksamuel.elastic4s.searches.QueryBuilderFn
 import com.sksamuel.elastic4s.searches.queries.QueryDefinition
 import org.elasticsearch.search.aggregations.AggregationBuilders
 import org.elasticsearch.search.aggregations.bucket.filters.FiltersAggregationBuilder
+import org.elasticsearch.search.aggregations.bucket.filters.FiltersAggregator.KeyedFilter
 
 case class FiltersAggregationDefinition(name: String, filters: Iterable[QueryDefinition])
   extends AggregationDefinition {
   type B = FiltersAggregationBuilder
   val builder: B = AggregationBuilders.filters(name, filters.map(QueryBuilderFn.apply).toSeq: _*)
+}
+
+case class KeyedFiltersAggregationDefinition(name: String, filters: Iterable[(String, QueryDefinition)])
+  extends AggregationDefinition {
+  type B = FiltersAggregationBuilder
+  val builder: B = AggregationBuilders.filters(name,
+    filters.map {
+      case (name, query) => new KeyedFilter(name, QueryBuilderFn(query))
+    }
+      .toSeq: _*)
 }


### PR DESCRIPTION
In Elastic4s 2.x, it was possible to provide name to [FiltersAggregation](https://github.com/sksamuel/elastic4s/blob/v2.4.0/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/aggregations.scala#L543) filters.

It seems that 5.x [FiltersAggregationDefinition](https://github.com/sksamuel/elastic4s/blob/master/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/aggs/FiltersAggregationDefinition.scala) accepts only [anonymous filters](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-filters-aggregation.html#_anonymous_filters).

This PR adds support to keyed FiltersAggregation.