### PR TITLE
Fix spray-json method names

### DIFF
--- a/elastic4s-spray-json/src/main/scala/com/sksamuel/elastic4s/sprayjson/package.scala
+++ b/elastic4s-spray-json/src/main/scala/com/sksamuel/elastic4s/sprayjson/package.scala
@@ -15,12 +15,12 @@ package object sprayjson {
   }
 
   @implicitNotFound("No RootJsonWriter for type ${T} found. Bring an implicit RootJsonWriter[T] instance in scope")
-  implicit def playJsonIndexable[T](implicit w: RootJsonWriter[T]) = new Indexable[T] {
+  implicit def sprayJsonIndexable[T](implicit w: RootJsonWriter[T]) = new Indexable[T] {
     override def json(t: T): String = w.write(t).compactPrint
   }
 
   @implicitNotFound("No RootJsonReader for type ${T} found. Bring an implicit RootJsonReader[T] instance in scope")
-  implicit def playJsonHitReader[T](implicit r: RootJsonReader[T]) = new HitReader[T] {
+  implicit def sprayJsonHitReader[T](implicit r: RootJsonReader[T]) = new HitReader[T] {
     override def read(hit: Hit): Either[Throwable, T] = try {
       Right(r.read(hit.sourceAsString.parseJson))
     } catch {


### PR DESCRIPTION
I noticed a copy/paste error with the spray-json module.