### PR TITLE
Fix issues with ScriptBuilder for parameter options passed to Java class Script(…)

### DIFF
--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/ScriptBuilder.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/ScriptBuilder.scala
@@ -2,17 +2,22 @@ package com.sksamuel.elastic4s
 
 import com.sksamuel.elastic4s.script.ScriptDefinition
 import org.elasticsearch.script.Script
+import org.elasticsearch.script.ScriptType
 
 import scala.collection.JavaConverters._
 
 object ScriptBuilder {
   def apply(script: ScriptDefinition): Script = {
+    var options = script.options.asJava
+    if (script.scriptType != ScriptType.INLINE){
+      options = null
+    }
     if (script.params.isEmpty) {
       new Script(
         script.scriptType,
         script.lang.getOrElse(Script.DEFAULT_SCRIPT_LANG),
         script.script,
-        script.options.asJava,
+        options,
         new java.util.HashMap[String, Object]()
       )
     } else {
@@ -21,7 +26,7 @@ object ScriptBuilder {
         script.scriptType,
         script.lang.getOrElse(Script.DEFAULT_SCRIPT_LANG),
         script.script,
-        script.options.asJava,
+        options,
         mappedParams
       )
     }


### PR DESCRIPTION
I ran into an issue with running stored script. It seems parameters are not passed correctly when `type=ScriptType.STORED`. So I fixed it.

```
java.lang.IllegalStateException: options must be null for [stored] scripts
        at org.elasticsearch.script.Script.<init>(Script.java:466)
        at com.sksamuel.elastic4s.ScriptBuilder$.apply(ScriptBuilder.scala:20)
        at com.sksamuel.elastic4s.update.UpdateExecutables$UpdateDefinitionExecutable$$anonfun$builder$14.apply(UpdateExecutables.scala:79)
        at com.sksamuel.elastic4s.update.UpdateExecutables$UpdateDefinitionExecutable$$anonfun$builder$14.apply(UpdateExecutables.scala:79)
        at scala.Option.map(Option.scala:146)
        at com.sksamuel.elastic4s.update.UpdateExecutables$UpdateDefinitionExecutable$.builder(UpdateExecutables.scala:79)
        at com.sksamuel.elastic4s.bulk.BulkExecutables$BulkDefinitionExecutable$$anonfun$apply$3.apply(BulkExecutables.scala:26)
        at com.sksamuel.elastic4s.bulk.BulkExecutables$BulkDefinitionExecutable$$anonfun$apply$3.apply(BulkExecutables.scala:23)
        at scala.collection.Iterator$class.foreach(Iterator.scala:893)
        at scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
        at scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
        at scala.collection.AbstractIterable.foreach(Iterable.scala:54)
        at com.sksamuel.elastic4s.bulk.BulkExecutables$BulkDefinitionExecutable$.apply(BulkExecutables.scala:23)
        at com.sksamuel.elastic4s.bulk.BulkExecutables$BulkDefinitionExecutable$.apply(BulkExecutables.scala:17)
        at com.sksamuel.elastic4s.TcpClient$class.execute(TcpClient.scala:28)
        at com.sksamuel.elastic4s.TcpClientConstructors$$anon$1.execute(TcpClient.scala:46)

```