### PR TITLE
Add include_lower, include_upper, and time_zone in range query

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/RangeQueryBodyFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/RangeQueryBodyFn.scala
@@ -10,15 +10,13 @@ object RangeQueryBodyFn {
     builder.startObject("range")
     builder.startObject(range.field)
 
-    if (range.gte.nonEmpty) {
-      builder.field("gte", range.gte.get)
-    }
-
-    if (range.lte.nonEmpty) {
-      builder.field("lte", range.lte.get)
-    }
+    range.gte.foreach(builder.field("gte", _))
+    range.lte.foreach(builder.field("lte", _))
+    range.includeUpper.foreach(builder.field("include_upper", _))
+    range.includeLower.foreach(builder.field("include_lower", _))
 
     range.boost.map(_.toString).foreach(builder.field("boost", _))
+    range.timeZone.foreach(builder.field("time_zone", _))
     range.queryName.foreach(builder.field("_name", _))
 
     builder.endObject()


### PR DESCRIPTION
This adds exclusive range support for `RangeQueryBodyFn`. I also noticed `time_zone` was missing, so I added that too.

It seems like `lt` and `gt` are preferred now, but since I wasn't 100% sure I didn't want to go renaming things. The Java client still uses `include_*`, so I guess it won't be removed anytime soon.