### PR TITLE
Make isTerminatedEarly optional to reflect internal API

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/responses.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/responses.scala
@@ -107,7 +107,7 @@ trait AggregationResponse {
 
 case class SearchResponse(took: Int,
                           private val timed_out: Boolean,
-                          private val terminated_early: Boolean,
+                          private val terminated_early: Option[Boolean],
                           private val suggest: Map[String, Seq[SuggestionResult]],
                           private val _shards: Shards,
                           private val _scroll_id: String,
@@ -125,7 +125,7 @@ case class SearchResponse(took: Int,
   def shards: Shards = _shards
 
   def isTimedOut: Boolean = timed_out
-  def isTerminatedEarly: Boolean = terminated_early
+  def isTerminatedEarly: Option[Boolean] = terminated_early
 
   def isEmpty: Boolean = hits.isEmpty
   def nonEmpty: Boolean = hits.nonEmpty

--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/RichSearchResponse.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/RichSearchResponse.scala
@@ -45,7 +45,7 @@ case class RichSearchResponse(original: SearchResponse) {
   def phraseSuggestion(name: String): PhraseSuggestionResult = suggestion(name).asInstanceOf[PhraseSuggestionResult]
 
   def isTimedOut: Boolean = original.isTimedOut
-  def isTerminatedEarly: Boolean = original.isTerminatedEarly
+  def isTerminatedEarly: Option[Boolean] = Option[java.lang.Boolean](original.isTerminatedEarly).map(_.booleanValue())
 
   @deprecated("use resp.aggregations, or resp.original.getAggregations", "2.0.0")
   def getAggregations = original.getAggregations


### PR DESCRIPTION
I ran into a NullPointerException and noticed it's because `terminatedEarly` [is actually an optional boolean internally](https://github.com/elastic/elasticsearch/blob/f9d9b74f0fb6d9be39d27f658479556230ecd8c1/core/src/main/java/org/elasticsearch/search/internal/InternalSearchResponse.java#L139).

Also, in case you're wondering why the awkward conversion from `java.lang.Boolean`, it's because `Predef.Boolean2boolean` isn't null-safe. I learned something new today.