### PR TITLE
Fix for rawQuery

### DIFF
--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/QueryBuilderFn.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/QueryBuilderFn.scala
@@ -36,6 +36,7 @@ object QueryBuilderFn {
     case q: QueryStringQueryDefinition => QueryStringBuilder.builder(q)
     case q: PercolateQueryDefinition => PercolateQueryBuilder(q)
     case q: PrefixQueryDefinition => PrefixQueryBuilderFn(q)
+    case q: RawQueryDefinition => RawQueryBuilderFn(q)
     case q: RegexQueryDefinition => RegexQueryBuilder(q)
     case q: RangeQueryDefinition => RangeQueryBuilder(q)
     case q: ScriptQueryDefinition => ScriptQueryBuilder(q)

--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/queries/RawQueryBuilderFn.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/queries/RawQueryBuilderFn.scala
@@ -1,0 +1,10 @@
+package com.sksamuel.elastic4s.searches.queries
+
+import org.elasticsearch.index.query.{QueryBuilders, WrapperQueryBuilder}
+
+object RawQueryBuilderFn {
+  def apply(q: RawQueryDefinition): WrapperQueryBuilder = {
+    val builder = QueryBuilders.wrapperQuery(q.json)
+    builder
+  }
+}


### PR DESCRIPTION
I noticed that `rawQuery` did not work due to a missing match, and it was unclear that it could work at all. With this code, a query of the form `{ "match": { "key": "value" } }` now works, see https://discuss.elastic.co/t/possible-to-pass-rest-json-query-format-to-the-java-api/2354 for additional information.