### PR TITLE
Field collapsing support

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticApi.scala
@@ -17,6 +17,7 @@ import com.sksamuel.elastic4s.reindex.ReindexApi
 import com.sksamuel.elastic4s.script.ScriptApi
 import com.sksamuel.elastic4s.searches.aggs.AggregationApi
 import com.sksamuel.elastic4s.searches.aggs.pipeline.PipelineAggregationApi
+import com.sksamuel.elastic4s.searches.collapse.CollapseApi
 import com.sksamuel.elastic4s.searches.queries.funcscorer.ScoreApi
 import com.sksamuel.elastic4s.searches.sort.SortApi
 import com.sksamuel.elastic4s.searches.suggestion.SuggestionApi
@@ -38,6 +39,7 @@ trait ElasticApi
     with BulkApi
     with CreateIndexApi
     with ClusterApi
+    with CollapseApi
     with DeleteApi
     with DeleteIndexApi
     with DynamicTemplateApi

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/SearchDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/SearchDefinition.scala
@@ -3,6 +3,7 @@ package com.sksamuel.elastic4s.searches
 import com.sksamuel.elastic4s.IndexesAndTypes
 import com.sksamuel.elastic4s.script.ScriptFieldDefinition
 import com.sksamuel.elastic4s.searches.aggs.AbstractAggregation
+import com.sksamuel.elastic4s.searches.collapse.CollapseDefinition
 import com.sksamuel.elastic4s.searches.queries._
 import com.sksamuel.elastic4s.searches.queries.matches.{MatchAllQueryDefinition, MatchQueryDefinition}
 import com.sksamuel.elastic4s.searches.queries.term.TermQueryDefinition
