### PR TITLE
Snapshot test suggestion

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,9 +28,11 @@ lazy val root = Project("elastic4s", file("."))
 
 lazy val core = Project("elastic4s-core", file("elastic4s-core"))
   .settings(name := "elastic4s-core")
+  .settings(resolvers += Resolver.bintrayRepo("commodityvectors", "commodityvectors-releases"))
   .settings(libraryDependencies ++= Seq(
     "org.locationtech.spatial4j"    % "spatial4j"     % "0.6",
     "com.vividsolutions"            % "jts"           % "1.13",
+    "com.commodityvectors"          %% "scalatest-snapshot-matcher-core" % "2.0.0" % "test",
     "com.fasterxml.jackson.core"    % "jackson-core"            % JacksonVersion        % "test",
     "com.fasterxml.jackson.core"    % "jackson-databind"        % JacksonVersion        % "test",
     "com.fasterxml.jackson.module"  %% "jackson-module-scala"   % JacksonVersion        % "test" exclude("org.scala-lang", "scala-library")

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ lazy val core = Project("elastic4s-core", file("elastic4s-core"))
     "com.fasterxml.jackson.core"    % "jackson-core"            % JacksonVersion        % "test",
     "com.fasterxml.jackson.core"    % "jackson-databind"        % JacksonVersion        % "test",
     "com.fasterxml.jackson.module"  %% "jackson-module-scala"   % JacksonVersion        % "test" exclude("org.scala-lang", "scala-library")
-  ))
+  )).settings(connectInput in Test := true)
 
 lazy val tcp = Project("elastic4s-tcp", file("elastic4s-tcp"))
   .settings(name := "elastic4s-tcp")

--- a/elastic4s-core/src/test/__snapshots__/com/sksamuel/elastic4s/mappings/MappingDefinitionDslTest/mapping-definition-should-include-timestamp-store-field.snap
+++ b/elastic4s-core/src/test/__snapshots__/com/sksamuel/elastic4s/mappings/MappingDefinitionDslTest/mapping-definition-should-include-timestamp-store-field.snap
@@ -1,0 +1,11 @@
+{
+  "mappings" : {
+    "foo" : {
+      "_timestamp" : {
+        "enabled" : true,
+        "path" : "mypath",
+        "store" : "yes"
+      }
+    }
+  }
+}

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/JsonSugar.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/JsonSugar.scala
@@ -1,12 +1,25 @@
 package com.sksamuel.elastic4s
 
