### PR TITLE
Wrong field name in QueryStringBodyFn

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/text/QueryStringBodyFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/text/QueryStringBodyFn.scala
@@ -24,7 +24,7 @@ object QueryStringBodyFn {
     s.boost.map(_.toString).foreach(builder.field("boost", _))
     s.quoteFieldSuffix.map(_.toString).foreach(builder.field("quote_field_suffix", _))
     s.splitOnWhitespace.map(_.toString).foreach(builder.field("split_on_whitespace", _))
-    s.tieBreaker.map(_.toString).foreach(builder.field("allow_leading_wildcard", _))
+    s.tieBreaker.foreach(builder.field("tie_breaker", _))
     s.rewrite.map(_.toString).foreach(builder.field("rewrite", _))
 
     if (s.fields.nonEmpty) {


### PR DESCRIPTION
The "allow_leading_wildcard" field name is used twice, instead of "tie_breaker". Also it's a double and should not be wrapped in quotes. TBH all the .toString maps above should also be removed (field method has all the necessary overloads, and knows better how to serialize it), but limiting changes to just this bug.