### PR TITLE
Fixes 'type' and 'matched_fields' for highlight query.

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/SearchBodyBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/SearchBodyBuilderFn.scala
@@ -52,7 +52,10 @@ object SearchBodyBuilderFn {
           field.highlightQuery.map(QueryBuilderFn.apply).map(_.bytes()).foreach { highlight =>
             builder.rawField("highlight_query", highlight, XContentType.JSON)
           }
-          field.matchedFields.foreach(builder.field("matched_fields", _))
+          if (field.matchedFields.nonEmpty) {
+            builder.field("matched_fields", field.matchedFields.asJava)
+          }
+          field.highlighterType.foreach(builder.field("type", _))
           field.noMatchSize.foreach(builder.field("no_match_size", _))
           field.numOfFragments.foreach(builder.field("number_of_fragments", _))
           field.order.foreach(builder.field("order", _))

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/SearchBodyFnTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/SearchBodyFnTest.scala
@@ -1,0 +1,25 @@
+package com.sksamuel.elastic4s.http.search.queries
+
+import org.scalatest.{FunSuite, Matchers}
+import com.sksamuel.elastic4s.http.ElasticDsl._
+import com.sksamuel.elastic4s.http.search.SearchBodyBuilderFn
+
+class SearchBodyFnTest extends FunSuite with Matchers {
+
+  test("highlight with 'matchedMatchedFields' generates proper 'matched_fields' field as array field.") {
+    val request = search("example" / "1") highlighting {
+      highlight("text")
+      .matchedFields("text", "text.ngram", "text.japanese")
+    }
+    SearchBodyBuilderFn(request).string() shouldBe
+      "{\"highlight\":{\"fields\":{\"text\":{\"matched_fields\":[\"text\",\"text.ngram\",\"text.japanese\"]}}}}"
+  }
+  test("highlight with 'highlighterType' generates 'type' field.") {
+    val request = search("example" / "1") highlighting {
+      highlight("text")
+        .highlighterType("fvh")
+    }
+    SearchBodyBuilderFn(request).string() shouldBe
+      "{\"highlight\":{\"fields\":{\"text\":{\"type\":\"fvh\"}}}}"
+  }
+}


### PR DESCRIPTION
This PR will fix query for highlighting.

Problems are 
- `type` is ignored.
- Multiple `matched_fields` are generated.(such like `{ "matched_fields": "text", "matched_fields": "text.japanese" }`)