-import com.fasterxml.jackson.databind.ObjectMapper
+import com.commodityvectors.snapshotmatchers.SnapshotSerializer
+import com.fasterxml.jackson.databind.{ObjectMapper, SerializationFeature}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import org.elasticsearch.common.xcontent.XContentBuilder
 import org.scalatest.Matchers
 import org.scalatest.matchers.{MatchResult, Matcher}
 
 trait JsonSugar extends Matchers {
+
+  implicit lazy val xContentSerializer = new SnapshotSerializer[XContentBuilder] {
+    val mapper = new ObjectMapper with ScalaObjectMapper
+    mapper.registerModule(DefaultScalaModule)
+    mapper.enable(SerializationFeature.INDENT_OUTPUT)
+
+    override def serialize(in: XContentBuilder): String = {
+      val json = mapper.readTree(in.string())
+      mapper.writerWithDefaultPrettyPrinter().writeValueAsString(json)
+    }
+  }
 
   protected val mapper = new ObjectMapper with ScalaObjectMapper
   mapper.registerModule(DefaultScalaModule)

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/mappings/MappingDefinitionDslTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/mappings/MappingDefinitionDslTest.scala
@@ -1,61 +1,68 @@
 package com.sksamuel.elastic4s.mappings
 
+import java.io.{StringWriter, Writer}
+
+import com.commodityvectors.snapshotmatchers.SnapshotMatcher
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter
+import com.fasterxml.jackson.databind.{ObjectMapper, SerializationFeature}
+import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
 import com.sksamuel.elastic4s.{ElasticApi, JsonSugar}
 import com.sksamuel.elastic4s.analyzers.{EnglishLanguageAnalyzer, SpanishLanguageAnalyzer}
 import com.sksamuel.elastic4s.indexes.CreateIndexContentBuilder
-import org.scalatest.{Matchers, WordSpec}
+import org.elasticsearch.common.xcontent.XContentBuilder
+import org.scalatest.{Matchers, WordSpec, fixture}
 
-class MappingDefinitionDslTest extends WordSpec with Matchers with JsonSugar with ElasticApi {
+class MappingDefinitionDslTest extends fixture.WordSpec with Matchers with JsonSugar with ElasticApi with SnapshotMatcher {
 
   "mapping definition" should {
-    "insert source exclusion directives when set" in {
+    "insert source exclusion directives when set" in { implicit test =>
       val mapping = MappingDefinition("test").sourceExcludes("excludeMe1", "excludeMe2")
       val output = MappingContentBuilder.build(mapping).string()
       output should include(""""_source":{"excludes":["excludeMe1","excludeMe2"]}""")
     }
-    "insert source exclusion directives when set and override enabled directive" in {
+    "insert source exclusion directives when set and override enabled directive" in { implicit test =>
       val mapping = MappingDefinition("test").sourceExcludes("excludeMe1", "excludeMe2").source(true)
       val output = MappingContentBuilder.build(mapping).string()
       output should include(""""_source":{"excludes":["excludeMe1","excludeMe2"]}""")
       output should not include """"enabled":true"""
     }
-    "insert source enabling" in {
+    "insert source enabling" in { implicit test =>
       val mapping = MappingDefinition("test").source(false)
       val output = MappingContentBuilder.build(mapping).string()
       output should not include """"_source":{"excludes":["excludeMe1","excludeMe2"]}"""
       output should include(""""enabled":false""")
     }
-    "not insert date detection by default" in {
+    "not insert date detection by default" in { implicit test =>
       val mapping = MappingDefinition("type")
       val output = MappingContentBuilder.build(mapping).string()
       output should not include "date"
     }
-    "insert date detection when set to true" in {
+    "insert date detection when set to true" in { implicit test =>
       val mapping = MappingDefinition("type").dateDetection(true)
       val output = MappingContentBuilder.build(mapping).string()
       output should include("""date_detection":true""")
     }
-    "insert date detection when set to false" in {
+    "insert date detection when set to false" in { implicit test =>
       val mapping = MappingDefinition("type").dateDetection(false)
       val output = MappingContentBuilder.build(mapping).string()
       output should include("""date_detection":false""")
     }
-    "not insert numeric detection by default" in {
+    "not insert numeric detection by default" in { implicit test =>
       val mapping = MappingDefinition("type")
       val output = MappingContentBuilder.build(mapping).string()
       output should not include "numeric"
     }
-    "insert numeric detection when set to true" in {
+    "insert numeric detection when set to true" in { implicit test =>
       val mapping = MappingDefinition("type").numericDetection(true)
       val output = MappingContentBuilder.build(mapping).string()
       output should include("""numeric_detection":true""")
     }
-    "insert numeric detection when set to false" in {
+    "insert numeric detection when set to false" in { implicit test =>
       val mapping = MappingDefinition("type").numericDetection(false)
       val output = MappingContentBuilder.build(mapping).string()
       output should include("""numeric_detection":false""")
     }
-    "include dynamic templates" in {
+    "include dynamic templates" in { implicit test =>
       val req = createIndex("docsAndTags").mappings(
         mapping("my_type") templates(
           dynamicTemplate("es", textField("") analyzer SpanishLanguageAnalyzer) matchPattern "regex" matching "*_es" matchMappingType "string",
@@ -64,7 +71,7 @@ class MappingDefinitionDslTest extends WordSpec with Matchers with JsonSugar wit
       )
       CreateIndexContentBuilder(req).string() should matchJsonResource("/json/mappings/mappings_with_dyn_templates.json")
     }
-    "include timestamp path field" in {
+    "include timestamp path field" in { implicit test =>
       val req = createIndex("docsAndTags").mappings(
         mapping ("foo") timestamp {
           timestamp(true) path "mypath" store true
@@ -72,15 +79,16 @@ class MappingDefinitionDslTest extends WordSpec with Matchers with JsonSugar wit
       )
       CreateIndexContentBuilder(req).string() should matchJsonResource("/json/mappings/timestamp_path.json")
     }
-    "include timestamp store field" in {
+    "include timestamp store field" in { implicit test =>
       val req = createIndex("docsAndTags").mappings(
         mapping("foo") timestamp {
           timestamp(true) path "mypath" store true
         }
       )
-      CreateIndexContentBuilder(req).string() should matchJsonResource("/json/mappings/timestamp_store.json")
+
+      CreateIndexContentBuilder(req) should matchSnapshot[XContentBuilder]()
     }
-    "include timestamp format field" in {
+    "include timestamp format field" in { implicit test =>
       val req = createIndex("docsAndTags").mappings(
         mapping("foo") timestamp {
           timestamp(true) format "qwerty"
@@ -88,7 +96,7 @@ class MappingDefinitionDslTest extends WordSpec with Matchers with JsonSugar wit
       )
       CreateIndexContentBuilder(req).string() should matchJsonResource("/json/mappings/timestamp_format.json")
     }
-    "include honor disabled timestamp" in {
+    "include honor disabled timestamp" in { implicit test =>
       val req = createIndex("docsAndTags").mappings(
         mapping("foo") timestamp {
           timestamp(false)


### PR DESCRIPTION
Hey @sksamuel.

Just a test change suggestion. Would like to know what do you think.

Start using snapshot matcher in favor of match json resource and simple json string match.

I put a commend on the test that actually is using this matcher.

You can find more info here: https://github.com/commodityvectors/scalatest-snapshot-matchers