### PR TITLE
#795 Add normalizer api

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticApi.scala
@@ -2,7 +2,7 @@ package com.sksamuel.elastic4s
 
 import com.sksamuel.elastic4s.admin.IndexAdminApi
 import com.sksamuel.elastic4s.alias.AliasesApi
-import com.sksamuel.elastic4s.analyzers.{AnalyzerApi, TokenizerApi}
+import com.sksamuel.elastic4s.analyzers.{AnalyzerApi, NormalizerApi, TokenizerApi}
 import com.sksamuel.elastic4s.bulk.BulkApi
 import com.sksamuel.elastic4s.delete.DeleteApi
 import com.sksamuel.elastic4s.explain.ExplainApi
@@ -44,6 +44,7 @@ trait ElasticApi
     with IndexAdminApi
     with LocksApi
     with MappingApi
+    with NormalizerApi
     with QueryApi
     with PipelineAggregationApi
     with ReindexApi

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/analyzers/Normalizer.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/analyzers/Normalizer.scala
@@ -1,0 +1,6 @@
+package com.sksamuel.elastic4s.analyzers
+
+abstract class Normalizer(val name: String)
+
+// Pre-built normalizers still to be added
+case class CustomNormalizer(override val name: String) extends Normalizer(name)

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/analyzers/NormalizerApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/analyzers/NormalizerApi.scala
@@ -1,0 +1,14 @@
+package com.sksamuel.elastic4s.analyzers
+
+trait NormalizerApi {
+
+  def customNormalizer(name: String): CustomNormalizerDefinition = {
+    CustomNormalizerDefinition(name)
+  }
+
+  def customNormalizer(name: String,
+                     filter: AnalyzerFilter,
+                     rest: AnalyzerFilter*): CustomNormalizerDefinition = {
+    CustomNormalizerDefinition(name, filter +: rest)
+  }
+}

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/analyzers/NormalizerDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/analyzers/NormalizerDefinition.scala
@@ -1,0 +1,69 @@
+package com.sksamuel.elastic4s.analyzers
+
+import org.elasticsearch.common.xcontent.{XContentBuilder, XContentFactory}
+
+import scala.collection.JavaConverters._
+
+// Base class for normalizers that have custom parameters set.
+abstract class NormalizerDefinition (val name: String) {
+
+  def buildWithName(source: XContentBuilder): Unit = {
+    source.startObject(name)
+    build(source)
+    source.endObject()
+  }
+
+  def buildWithName(): XContentBuilder = {
+    val xc = XContentFactory.jsonBuilder()
+    xc.startObject()
+    buildWithName(xc)
+    xc.endObject()
+    xc
+  }
+
+  def build(): XContentBuilder = {
+    val xc = XContentFactory.jsonBuilder()
+    xc.startObject()
+    build(xc)
+    xc.endObject()
+    xc
+  }
+
+  def build(source: XContentBuilder): Unit
+
+  def json: XContentBuilder = {
+    val builder = XContentFactory.jsonBuilder
+    builder.startObject()
+    build(builder)
+    builder.endObject()
+    builder
+  }
+}
+
+
+case class CustomNormalizerDefinition(override val name: String,
+                                    filters: Seq[AnalyzerFilter] = Nil) extends NormalizerDefinition(name) {
+
+  def build(source: XContentBuilder): Unit = {
+    source.field("type", "custom")
+    val tokenFilters = filters.collect { case token: TokenFilter => token }
+    val charFilters = filters.collect { case char: CharFilter => char }
+    if (tokenFilters.nonEmpty) {
+      source.field("filter", tokenFilters.map(_.name).asJava)
+    }
+    if (charFilters.nonEmpty) {
+      source.field("char_filter", charFilters.map(_.name).asJava)
+    }
+  }
+
+  def filters(filters: Seq[AnalyzerFilter]): CustomNormalizerDefinition = copy(filters = filters)
+  def addFilter(filter: AnalyzerFilter): CustomNormalizerDefinition = copy(filters = filters :+ filter)
+}
+
+object CustomNormalizerDefinition {
+  def apply(name: String,
+            first: AnalyzerFilter,
+            rest: AnalyzerFilter*): CustomNormalizerDefinition = {
+    CustomNormalizerDefinition(name, first +: rest)
+  }
+}

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/analyzers/TokenFilter.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/analyzers/TokenFilter.scala
@@ -33,6 +33,10 @@ case object LowercaseTokenFilter extends TokenFilter {
   val name = "lowercase"
 }
 
