### PR TITLE
SignificanceHeuristic parameter for SigTermsAggregation

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/aggs/SigTermsAggregationDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/aggs/SigTermsAggregationDefinition.scala
@@ -3,6 +3,7 @@ package com.sksamuel.elastic4s.searches.aggs
 import com.sksamuel.elastic4s.searches.aggs.pipeline.PipelineAggregationDefinition
 import com.sksamuel.elastic4s.searches.queries.QueryDefinition
 import com.sksamuel.exts.OptionImplicits._
+import org.elasticsearch.search.aggregations.bucket.significant.heuristics.SignificanceHeuristic
 import org.elasticsearch.search.aggregations.bucket.terms.support.IncludeExclude
 
 case class SigTermsAggregationDefinition(name: String,
@@ -16,7 +17,8 @@ case class SigTermsAggregationDefinition(name: String,
                                          backgroundFilter: Option[QueryDefinition] = None,
                                          pipelines: Seq[PipelineAggregationDefinition] = Nil,
                                          subaggs: Seq[AggregationDefinition] = Nil,
-                                         metadata: Map[String, AnyRef] = Map.empty)
+                                         metadata: Map[String, AnyRef] = Map.empty,
+                                         heuristic: Option[SignificanceHeuristic] = None)
   extends AggregationDefinition {
 
   type T = SigTermsAggregationDefinition
@@ -31,6 +33,8 @@ case class SigTermsAggregationDefinition(name: String,
     val exc = if (exclude.isEmpty) null else exclude.toArray
     copy(includeExclude = new IncludeExclude(inc, exc).some)
   }
+  def significanceHeuristic(heuristic: SignificanceHeuristic): SigTermsAggregationDefinition =
+    copy(heuristic = heuristic.some)
 
   def field(field: String): SigTermsAggregationDefinition = copy(field = field.some)
   def shardMinDocCount(min: Long): SigTermsAggregationDefinition = copy(shardMinDocCount = min.some)

--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/aggs/SigTermsAggregationBuilder.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/aggs/SigTermsAggregationBuilder.scala
@@ -22,6 +22,7 @@ object SigTermsAggregationBuilder {
     agg.subaggs.map(AggregationBuilder.apply).foreach(builder.subAggregation)
     agg.pipelines.map(PipelineAggregationBuilderFn.apply).foreach(builder.subAggregation)
     if (agg.metadata.nonEmpty) builder.setMetaData(agg.metadata.asJava)
+    agg.heuristic.foreach(builder.significanceHeuristic)
     builder
   }
 }


### PR DESCRIPTION
Potential (temporal?) fix for #770

Whether it is planned to hide Java `SignificanceHeuristic` class hierarchy from DSL users, it would be nice to be able to set that parameter right now.