### PR TITLE
Exposed format option for RangeQueryDefinition

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/queries/RangeQueryDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/queries/RangeQueryDefinition.scala
@@ -11,6 +11,7 @@ case class RangeQueryDefinition(field: String,
                                 gte: Option[Any] = None,
                                 gt: Option[Any] = None,
                                 lt: Option[Any] = None,
+                                format: Option[String] = None,
                                 queryName: Option[String] = None)
   extends MultiTermQueryDefinition {
 
@@ -33,6 +34,8 @@ case class RangeQueryDefinition(field: String,
 
   def gte(gte: Long): RangeQueryDefinition = copy(gte = gte.some)
   def lte(lte: Long): RangeQueryDefinition = copy(lte = lte.some)
+
+  def format(fmt: String): RangeQueryDefinition = copy(format = fmt.some)
 
   @deprecated("use lte or lt", "5.3.1")
   def includeUpper(includeUpper: Boolean): RangeQueryDefinition = copy(includeUpper = includeUpper.some)

--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/queries/RangeQueryBuilderFn.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/queries/RangeQueryBuilderFn.scala
@@ -11,6 +11,7 @@ object RangeQueryBuilderFn {
     q.lt.foreach(builder.lt)
     q.gte.foreach(builder.gte)
     q.lte.foreach(builder.lte)
+    q.format.foreach(builder.format)
 
 
     q.includeLower.foreach(builder.includeLower)


### PR DESCRIPTION
Added a "format" option for range queries. Based on the [Range Query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html#_date_format_in_range_queries).