### PR TITLE
Fix dependency issue with tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,10 @@ lazy val tcp = Project("elastic4s-tcp", file("elastic4s-tcp"))
 
 lazy val http = Project("elastic4s-http", file("elastic4s-http"))
   .settings(name := "elastic4s-http")
-    .settings(libraryDependencies += "org.elasticsearch.client" % "rest" % ElasticsearchVersion)
+    .settings(libraryDependencies ++= Seq(
+      "org.elasticsearch.client"    % "rest"        % ElasticsearchVersion,
+      "org.apache.logging.log4j"    % "log4j-api"   % Log4jVersion  % "test"
+    ))
   .dependsOn(core)
 
 lazy val xpacksecurity = Project("elastic4s-xpack-security", file("elastic4s-xpack-security"))


### PR DESCRIPTION
I'm a bit confusing… my previous PR #879 broke the tests on Travis-CI :/

It seems that log4j dependency is missing with tests.

```
[info] com.sksamuel.elastic4s.http.search.aggs.RangeAggregationBuilderTest *** ABORTED ***
[info]   java.lang.NoClassDefFoundError: org/apache/logging/log4j/Logger
[info]   at org.elasticsearch.common.logging.Loggers.getLogger(Loggers.java:101)
[info]   at org.elasticsearch.common.ParseField.<clinit>(ParseField.java:35)
[info]   at org.elasticsearch.script.ScriptType.<clinit>(ScriptType.java:43)
[info]   at com.sksamuel.elastic4s.script.ScriptDefinition$.apply$default$3(ScriptDefinition.scala:9)
[...]
```


This problem is quite weird.
I added the dependency, I'm not sure it's the best solution.