### PR TITLE
Add support for range query in Http Client

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/QueryBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/QueryBuilderFn.scala
@@ -29,5 +29,6 @@ object QueryBuilderFn {
     case t: TermsQueryDefinition[_] => TermsQueryBodyFn(t)
     case q: TypeQueryDefinition => TypeQueryBodyFn(q)
     case q: WildcardQueryDefinition => WildcardQueryBodyFn(q)
+    case r: RangeQueryDefinition => RangeQueryBodyFn(r)
   }
 }

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/RangeQueryBodyFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/RangeQueryBodyFn.scala
@@ -1,0 +1,29 @@
+package com.sksamuel.elastic4s.http.search.queries
+
+import com.sksamuel.elastic4s.searches.queries.RangeQueryDefinition
+import org.elasticsearch.common.xcontent.{XContentBuilder, XContentFactory}
+
+object RangeQueryBodyFn {
+  def apply(range: RangeQueryDefinition): XContentBuilder = {
+    val builder = XContentFactory.jsonBuilder()
+    builder.startObject()
+    builder.startObject("range")
+    builder.startObject(range.field)
+
+    if (range.gte.nonEmpty) {
+      builder.field("gte", range.gte.get)
+    }
+
+    if (range.lte.nonEmpty) {
+      builder.field("lte", range.lte.get)
+    }
+
+    range.boost.map(_.toString).foreach(builder.field("boost", _))
+    range.queryName.foreach(builder.field("_name", _))
+
+    builder.endObject()
+    builder.endObject()
+    builder.endObject()
+    builder
+  }
+}

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchHttpTest.scala
@@ -152,6 +152,38 @@ class SearchHttpTest
         resp.totalHits shouldBe 1
         resp.maxScore shouldBe 14.5
       }
+      "support range query using gte" in {
+        val resp = http.execute {
+          search("chess" / "pieces") query {
+            rangeQuery("value").gte("3")
+          }
+        }.await
+        resp.totalHits shouldBe 4
+      }
+      "support range query using lte" in {
+        val resp = http.execute {
+          search("chess" / "pieces") query {
+            rangeQuery("value").lte("3")
+          }
+        }.await
+        resp.totalHits shouldBe 4
+      }
+      "support range query using both lte & gte" in {
+        val resp = http.execute {
+          search("chess" / "pieces") query {
+            rangeQuery("value").gte("5").lte("7")
+          }
+        }.await
+        resp.totalHits shouldBe 1
+      }
+      "support boost in range query" in {
+        val resp = http.execute {
+          search("chess" / "pieces") query {
+            rangeQuery("value").lte("3").boost(14.5)
+          }
+        }.await
+        resp.maxScore shouldBe 14.5
+      }
     }
   }
 }


### PR DESCRIPTION
The support for Range Query was only available in TcpClient. This change is to make it available for HttpClient as well.