### PR TITLE
Add raw query support to HTTP

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/SearchDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/SearchDefinition.scala
@@ -58,9 +58,7 @@ case class SearchDefinition(indexesTypes: IndexesAndTypes,
 
   def minScore(min: Double): SearchDefinition = copy(minScore = min.some)
 
-  def types(first: String, rest: String*): SearchDefinition =
-    copy(indexesTypes = IndexesAndTypes(indexesTypes.indexes, first +: rest))
-
+  def types(first: String, rest: String*): SearchDefinition = types(first +: rest)
   def types(types: Iterable[String]): SearchDefinition =
     copy(indexesTypes = IndexesAndTypes(indexesTypes.indexes, types.toSeq))
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/SearchDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/SearchDefinition.scala
@@ -58,7 +58,9 @@ case class SearchDefinition(indexesTypes: IndexesAndTypes,
 
   def minScore(min: Double): SearchDefinition = copy(minScore = min.some)
 
-  def types(first: String, rest: String*): SearchDefinition = copy(first +: rest)
+  def types(first: String, rest: String*): SearchDefinition =
+    copy(indexesTypes = IndexesAndTypes(indexesTypes.indexes, first +: rest))
+
   def types(types: Iterable[String]): SearchDefinition =
     copy(indexesTypes = IndexesAndTypes(indexesTypes.indexes, types.toSeq))
 

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/RawQueryBodyFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/RawQueryBodyFn.scala
@@ -1,0 +1,16 @@
+package com.sksamuel.elastic4s.http.search
+
+import com.sksamuel.elastic4s.searches.queries.RawQueryDefinition
+import org.elasticsearch.common.xcontent.{NamedXContentRegistry, XContentBuilder, XContentFactory, XContentType}
+
+object RawQueryBodyFn {
+  def apply(q: RawQueryDefinition): XContentBuilder = {
+    val builder = XContentFactory.jsonBuilder()
+    val parser = XContentFactory.xContent(XContentType.JSON).createParser(NamedXContentRegistry.EMPTY, q.json)
+    try {
+      builder.copyCurrentStructure(parser)
+    } finally {
+      parser.close()
+    }
+  }
+}

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/QueryBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/QueryBuilderFn.scala
@@ -1,5 +1,6 @@
 package com.sksamuel.elastic4s.http.search.queries
 
+import com.sksamuel.elastic4s.http.search.RawQueryBodyFn
 import com.sksamuel.elastic4s.http.search.queries.compound.{BoolQueryBuilderFn, BoostingQueryBodyFn, ConstantScoreBodyFn, DisMaxQueryBodyFn}
 import com.sksamuel.elastic4s.http.search.queries.geo.{GeoBoundingBoxQueryBodyFn, GeoDistanceQueryBodyFn, GeoPolyonQueryBodyFn}
 import com.sksamuel.elastic4s.http.search.queries.nested.{HasChildBodyFn, HasParentBodyFn, NestedQueryBodyFn, ParentIdQueryBodyFn}
@@ -40,6 +41,7 @@ object QueryBuilderFn {
     case q: PrefixQueryDefinition => PrefixQueryBodyFn(q)
     case q: QueryStringQueryDefinition => QueryStringBodyFn(q)
     case r: RangeQueryDefinition => RangeQueryBodyFn(r)
+    case q: RawQueryDefinition => RawQueryBodyFn(q)
     case q: RegexQueryDefinition => RegexQueryBodyFn(q)
     case q: ScriptQueryDefinition => ScriptQueryBodyFn(q)
     case s: SimpleStringQueryDefinition => SimpleStringBodyFn(s)


### PR DESCRIPTION
This also fixes a bug with `def types(first: String, rest: String*)` where the types were being inserted in the wrong place in `IndexesAndTypes`