### PR TITLE
Add implicit codec when converting a http response to a string

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/HttpClient.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/HttpClient.scala
@@ -7,7 +7,7 @@ import org.apache.http.HttpHost
 import org.elasticsearch.client.{Response, ResponseException, ResponseListener, RestClient}
 
 import scala.concurrent.{Future, Promise}
-import scala.io.Source
+import scala.io.{Codec, Source}
 import scala.util.{Failure, Try}
 
 trait HttpClient extends Logging {
@@ -74,7 +74,7 @@ trait HttpExecutable[T, U] extends Logging {
   // is then marshalled into the type U
   protected def executeAsyncAndMapResponse(listener: ResponseListener => Any,
                                            format: JsonFormat[U],
-                                           failureHandler: Exception => Try[U]): Future[U] = {
+                                           failureHandler: Exception => Try[U])(implicit codec: Codec): Future[U] = {
     val p = Promise[U]()
     listener(new ResponseListener {
 


### PR DESCRIPTION
## Goal

Define the `scala.io.Codec` ( string encoding ) that should be used when converting
a http response to a string.

## Fixes

When your `defaultCharset` defined in `scala.io.Codec` doesn't match the http response encoding.
