### PR TITLE
minor Circe improvements

### DIFF
--- a/elastic4s-circe/src/main/scala/com/sksamuel/elastic4s/circe/package.scala
+++ b/elastic4s-circe/src/main/scala/com/sksamuel/elastic4s/circe/package.scala
@@ -33,7 +33,7 @@ package object circe {
   @implicitNotFound(
     "No Decoder for type ${T} found. Use 'import io.circe.generic.auto._' or provide an implicit Decoder instance ")
   implicit def jsonFormatWithCirce[T](implicit decoder: Decoder[T]): JsonFormat[T] = new JsonFormat[T] {
-    override def fromJson(json: String): T = decode[T](json).right.get
+    override def fromJson(json: String): T = decode[T](json).fold(throw _, identity)
   }
 
   @implicitNotFound(
@@ -44,7 +44,7 @@ package object circe {
 
   @implicitNotFound(
     "No Encoder for type ${T} found. Use 'import io.circe.generic.auto._' or provide an implicit Encoder instance ")
-  implicit def indexableWithCirce[T](implicit encoder: Encoder[T]): Indexable[T] = new Indexable[T] {
-    override def json(t: T): String = encoder(t).noSpaces
+  implicit def indexableWithCirce[T](implicit encoder: Encoder[T], printer: Json => String = Printer.noSpaces.pretty): Indexable[T] = new Indexable[T] {
+    override def json(t: T): String = printer(encoder(t))
   }
 }


### PR DESCRIPTION
The `jsonFormatWithCirce` is currently doing `.right.get` which in case of problems with decoding just throws `NoSuchElementException("Either.right.value on Left")` which is not very informative. `fold(throw _, identity)` will throw the underlying Circe exception with information about what went wrong.

In the `indexableWithCirce` the parameter `printer: Json => String = Printer.noSpaces.pretty` allows to customize JSON encoding, like dropping `None` / `null` values, for example:
```
implicit val myJsonPrinter: Json => String = Printer.noSpaces.copy(dropNullKeys = true).pretty

esClient execute { 
  indexInto(index, documentType)
    .doc(doc)
    .id(doc.id)
}
```