+case object UppercaseTokenFilter extends TokenFilter {
+  val name = "uppercase"
+}
+
 case object KStemTokenFilter extends TokenFilter {
   val name = "kstem"
 }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/indexes/AnalysisContentBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/indexes/AnalysisContentBuilder.scala
@@ -23,6 +23,13 @@ object AnalysisContentBuilder {
     ad.analyzers.foreach(_.buildWithName(source))
     source.endObject()
 
+    val normalizers = ad.normalizers
+    if (normalizers.nonEmpty) {
+      source.startObject("normalizer")
+      normalizers.foreach(_.buildWithName(source))
+      source.endObject()
+    }
+
     val tokenizers = ad.tokenizers
     if (tokenizers.nonEmpty) {
       source.startObject("tokenizer")

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/indexes/AnalysisDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/indexes/AnalysisDefinition.scala
@@ -2,24 +2,36 @@ package com.sksamuel.elastic4s.indexes
 
 import com.sksamuel.elastic4s.analyzers._
 
-case class AnalysisDefinition(analyzers: Iterable[AnalyzerDefinition]) {
+case class AnalysisDefinition(analyzers: Iterable[AnalyzerDefinition], normalizers: Iterable[NormalizerDefinition]) {
 
   def tokenizers: Iterable[Tokenizer] =
     analyzers.collect {
       case custom: CustomAnalyzerDefinition => custom
     }.map(_.tokenizer).filter(_.customized)
 
-  def tokenFilterDefinitions: Iterable[TokenFilterDefinition] =
-    analyzers.collect {
+  def tokenFilterDefinitions: Iterable[TokenFilterDefinition] = {
+    val fromAnalyzers = analyzers.collect {
       case custom: CustomAnalyzerDefinition => custom
-    }.flatMap(_.filters).collect {
+    }.flatMap(_.filters)
+    val fromNormalizers = normalizers.collect {
+      case custom: CustomNormalizerDefinition => custom
+    }.flatMap(_.filters)
+
+    (fromAnalyzers ++ fromNormalizers).collect {
       case token: TokenFilterDefinition => token
     }
+  }
 
-  def charFilterDefinitions: Iterable[CharFilterDefinition] =
-    analyzers.collect {
+  def charFilterDefinitions: Iterable[CharFilterDefinition] = {
+    val fromAnalyzers = analyzers.collect {
       case custom: CustomAnalyzerDefinition => custom
-    }.flatMap(_.filters).collect {
+    }.flatMap(_.filters)
+    val fromNormalizers = normalizers.collect {
+      case custom: CustomNormalizerDefinition => custom
+    }.flatMap(_.filters)
+
+    (fromAnalyzers ++ fromNormalizers).collect {
       case char: CharFilterDefinition => char
     }
+  }
 }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/indexes/CreateIndexDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/indexes/CreateIndexDefinition.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.elastic4s.indexes
 
-import com.sksamuel.elastic4s.analyzers.AnalyzerDefinition
+import com.sksamuel.elastic4s.analyzers.{AnalyzerDefinition, NormalizerDefinition}
 import com.sksamuel.elastic4s.mappings.MappingDefinition
 import com.sksamuel.exts.OptionImplicits._
 
@@ -32,7 +32,15 @@ case class CreateIndexDefinition(name: String,
   def mappings(mappings: Iterable[MappingDefinition]): CreateIndexDefinition = copy(mappings = this.mappings ++ mappings)
 
   def analysis(first: AnalyzerDefinition, rest: AnalyzerDefinition*): CreateIndexDefinition = analysis(first +: rest)
-  def analysis(analyzers: Iterable[AnalyzerDefinition]): CreateIndexDefinition = copy(analysis = AnalysisDefinition(analyzers).some)
+  def analysis(analyzers: Iterable[AnalyzerDefinition]): CreateIndexDefinition = analysis(analyzers, Nil)
+  def analysis(analyzers: Iterable[AnalyzerDefinition], normalizers: Iterable[NormalizerDefinition]): CreateIndexDefinition =
+    analysis match {
+      case None    => copy(analysis = AnalysisDefinition(analyzers, normalizers).some)
+      case Some(a) => copy(analysis = AnalysisDefinition(a.analyzers ++ analyzers, a.normalizers ++ normalizers).some)
+    }
+
+  def normalizers(first: NormalizerDefinition, rest: NormalizerDefinition*): CreateIndexDefinition = analysis(Nil, first +: rest)
+  def normalizers(normalizers: Iterable[NormalizerDefinition]): CreateIndexDefinition = analysis(Nil, normalizers)
 
   def source(source: String): CreateIndexDefinition = copy(rawSource = source.some)
 }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/attributes.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/attributes.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.elastic4s.mappings
 
-import com.sksamuel.elastic4s.analyzers.Analyzer
+import com.sksamuel.elastic4s.analyzers.{Analyzer, Normalizer}
 import org.elasticsearch.common.xcontent.XContentBuilder
 
 object attributes {
@@ -245,6 +245,25 @@ object attributes {
 
     protected override def insert(source: XContentBuilder): Unit = {
       _analyzer.foreach(source.field("analyzer", _))
+    }
+  }
+
+  trait AttributeNormalizer extends Attribute { self: KeywordFieldDefinition =>
+
+    private[this] var _normalizer: Option[String] = None
+
+    def normalizer(normalizer: String): this.type = {
+      _normalizer = Some(normalizer)
+      this
+    }
+
+    def normalizer(normalizer: Normalizer): this.type = {
+      _normalizer = Some(normalizer.name)
+      this
+    }
+
+    protected override def insert(source: XContentBuilder): Unit = {
+      _normalizer.foreach(source.field("normalizer", _))
     }
   }
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/types.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/types.scala
@@ -148,6 +148,7 @@ final class KeywordFieldDefinition(name: String)
     with AttributeIncludeInAll
     with AttributeIndex
     with AttributeIndexOptions
+    with AttributeNormalizer
     with AttributeNorms
     with AttributeNullValue[String]
     with AttributeStore
@@ -168,6 +169,7 @@ final class KeywordFieldDefinition(name: String)
     super[AttributeIndex].insert(source)
     super[AttributeIndexOptions].insert(source)
     super[AttributeNullValue].insert(source)
+    super[AttributeNormalizer].insert(source)
     super[AttributeNorms].insert(source)
     super[AttributeNullValue].insert(source)
     super[AttributeStore].insert(source)

--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/admin/CreateIndexTemplateDefinition.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/admin/CreateIndexTemplateDefinition.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.elastic4s.admin
 
-import com.sksamuel.elastic4s.analyzers.AnalyzerDefinition
+import com.sksamuel.elastic4s.analyzers.{AnalyzerDefinition, NormalizerDefinition}
 import com.sksamuel.elastic4s.indexes.{AnalysisContentBuilder, AnalysisDefinition}
 import com.sksamuel.elastic4s.mappings.{MappingContentBuilder, MappingDefinition}
 import org.elasticsearch.action.admin.indices.alias.Alias
@@ -48,11 +48,18 @@ case class CreateIndexTemplateDefinition(name: String,
     builder
   }
 
-  def analysis(first: AnalyzerDefinition, rest: AnalyzerDefinition*): CreateIndexTemplateDefinition =
-    analysis(first +: rest)
+  def analysis(first: AnalyzerDefinition, rest: AnalyzerDefinition*): CreateIndexTemplateDefinition = analysis(first +: rest, Nil)
 
-  def analysis(analyzers: Iterable[AnalyzerDefinition]): CreateIndexTemplateDefinition =
-    copy(analysis = AnalysisDefinition(analyzers).some)
+  def analysis(analyzers: Iterable[AnalyzerDefinition]): CreateIndexTemplateDefinition = analysis(analyzers, Nil)
+
+  def analysis(analyzers: Iterable[AnalyzerDefinition], normalizers: Iterable[NormalizerDefinition]): CreateIndexTemplateDefinition =
+    analysis match {
+      case None    => copy(analysis = AnalysisDefinition(analyzers, normalizers).some)
+      case Some(a) => copy(analysis = AnalysisDefinition(a.analyzers ++ analyzers, a.normalizers ++ normalizers).some)
+    }
+
+  def normalizers(first: NormalizerDefinition, rest: NormalizerDefinition*): CreateIndexTemplateDefinition = analysis(Nil, first +: rest)
+  def normalizers(normalizers: Iterable[NormalizerDefinition]): CreateIndexTemplateDefinition = analysis(Nil, normalizers)
 
   def mappings(first: MappingDefinition, rest: MappingDefinition*): CreateIndexTemplateDefinition =
     mappings(first +: rest)

--- a/elastic4s-tests/src/test/resources/json/createindex/createindex_analyis2.json
+++ b/elastic4s-tests/src/test/resources/json/createindex/createindex_analyis2.json
@@ -9,6 +9,10 @@
             "qu=>q"
           ]
         },
+        "mapping_charfilter2": {
+            "mappings": [ "x=>y" ],
+            "type": "mapping"
+        },
         "pattern_replace_charfilter": {
           "type": "pattern_replace",
           "pattern": "sample(.*)",
@@ -65,6 +69,23 @@
           "type": "custom",
           "tokenizer": "myTokenizer5"
         }
+      },
+      "normalizer": {
+          "myNormalizer1": {
+              "filter": [
+                  "lowercase"
+              ],
+              "type": "custom"
+          },
+          "myNormalizer2": {
+              "char_filter": [
+                  "mapping_charfilter2"
+              ],
+              "filter": [
+                  "uppercase"
+              ],
+              "type": "custom"
+          }
       },
       "tokenizer": {
         "myTokenizer1": {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/analyzers/CustomNormalizerTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/analyzers/CustomNormalizerTest.scala
@@ -1,0 +1,19 @@
+package com.sksamuel.elastic4s.analyzers
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class CustomNormalizerTest extends FlatSpec with Matchers {
+
+  "CustomNormalizer" should "support predefined filters" in {
+    CustomNormalizerDefinition(
+      "mygerman",
+      PredefinedTokenFilter("lowercase"),
+      PredefinedTokenFilter("german_stop"),
+      PredefinedTokenFilter("german_keywords"),
+      PredefinedTokenFilter("german_normalization"),
+      PredefinedTokenFilter("german_stemmer"),
+      PredefinedCharFilter("german_charfilter")
+    ).buildWithName().string shouldBe
+      """{"mygerman":{"type":"custom","filter":["lowercase","german_stop","german_keywords","german_normalization","german_stemmer"],"char_filter":["german_charfilter"]}}"""
+  }
+}

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/analyzers/NormalizerTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/analyzers/NormalizerTest.scala
@@ -1,0 +1,52 @@
+package com.sksamuel.elastic4s.analyzers
+
+import com.sksamuel.elastic4s.testkit.ElasticSugar
+import org.scalatest.{FreeSpec, Matchers}
+
+class NormalizerTest extends FreeSpec with Matchers with ElasticSugar {
+
+  client.execute {
+    createIndex("normalizer").mappings {
+      mapping("test") fields (
+        keywordField("keywordLowercase") normalizer "lowercaseNorm",
+        keywordField("keywordUppercaseMappingChar") normalizer "uppercaseMappingCharNorm"
+        )
+    } normalizers(
+      customNormalizer("lowercaseNorm", LowercaseTokenFilter),
+      customNormalizer("uppercaseMappingCharNorm", UppercaseTokenFilter, MappingCharFilter("xtoy","x" -> "y" ))
+    )
+  }.await
+
+  client.execute {
+    indexInto("normalizer" / "test").fields(
+      "keywordLowercase" -> "VeryMuchMixedCASe",
+      "keywordUppercaseMappingChar" -> "Replace xs with ys"
+      )
+  }.await
+
+  refresh("normalizer")
+  blockUntilCount(1, "normalizer")
+
+  "custom Normalizer" - {
+    "should apply a lowercase filter " in {
+      client.execute {
+        // normalizers are applied on search as well
+        search("normalizer" / "test") query termQuery("keywordLowercase" -> "VERYMUCHMIXEDCASE")
+      }.await.totalHits shouldBe 1
+      client.execute {
+        search("normalizer" / "test") query termQuery("keywordLowercase" -> "verymuchmixedcase")
+      }.await.totalHits shouldBe 1
+    }
+
+    "should apply a token filter and a character filter" in {
+      client.execute {
+        search("normalizer" / "test") query termQuery("keywordUppercaseMappingChar" -> "REPLACE XS WITH YS")
+      }.await.totalHits shouldBe 0
+      client.execute {
+        search("normalizer" / "test") query termQuery("keywordUppercaseMappingChar" -> "REPLACE YS WITH YS")
+      }.await.totalHits shouldBe 1
+    }
+  }
+
+
+}

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/indexes/CreateIndexApiTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/indexes/CreateIndexApiTest.scala
@@ -93,7 +93,7 @@ class CreateIndexApiTest extends FlatSpec with MockitoSugar with JsonSugar with 
     CreateIndexContentBuilder(req).string() should matchJsonResource("/json/createindex/createindex_stop_path.json")
   }
 
-  it should "support custom analyzers, tokenizers and filters" in {
+  it should "support custom analyzers, normalizers, tokenizers and filters" in {
     val req = createIndex("users").analysis(
       PatternAnalyzerDefinition("patternAnalyzer", regex = "[a-z]"),
       SnowballAnalyzerDefinition("mysnowball", lang = "english", stopwords = Seq("stop1", "stop2", "stop3")),
@@ -132,6 +132,9 @@ class CreateIndexApiTest extends FlatSpec with MockitoSugar with JsonSugar with 
       CustomAnalyzerDefinition(
         "myAnalyzer5",
         NGramTokenizer("myTokenizer5", minGram = 4, maxGram = 18, tokenChars = Seq("letter", "punctuation")))
+    ).normalizers(
+      CustomNormalizerDefinition("myNormalizer1", LowercaseTokenFilter),
+      CustomNormalizerDefinition("myNormalizer2", UppercaseTokenFilter, MappingCharFilter("mapping_charfilter2", "x" -> "y"))
     )
     CreateIndexContentBuilder(req).string() should matchJsonResource("/json/createindex/createindex_analyis2.json")
   }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/mappings/MappingTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/mappings/MappingTest.scala
@@ -13,10 +13,13 @@ class MappingTest extends WordSpec with ElasticSugar with Matchers {
     createIndex("q").mappings {
       mapping("r") as Seq(
         field("a", TextType) stored true analyzer WhitespaceAnalyzer,
-        field("b", TextType)
+        field("b", TextType),
+        field("kw", KeywordType) normalizer "my_normalizer"
       )
     } analysis {
       CustomAnalyzerDefinition("my_analyzer", WhitespaceTokenizer, LowercaseTokenFilter)
+    } normalizers {
+      CustomNormalizerDefinition("my_normalizer", LowercaseTokenFilter)
     }
   }.await
 
@@ -44,6 +47,10 @@ class MappingTest extends WordSpec with ElasticSugar with Matchers {
 
       val b = map.get("properties").asInstanceOf[util.Map[String, Any]].get("b").asInstanceOf[util.Map[String, Any]]
       b.get("type") shouldBe "text"
+
+      val kw = map.get("properties").asInstanceOf[util.Map[String, Any]].get("kw").asInstanceOf[util.Map[String, Any]]
+      kw.get("type") shouldBe "keyword"
+      kw.get("normalizer") shouldBe "my_normalizer"
     }
     "support getting all mappings" in {
       client.execute {


### PR DESCRIPTION
I implemented the new normalizer API https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-normalizers.html

I don't know if you want to integrate it since it's still marked as experimental but I did it anyway.

The only non-backwards compatible difference is that calling .analysis(...) twice will now append the analyzers instead of overwriting them, I don't know if this could be a problem, feel free to take and/or modify the code as needed