### PR TITLE
HttpClient Configuration

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/HttpClient.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/HttpClient.scala
@@ -3,8 +3,12 @@ package com.sksamuel.elastic4s.http
 import cats.Show
 import com.sksamuel.elastic4s.{ElasticsearchClientUri, JsonFormat}
 import com.sksamuel.exts.Logging
-import org.apache.http.HttpHost
 import org.elasticsearch.client.{Response, ResponseException, ResponseListener, RestClient}
+import org.elasticsearch.client.RestClientBuilder.{RequestConfigCallback, HttpClientConfigCallback}
+
+import org.apache.http.HttpHost
+import org.apache.http.client.config.RequestConfig
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder
 
 import scala.concurrent.{Future, Promise}
 import scala.io.Source
@@ -49,10 +53,18 @@ object HttpClient extends Logging {
     override def rest: RestClient = client
   }
 
-  def apply(uri: ElasticsearchClientUri): HttpClient = {
+  def apply(
+    uri: ElasticsearchClientUri,
+    requestConfigCallback: RequestConfigCallback = NoOpRequestConfigCallback,
+    httpClientConfigCallback: HttpClientConfigCallback = NoOpHttpClientConfigCallback
+  ): HttpClient = {
     val hosts = uri.hosts.map { case (host, port) => new HttpHost(host, port, "http") }
     logger.info(s"Creating HTTP client on ${hosts.mkString(",")}")
-    val client = RestClient.builder(hosts: _*).build()
+    val client = RestClient.builder(hosts: _*)
+      .setRequestConfigCallback(requestConfigCallback)
+      .setHttpClientConfigCallback(httpClientConfigCallback)
+      .build()
+
     HttpClient.fromRestClient(client)
   }
 }
@@ -105,5 +117,31 @@ trait HttpExecutable[T, U] extends Logging {
         }
       case _ => Failure(e)
     }
+  }
+}
+
+ /**
+   * RequestConfigCallback that performs a no-op on the given RequestConfig.Builder.
+   *
+   * Used as a default parameter to the HttpClient when no custom request
+   * configuration is needed.
+   *
+   */
+object NoOpRequestConfigCallback extends RequestConfigCallback {
+  override def customizeRequestConfig(requestConfigBuilder: RequestConfig.Builder): RequestConfig.Builder = {
+      requestConfigBuilder
+  }
+}
+
+ /**
+   * HttpAsyncClientBuilder that performs a no-op on the given HttpAsyncClientBuilder
+   *
+   * Used as a default parameter to the HttpClient when no custom HttpAsync
+   * configuration is needed.
+   *
+   */
+object NoOpHttpClientConfigCallback extends HttpClientConfigCallback {
+  override def customizeHttpClient(httpAsyncClientBuilder: HttpAsyncClientBuilder): HttpAsyncClientBuilder = {
+    httpAsyncClientBuilder
   }
 }


### PR DESCRIPTION
### Motivation
Adds the functionality described by elasticsearch here: https://www.elastic.co/guide/en/elasticsearch/client/java-rest/current/_common_configuration.html

Allows users to optionally configure the `RestClient` being defined within the `HttpClient` by defining their own version of a `...Callback` `trait`.

Configurations includes things like connection timeouts, connection request timeouts, max number of available connections, etc.

### Implementation Notes
I didn't know the best way (or the preferred way) to do this so here were my thoughts:

I made the callbacks parameters on the only existing `apply` to the `HttpClient` and gave them optional values that just perform no-ops (i.e. the callback just returns the given builder).

I did this as an easy way to not write more than one `apply` while making providing the callbacks optional.

The drawback is that callbacks are always called (even if they're doing nothing).

Another way I thought of implementing this was to pass the callbacks in as `Option` values and then perform the "setters" in mutation fashion on the `RestClientBuilder` like so:

```
  def apply(
    uri: ElasticsearchClientUri,
    requestConfigCallback: Option[RequestConfigCallback] = None,
    httpClientConfigCallback: Option[HttpClientConfigCallback] = None
  ): HttpClient = {
    val hosts = uri.hosts.map { case (host, port) => new HttpHost(host, port, "http") }
    logger.info(s"Creating HTTP client on ${hosts.mkString(",")}")
    val clientBuilder = RestClient.builder(hosts: _*)

    requestConfigCallback.foreach(clientBuilder.setRequestConfigCallback)
    httpClientConfigCallback.foreach(clientBuilder.setHttpClientConfigCallback)

    HttpClient.fromRestClient(clientBuilder.build())
  }
```

which wouldn't require the no-ops but would have code that looks like mutation.

Happy to change it to this, or to anything suggested!