### PR TITLE
#788 add support for aliasExists check in Http DSL

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/admin/IndexAdminApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/admin/IndexAdminApi.scala
@@ -29,6 +29,8 @@ trait IndexAdminApi {
 
   def indexExists(index: String): IndexExistsDefinition = IndexExistsDefinition(index)
 
+  def aliasExists(alias: String): AliasExistsDefinition = AliasExistsDefinition(alias)
+
   def clearCache(first: String, rest: String*): ClearCacheDefinition = clearCache(first +: rest)
   def clearCache(indexes: Iterable[String]): ClearCacheDefinition = ClearCacheDefinition(indexes.toSeq)
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/admin/domain.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/admin/domain.scala
@@ -9,6 +9,7 @@ case class CloseIndexDefinition(indexes: Indexes)
 case class GetSegmentsDefinition(indexes: Indexes)
 case class IndexExistsDefinition(index: String)
 case class TypesExistsDefinition(indexes: Seq[String], types: Seq[String])
+case class AliasExistsDefinition(alias: String)
 case class IndicesStatsDefinition(indexes: Indexes)
 
 case class ClearCacheDefinition(indexes: Seq[String],

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/IndexAdminImplicits.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/IndexAdminImplicits.scala
@@ -27,6 +27,10 @@ case class IndexExistsResponse(exists: Boolean) {
   def isExists: Boolean = exists
 }
 
+case class AliasExistsResponse(exists: Boolean) {
+  def isExists: Boolean = exists
+}
+
 case class ClearCacheResponse(_shards: Shards) {
   def shards: Shards = _shards
 }
@@ -86,6 +90,17 @@ trait IndexAdminImplicits extends IndexShowImplicits {
       logger.debug(s"Connecting to $endpoint for type exists check")
       val resp = client.performRequest("HEAD", endpoint)
       Future.successful(TypeExistsResponse(resp.getStatusLine.getStatusCode == 200))
+    }
+  }
+
+  implicit object AliasExistsExecutable extends HttpExecutable[AliasExistsDefinition, AliasExistsResponse] {
+    override def execute(client: RestClient,
+                         request: AliasExistsDefinition,
+                         format: JsonFormat[AliasExistsResponse]): Future[AliasExistsResponse] = {
+      val endpoint = s"/_alias/${request.alias}"
+      logger.debug(s"Connecting to $endpoint for alias exists check")
+      val resp = client.performRequest("HEAD", endpoint)
+      Future.successful(AliasExistsResponse(resp.getStatusLine.getStatusCode == 200))
     }
   }
 


### PR DESCRIPTION
I noticed there are no (medium) tests for the HttpClient so far. 
Is this intended? If not I will start and write the first one for this endpoint. 