@@ -18,6 +19,7 @@ import scala.concurrent.duration.{Duration, FiniteDuration}
 
 case class SearchDefinition(indexesTypes: IndexesAndTypes,
                             aggs: Seq[AbstractAggregation] = Nil,
+                            collapse: Option[CollapseDefinition] = None,
                             explain: Option[Boolean] = None,
                             fetchContext: Option[FetchSourceContext] = None,
                             from: Option[Int] = None,
@@ -272,4 +274,6 @@ case class SearchDefinition(indexesTypes: IndexesAndTypes,
 
   def sourceFiltering(includes: Iterable[String], excludes: Iterable[String]): SearchDefinition =
     copy(fetchContext = new FetchSourceContext(true, includes.toArray, excludes.toArray).some)
+
+  def collapse(collapse: CollapseDefinition) = copy(collapse = collapse.some)
 }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/collapse/CollapseApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/collapse/CollapseApi.scala
@@ -1,0 +1,5 @@
+package com.sksamuel.elastic4s.searches.collapse
+
+trait CollapseApi {
+  def collapseField(field: String): CollapseDefinition = CollapseDefinition(field)
+}

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/collapse/CollapseDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/collapse/CollapseDefinition.scala
@@ -1,0 +1,12 @@
+package com.sksamuel.elastic4s.searches.collapse
+
+import com.sksamuel.elastic4s.searches.queries.InnerHitDefinition
+import com.sksamuel.exts.OptionImplicits._
+
+case class CollapseDefinition(field: String,
+                              inner: Option[InnerHitDefinition] = None,
+                              maxConcurrentGroupSearches: Option[Int] = None) {
+
+  def inner(inner: InnerHitDefinition): CollapseDefinition = copy(inner = inner.some)
+  def maxConcurrentGroupSearches(max: Int): CollapseDefinition = copy(maxConcurrentGroupSearches = max.some)
+}

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/SearchBodyBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/SearchBodyBuilderFn.scala
@@ -1,6 +1,7 @@
 package com.sksamuel.elastic4s.http.search
 
 import com.sksamuel.elastic4s.http.search.aggs.AggregationBuilderFn
+import com.sksamuel.elastic4s.http.search.collapse.CollapseBuilderFn
 import com.sksamuel.elastic4s.http.search.queries.{QueryBuilderFn, SortContentBuilder}
 import com.sksamuel.elastic4s.searches.SearchDefinition
 import com.sksamuel.elastic4s.searches.suggestion.TermSuggestionDefinition
@@ -18,6 +19,7 @@ object SearchBodyBuilderFn {
 
     request.query.map(QueryBuilderFn.apply).foreach(x => builder.rawField("query", new BytesArray(x.string), XContentType.JSON))
     request.postFilter.map(QueryBuilderFn.apply).foreach(x => builder.rawField("post_filter", new BytesArray(x.string), XContentType.JSON))
+    request.collapse.map(CollapseBuilderFn.apply).foreach(x => builder.rawField("collapse", new BytesArray(x.string), XContentType.JSON))
 
     if (request.explain.contains(true)) {
       builder.field("explain", true)

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/collapse/CollapseBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/collapse/CollapseBuilderFn.scala
@@ -1,0 +1,22 @@
+package com.sksamuel.elastic4s.http.search.collapse
+
+import com.sksamuel.elastic4s.http.search.queries.nested.InnerHitQueryBodyFn
+import com.sksamuel.elastic4s.searches.collapse.CollapseDefinition
+import org.elasticsearch.common.bytes.BytesArray
+import org.elasticsearch.common.xcontent.{XContentBuilder, XContentFactory, XContentType}
+
+object CollapseBuilderFn {
+
+  def apply(collapse: CollapseDefinition): XContentBuilder = {
+    val builder = XContentFactory.jsonBuilder()
+    builder.startObject()
+    builder.field("field", collapse.field)
+    collapse.maxConcurrentGroupSearches.foreach(max => builder.field("max_concurrent_group_searches", max))
+    collapse
+      .inner
+      .map(InnerHitQueryBodyFn.apply)
+      .foreach(x => builder.rawField("inner_hits", new BytesArray(x.string), XContentType.JSON))
+    builder.endObject()
+    builder
+  }
+}

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/collapse/CollapseBuilderFnTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/collapse/CollapseBuilderFnTest.scala
@@ -1,0 +1,21 @@
+package com.sksamuel.elastic4s.http.search.collapse
+
+import com.sksamuel.elastic4s.searches.collapse.CollapseDefinition
+import com.sksamuel.elastic4s.searches.queries.InnerHitDefinition
+import org.scalatest.{FunSuite, Matchers}
+
+class CollapseBuilderFnTest extends FunSuite with Matchers {
+
+  test("collapse builder should generate simple collapse json") {
+    val c = CollapseDefinition("something")
+    CollapseBuilderFn.apply(c).string shouldBe """{"field":"something"}"""
+  }
+
+  test("collapse builder should support inner hits and max searches") {
+    val c = CollapseDefinition("something")
+      .inner(InnerHitDefinition("name").size(1))
+      .maxConcurrentGroupSearches(8)
+    CollapseBuilderFn.apply(c).string shouldBe
+      """{"field":"something","max_concurrent_group_searches":8,"inner_hits":{"size":1}}"""
+  }
+}

--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/search/SearchImplicits.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/search/SearchImplicits.scala
@@ -5,6 +5,7 @@ import com.sksamuel.elastic4s.Executable
 import com.sksamuel.elastic4s.script.{ScriptFieldDefinition, SortBuilderFn}
 import com.sksamuel.elastic4s.searches._
 import com.sksamuel.elastic4s.searches.aggs.AggregationBuilderFn
+import com.sksamuel.elastic4s.searches.collapse.CollapseBuilderFn
 import com.sksamuel.elastic4s.searches.highlighting.HighlightBuilderFn
 import org.elasticsearch.action.search.{MultiSearchResponse, SearchResponse}
 import org.elasticsearch.client.Client
@@ -60,6 +61,7 @@ trait SearchImplicits {
       search.terminateAfter.foreach(builder.terminateAfter)
       search.timeout.map(dur => TimeValue.timeValueNanos(dur.toNanos)).foreach(builder.timeout)
       search.indexBoosts.foreach { case (index, boost) => builder.indexBoost(index, boost.toFloat) }
+      search.collapse.foreach(c => builder.collapse(CollapseBuilderFn.apply(c)))
 
       if (search.storedFields.nonEmpty)
         builder.storedFields(search.storedFields.asJava)

--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/SearchBuilderFn.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/SearchBuilderFn.scala
@@ -2,6 +2,7 @@ package com.sksamuel.elastic4s.searches
 
 import com.sksamuel.elastic4s.script.{ScriptFieldDefinition, SortBuilderFn}
 import com.sksamuel.elastic4s.searches.aggs.AggregationBuilderFn
+import com.sksamuel.elastic4s.searches.collapse.CollapseBuilderFn
 import com.sksamuel.elastic4s.searches.highlighting.HighlightBuilderFn
 import org.elasticsearch.action.search.SearchRequestBuilder
 import org.elasticsearch.client.Client
@@ -35,6 +36,7 @@ object SearchBuilderFn {
     search.timeout.map(dur => TimeValue.timeValueNanos(dur.toNanos)).foreach(builder.setTimeout)
     search.keepAlive.foreach(builder.setScroll)
     search.version.foreach(builder.setVersion)
+    search.collapse.foreach(c => builder.setCollapse(CollapseBuilderFn.apply(c)))
 
     search.fetchContext.foreach { context =>
       builder.setFetchSource(context.fetchSource)

--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/collapse/CollapseBuilderFn.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/collapse/CollapseBuilderFn.scala
@@ -1,0 +1,13 @@
+package com.sksamuel.elastic4s.searches.collapse
+
+import com.sksamuel.elastic4s.searches.queries.InnerHitBuilder
+import org.elasticsearch.search.collapse.CollapseBuilder
+
+object CollapseBuilderFn {
+  def apply(collapse: CollapseDefinition): CollapseBuilder = {
+    val builder = new CollapseBuilder(collapse.field)
+    collapse.inner.foreach(inner => builder.setInnerHits(InnerHitBuilder.apply(inner)))
+    collapse.maxConcurrentGroupSearches.foreach(builder.setMaxConcurrentGroupRequests)
+    builder
+  }
+}

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/collapse/CollapseHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/collapse/CollapseHttpTest.scala
@@ -17,18 +17,18 @@ class CollapseHttpTest extends FreeSpec with Matchers with SharedElasticSugar wi
     http.execute {
       createIndex("collapse") mappings {
         mapping("hotels") fields(
-          keywordField("name") docValues true,
-          keywordField("board") docValues true
+          keywordField("name"),
+          keywordField("board")
         )
       }
     }.await
 
     http.execute {
       bulk(
-        indexInto("collapse" / "hotels") id "1" fields("name" -> "Ibiza Playa", "board" -> "AI", "price" -> 150),
-        indexInto("collapse" / "hotels") id "2" fields("name" -> "Ibiza Playa", "board" -> "BB", "price" -> 120),
+        indexInto("collapse" / "hotels") id "1" fields("name" -> "Ibiza Playa", "board" -> "AI"),
+        indexInto("collapse" / "hotels") id "2" fields("name" -> "Ibiza Playa", "board" -> "BB"),
 
-        indexInto("collapse" / "hotels") id "3" fields("name" -> "Best Tenerife", "board" -> "AI", "price" -> 220)
+        indexInto("collapse" / "hotels") id "3" fields("name" -> "Best Tenerife", "board" -> "AI")
       ).refresh(RefreshPolicy.IMMEDIATE)
     }.await
   }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/collapse/CollapseHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/collapse/CollapseHttpTest.scala
@@ -1,0 +1,48 @@
+package com.sksamuel.elastic4s.search.collapse
+
+import com.sksamuel.elastic4s.ElasticsearchClientUri
+import com.sksamuel.elastic4s.http.{ElasticDsl, HttpClient}
+import com.sksamuel.elastic4s.jackson.ElasticJackson.Implicits._
+import com.sksamuel.elastic4s.testkit.SharedElasticSugar
+import org.elasticsearch.action.support.WriteRequest.RefreshPolicy
+import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
+
+class CollapseHttpTest extends FreeSpec with Matchers with SharedElasticSugar with ElasticDsl with BeforeAndAfterAll {
+
+  var http: HttpClient = _
+
+  override protected def beforeAll(): Unit = {
+    http = HttpClient(ElasticsearchClientUri("elasticsearch://" + node.ipAndPort))
+
+    http.execute {
+      createIndex("collapse") mappings {
+        mapping("hotels") fields(
+          keywordField("name") docValues true,
+          keywordField("board") docValues true
+        )
+      }
+    }.await
+
+    http.execute {
+      bulk(
+        indexInto("collapse" / "hotels") id "1" fields("name" -> "Ibiza Playa", "board" -> "AI", "price" -> 150),
+        indexInto("collapse" / "hotels") id "2" fields("name" -> "Ibiza Playa", "board" -> "BB", "price" -> 120),
+
+        indexInto("collapse" / "hotels") id "3" fields("name" -> "Best Tenerife", "board" -> "AI", "price" -> 220)
+      ).refresh(RefreshPolicy.IMMEDIATE)
+    }.await
+  }
+
+  "collapse" - {
+    "should be supported in http client" in {
+      val resp = http.execute {
+        search("collapse" / "hotels") collapse {
+          collapseField("board")
+        }
+      }.await
+
+      resp.totalHits shouldBe 3
+      resp.hits.size shouldBe 2
+    }
+  }
+}

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/collapse/CollapseTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/collapse/CollapseTest.scala
@@ -1,0 +1,73 @@
+package com.sksamuel.elastic4s.search.collapse
+
+import com.sksamuel.elastic4s.testkit.ElasticSugar
+import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
+
+class CollapseTest extends FreeSpec with Matchers with ElasticSugar with BeforeAndAfterAll {
+
+  override protected def beforeAll(): Unit = {
+    client.execute {
+      createIndex("collapse") mappings {
+        mapping("hotels") fields(
+          keywordField("name") docValues true,
+          keywordField("board") docValues true
+        )
+      }
+    }.await
+
+    client.execute {
+      bulk(
+        indexInto("collapse" / "hotels") id "1" fields("name" -> "Ibiza Playa", "board" -> "AI", "price" -> 150, "rating" -> 7),
+        indexInto("collapse" / "hotels") id "2" fields("name" -> "Ibiza Playa", "board" -> "BB", "price" -> 120, "rating" -> 7),
+
+        indexInto("collapse" / "hotels") id "3" fields("name" -> "Best Tenerife", "board" -> "AI", "price" -> 220, "rating" -> 9),
+        indexInto("collapse" / "hotels") id "4" fields("name" -> "Best Tenerife", "board" -> "HP", "price" -> 210, "rating" -> 9),
+        indexInto("collapse" / "hotels") id "5" fields("name" -> "Best Tenerife", "board" -> "BB", "price" -> 180, "rating" -> 9),
+
+        indexInto("collapse" / "hotels") id "6" fields("name" -> "Parque Santiago", "board" -> "AI", "price" -> 170, "rating" -> 8),
+
+        indexInto("collapse" / "hotels") id "7" fields("name" -> "Palma Bay", "board" -> "BB", "price" -> 100, "rating" -> 4)
+      )
+    }.await
+
+    refresh("collapse")
+    blockUntilCount(7, "collapse")
+  }
+
+  "collapse" - {
+
+    /**
+      * The total number of hits in the response indicates the number of matching documents without collapsing.
+      * The total number of distinct group is unknown.
+      */
+    "should preform collapsing on field" in {
+      val resp = client.execute {
+        search("collapse" / "hotels") collapse {
+          collapseField("name")
+        } sortByFieldAsc "price"
+      }.await
+
+      resp.hits.length shouldBe 4
+      resp.totalHits shouldBe 7L
+
+      resp.hits.map(_.java.id) shouldBe Array("7", "2", "6", "5")
+    }
+
+    "should support inner hits" in {
+      val resp = client.execute {
+        search("collapse" / "hotels") collapse {
+          collapseField("name") inner {
+            innerHits("by-price") size 1 sortBy fieldSort("price")
+          }
+        } sortByFieldDesc "rating"
+      }.await
+
+      resp.hits.map(_.java.id) shouldBe Array("5", "6", "2", "7")
+
+      val inner = resp.hits(0).java.getInnerHits.get("by-price")
+      inner.hits.length shouldBe 1
+      inner.totalHits shouldBe 3L
+      inner.getHits.head.id shouldBe "5"
+    }
+  }
+}

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/collapse/CollapseTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/collapse/CollapseTest.scala
@@ -9,8 +9,8 @@ class CollapseTest extends FreeSpec with Matchers with ElasticSugar with BeforeA
     client.execute {
       createIndex("collapse") mappings {
         mapping("hotels") fields(
-          keywordField("name") docValues true,
-          keywordField("board") docValues true
+          keywordField("name"),
+          keywordField("board")
         )
       }
     }.await


### PR DESCRIPTION
Add field collapsing introduced in 5.3.0 [pew](https://www.elastic.co/guide/en/elasticsearch/reference/5.3/search-request-collapse.html)