### PR TITLE
DateHistogramAggregation support for HttpClient

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/AggregationBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/AggregationBuilderFn.scala
@@ -15,6 +15,7 @@ object AggregationBuilderFn {
       case agg: SumAggregationDefinition => SumAggregationBuilder(agg)
       case agg: TermsAggregationDefinition => TermsAggregationBuilder(agg)
       case agg: ValueCountAggregationDefinition => ValueCountAggregationBuilder(agg)
+      case agg: DateHistogramAggregation => DateHistogramAggregationBuilder(agg)
     }
     builder
   }

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/DateHistogramAggregationBuilder.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/DateHistogramAggregationBuilder.scala
@@ -1,0 +1,29 @@
+package com.sksamuel.elastic4s.http.search.aggs
+
+import com.sksamuel.elastic4s.http.ScriptBuilderFn
+import com.sksamuel.elastic4s.searches.aggs.DateHistogramAggregation
+import org.elasticsearch.common.xcontent.{XContentBuilder, XContentFactory}
+
+object DateHistogramAggregationBuilder {
+  def apply(agg: DateHistogramAggregation): XContentBuilder = {
+    val builder = XContentFactory.jsonBuilder()
+    builder.startObject()
+    builder.startObject("date_histogram")
+    agg.interval.foreach(builder.field("interval", _))
+    agg.minDocCount.foreach(builder.field("min_doc_count", _))
+    agg.timeZone.foreach(builder.field("time_zone", _))
+    agg.order.foreach(builder.field("order", _))
+    agg.offset.foreach(builder.field("offset", _))
+    agg.format.foreach(builder.field("format", _))
+    agg.field.foreach(builder.field("field", _))
+    agg.script.foreach { script =>
+      builder.rawField("script", ScriptBuilderFn(script).bytes)
+    }
+    agg.missing.foreach(builder.field("missing", _))
+    agg.extendedBounds.foreach(builder.field("extended_bounds", _))
+    builder.endObject()    
+    SubAggsBuilderFn(agg, builder)
+    AggMetaDataFn(agg, builder)
+    builder.endObject()
+  }
+}


### PR DESCRIPTION
I need to use date_histogram_aggregation in a query but it turned out that a builder object for this particular aggregation was not implemented yet. Luckily it was quite easy to implement taking existing builders as example.
