### PR TITLE
More-like-this query routing fix

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/QueryApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/QueryApi.scala
@@ -161,13 +161,13 @@ trait QueryApi {
       likeItems(first +: rest)
 
     def likeItems(items: Iterable[MoreLikeThisItem]): MoreLikeThisQueryDefinition =
-      likeDocs(items.map { item => DocumentRef(item.index, item.`type`, item.id) })
+      MoreLikeThisQueryDefinition(fields).copy(likeDocs = items.toSeq)
 
     def likeDocs(first: DocumentRef,
                  rest: DocumentRef*): MoreLikeThisQueryDefinition = likeDocs(first +: rest)
 
     def likeDocs(docs: Iterable[DocumentRef]): MoreLikeThisQueryDefinition =
-      MoreLikeThisQueryDefinition(fields).copy(likeDocs = docs.toSeq)
+      likeItems(docs.map { d => MoreLikeThisItem(d) })
 
     def artificialDocs(first: ArtificialDocument,
                        rest: ArtificialDocument*): MoreLikeThisQueryDefinition = artificialDocs(first +: rest)

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/QueryApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/QueryApi.scala
@@ -167,7 +167,7 @@ trait QueryApi {
                  rest: DocumentRef*): MoreLikeThisQueryDefinition = likeDocs(first +: rest)
 
     def likeDocs(docs: Iterable[DocumentRef]): MoreLikeThisQueryDefinition =
-      likeItems(docs.map { d => MoreLikeThisItem(d) })
+      likeItems(docs.map { d => MoreLikeThisItem(d.index, d.`type`, d.id) })
 
     def artificialDocs(first: ArtificialDocument,
                        rest: ArtificialDocument*): MoreLikeThisQueryDefinition = artificialDocs(first +: rest)

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/queries/MoreLikeThisQueryDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/queries/MoreLikeThisQueryDefinition.scala
@@ -2,14 +2,19 @@ package com.sksamuel.elastic4s.searches.queries
 
 import com.sksamuel.elastic4s.DocumentRef
 
-@deprecated("use DocumentRef", "5.0.0")
-case class MoreLikeThisItem(index: String, `type`: String, id: String)
+case class MoreLikeThisItem(ref: DocumentRef, routing: Option[String] = None)
+object MoreLikeThisItem {
+  def apply(index: String, `type`: String, id: String): MoreLikeThisItem =
+    MoreLikeThisItem(DocumentRef(index, `type`, id))
+  def apply(index: String, `type`: String, id: String, routing: String): MoreLikeThisItem =
+    MoreLikeThisItem(DocumentRef(index, `type`, id), Some(routing))
+}
 
-case class ArtificialDocument(index: String, `type`: String, doc: String)
+case class ArtificialDocument(index: String, `type`: String, doc: String, routing: Option[String] = None)
 
 case class MoreLikeThisQueryDefinition(fields: Seq[String],
                                        likeTexts: Seq[String] = Nil,
-                                       likeDocs: Seq[DocumentRef] = Nil,
+                                       likeDocs: Seq[MoreLikeThisItem] = Nil,
                                        analyzer: Option[String] = None,
                                        artificialDocs: Seq[ArtificialDocument] = Nil,
                                        boost: Option[Double] = None,
@@ -24,7 +29,7 @@ case class MoreLikeThisQueryDefinition(fields: Seq[String],
                                        maxQueryTerms: Option[Int] = None,
                                        minShouldMatch: Option[String] = None,
                                        unlikeTexts: Seq[String] = Nil,
-                                       unlikeDocs: Seq[DocumentRef] = Nil,
+                                       unlikeDocs: Seq[MoreLikeThisItem] = Nil,
                                        stopWords: Seq[String] = Nil,
                                        queryName: Option[String] = None) extends QueryDefinition {
 
@@ -43,10 +48,10 @@ case class MoreLikeThisQueryDefinition(fields: Seq[String],
     unlikeItems(first +: rest)
 
   def unlikeItems(unlikes: Iterable[MoreLikeThisItem]): MoreLikeThisQueryDefinition =
-    unlikeDocs(unlikes.map { item => DocumentRef(item.index, item.`type`, item.id) })
+    copy(unlikeDocs = unlikeDocs ++ unlikes)
 
   def unlikeDocs(unlikes: Iterable[DocumentRef]): MoreLikeThisQueryDefinition =
-    copy(unlikeDocs = unlikeDocs ++ unlikes)
+    unlikeItems(unlikes.map { d => MoreLikeThisItem(d) })
 
   def include(inc: Boolean): MoreLikeThisQueryDefinition = copy(include = Some(inc))
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/queries/MoreLikeThisQueryDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/queries/MoreLikeThisQueryDefinition.scala
@@ -2,13 +2,7 @@ package com.sksamuel.elastic4s.searches.queries
 
 import com.sksamuel.elastic4s.DocumentRef
 
-case class MoreLikeThisItem(ref: DocumentRef, routing: Option[String] = None)
-object MoreLikeThisItem {
-  def apply(index: String, `type`: String, id: String): MoreLikeThisItem =
-    MoreLikeThisItem(DocumentRef(index, `type`, id))
-  def apply(index: String, `type`: String, id: String, routing: String): MoreLikeThisItem =
-    MoreLikeThisItem(DocumentRef(index, `type`, id), Some(routing))
-}
+case class MoreLikeThisItem(index: String, `type`: String, id: String, routing: Option[String] = None)
 
 case class ArtificialDocument(index: String, `type`: String, doc: String, routing: Option[String] = None)
 
@@ -51,7 +45,7 @@ case class MoreLikeThisQueryDefinition(fields: Seq[String],
     copy(unlikeDocs = unlikeDocs ++ unlikes)
 
   def unlikeDocs(unlikes: Iterable[DocumentRef]): MoreLikeThisQueryDefinition =
-    unlikeItems(unlikes.map { d => MoreLikeThisItem(d) })
+    unlikeItems(unlikes.map { d => MoreLikeThisItem(d.index, d.`type`, d.id) })
 
   def include(inc: Boolean): MoreLikeThisQueryDefinition = copy(include = Some(inc))
 

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/specialized/MoreLikeThisBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/specialized/MoreLikeThisBuilderFn.scala
@@ -18,9 +18,10 @@ object MoreLikeThisBuilderFn {
     q.likeTexts.foreach(text => builder.value(text))
     q.likeDocs.foreach { doc =>
       builder.startObject()
-      builder.field("_index", doc.index)
-      builder.field("_type", doc.`type`)
-      builder.field("_id", doc.id)
+      builder.field("_index", doc.ref.index)
+      builder.field("_type", doc.ref.`type`)
+      builder.field("_id", doc.ref.id)
+      doc.routing.foreach { r ⇒ builder.field("_routing", r) }
       builder.endObject()
     }
     q.artificialDocs.foreach { doc =>
@@ -28,6 +29,7 @@ object MoreLikeThisBuilderFn {
       builder.field("_index", doc.index)
       builder.field("_type", doc.`type`)
       builder.rawField("doc", new BytesArray(doc.doc))
+      doc.routing.foreach { r ⇒ builder.field("_routing", r) }
       builder.endObject()
     }
     builder.endArray()
@@ -37,9 +39,10 @@ object MoreLikeThisBuilderFn {
       q.unlikeTexts.foreach(text => builder.value(text))
       q.unlikeDocs.foreach { doc =>
         builder.startObject()
-        builder.field("_index", doc.index)
-        builder.field("_type", doc.`type`)
-        builder.field("_id", doc.id)
+        builder.field("_index", doc.ref.index)
+        builder.field("_type", doc.ref.`type`)
+        builder.field("_id", doc.ref.id)
+        doc.routing.foreach { r ⇒ builder.field("_routing", r) }
         builder.endObject()
       }
       builder.endArray()

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/specialized/MoreLikeThisBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/specialized/MoreLikeThisBuilderFn.scala
@@ -18,9 +18,9 @@ object MoreLikeThisBuilderFn {
     q.likeTexts.foreach(text => builder.value(text))
     q.likeDocs.foreach { doc =>
       builder.startObject()
-      builder.field("_index", doc.ref.index)
-      builder.field("_type", doc.ref.`type`)
-      builder.field("_id", doc.ref.id)
+      builder.field("_index", doc.index)
+      builder.field("_type", doc.`type`)
+      builder.field("_id", doc.id)
       doc.routing.foreach { r ⇒ builder.field("_routing", r) }
       builder.endObject()
     }
@@ -39,9 +39,9 @@ object MoreLikeThisBuilderFn {
       q.unlikeTexts.foreach(text => builder.value(text))
       q.unlikeDocs.foreach { doc =>
         builder.startObject()
-        builder.field("_index", doc.ref.index)
-        builder.field("_type", doc.ref.`type`)
-        builder.field("_id", doc.ref.id)
+        builder.field("_index", doc.index)
+        builder.field("_type", doc.`type`)
+        builder.field("_id", doc.id)
         doc.routing.foreach { r ⇒ builder.field("_routing", r) }
         builder.endObject()
       }

--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/queries/MoreLikeThisQueryBuilderFn.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/queries/MoreLikeThisQueryBuilderFn.scala
@@ -8,7 +8,7 @@ object MoreLikeThisQueryBuilderFn {
   def apply(q: MoreLikeThisQueryDefinition): MoreLikeThisQueryBuilder = {
 
     val docs = q.likeDocs.map { item =>
-      new MoreLikeThisQueryBuilder.Item(item.ref.index, item.ref.`type`, item.ref.id).routing(item.routing.orNull)
+      new MoreLikeThisQueryBuilder.Item(item.index, item.`type`, item.id).routing(item.routing.orNull)
     } ++ q.artificialDocs.map { doc =>
 
       val parser = XContentFactory.xContent(XContentType.JSON).createParser(NamedXContentRegistry.EMPTY, doc.doc.getBytes)
@@ -41,7 +41,7 @@ object MoreLikeThisQueryBuilderFn {
     q.queryName.foreach(builder.queryName)
 
     builder.unlike(q.unlikeDocs.toArray.map { item =>
-      new MoreLikeThisQueryBuilder.Item(item.ref.index, item.ref.`type`, item.ref.id).routing(item.routing.orNull)
+      new MoreLikeThisQueryBuilder.Item(item.index, item.`type`, item.id).routing(item.routing.orNull)
     })
     builder.unlike(q.unlikeTexts.toArray)
     builder.stopWords(q.stopWords: _*)

--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/queries/MoreLikeThisQueryBuilderFn.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/queries/MoreLikeThisQueryBuilderFn.scala
@@ -7,15 +7,16 @@ object MoreLikeThisQueryBuilderFn {
 
   def apply(q: MoreLikeThisQueryDefinition): MoreLikeThisQueryBuilder = {
 
-    val docs = q.likeDocs.map { doc => new MoreLikeThisQueryBuilder.Item(doc.index, doc.`type`, doc.id) } ++
-      q.artificialDocs.map { doc =>
+    val docs = q.likeDocs.map { item =>
+      new MoreLikeThisQueryBuilder.Item(item.ref.index, item.ref.`type`, item.ref.id).routing(item.routing.orNull)
+    } ++ q.artificialDocs.map { doc =>
 
-        val parser = XContentFactory.xContent(XContentType.JSON).createParser(NamedXContentRegistry.EMPTY, doc.doc.getBytes)
-        parser.close()
-        val builder = XContentFactory.jsonBuilder().copyCurrentStructure(parser)
+      val parser = XContentFactory.xContent(XContentType.JSON).createParser(NamedXContentRegistry.EMPTY, doc.doc.getBytes)
+      parser.close()
+      val builder = XContentFactory.jsonBuilder().copyCurrentStructure(parser)
 
-        new MoreLikeThisQueryBuilder.Item(doc.index, doc.`type`, builder)
-      }
+      new MoreLikeThisQueryBuilder.Item(doc.index, doc.`type`, builder).routing(doc.routing.orNull)
+    }
 
     println(docs)
 
@@ -39,7 +40,9 @@ object MoreLikeThisQueryBuilderFn {
     q.minWordLength.foreach(builder.minWordLength)
     q.queryName.foreach(builder.queryName)
 
-    builder.unlike(q.unlikeDocs.toArray.map { doc => new MoreLikeThisQueryBuilder.Item(doc.index, doc.`type`, doc.id) })
+    builder.unlike(q.unlikeDocs.toArray.map { item =>
+      new MoreLikeThisQueryBuilder.Item(item.ref.index, item.ref.`type`, item.ref.id).routing(item.routing.orNull)
+    })
     builder.unlike(q.unlikeTexts.toArray)
     builder.stopWords(q.stopWords: _*)
     builder

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/MoreLikeThisQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/MoreLikeThisQueryTest.scala
@@ -1,6 +1,5 @@
 package com.sksamuel.elastic4s.search.queries
 
-import com.sksamuel.elastic4s.DocumentRef
 import com.sksamuel.elastic4s.analyzers.StandardAnalyzer
 import com.sksamuel.elastic4s.searches.queries.{ArtificialDocument, MoreLikeThisItem}
 import com.sksamuel.elastic4s.testkit.ElasticSugar
@@ -44,11 +43,11 @@ class MoreLikeThisQueryTest extends WordSpec with Matchers with ElasticSugar {
     }
 
     "find matches based on doc refs" in {
-      val ref = DocumentRef("drinks", "drink", "4")
+      val item = MoreLikeThisItem("drinks", "drink", "4")
       val resp1 = client.execute {
         search("drinks" / "drink").query {
           moreLikeThisQuery("text")
-            .likeItems(MoreLikeThisItem(ref, Some("2"))) minTermFreq 1 minDocFreq 1
+            .likeItems(item.copy(routing = Some("2"))) minTermFreq 1 minDocFreq 1
         }
       }.await
       resp1.hits.map(_.id).toSet shouldBe Set()
@@ -56,7 +55,7 @@ class MoreLikeThisQueryTest extends WordSpec with Matchers with ElasticSugar {
       val resp2 = client.execute {
         search("drinks" / "drink").query {
           moreLikeThisQuery("text")
-            .likeItems(MoreLikeThisItem(ref, Some("1"))) minTermFreq 1 minDocFreq 1
+            .likeItems(item.copy(routing = Some("1"))) minTermFreq 1 minDocFreq 1
         }
       }.await
       resp2.hits.map(_.id).toSet shouldBe Set("8")

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/MoreLikeThisQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/MoreLikeThisQueryTest.scala
@@ -2,7 +2,7 @@ package com.sksamuel.elastic4s.search.queries
 
 import com.sksamuel.elastic4s.DocumentRef
 import com.sksamuel.elastic4s.analyzers.StandardAnalyzer
-import com.sksamuel.elastic4s.searches.queries.ArtificialDocument
+import com.sksamuel.elastic4s.searches.queries.{ArtificialDocument, MoreLikeThisItem}
 import com.sksamuel.elastic4s.testkit.ElasticSugar
 import org.elasticsearch.action.support.WriteRequest.RefreshPolicy
 import org.scalatest.{Matchers, WordSpec}
@@ -10,20 +10,24 @@ import org.scalatest.{Matchers, WordSpec}
 class MoreLikeThisQueryTest extends WordSpec with Matchers with ElasticSugar {
 
   client.execute {
-    createIndex("drinks").mappings {
-      mapping("alcohol") source true as (
+    createIndex("drinks").mappings (
+      mapping("category") as (
         textField("name") store true analyzer StandardAnalyzer
-      )
-    } shards 1
+        ),
+      mapping("drink") as (
+        textField("text") store true analyzer StandardAnalyzer
+        ) parent "a"
+    ) shards 3
   }.await
 
   client.execute {
     bulk(
-      indexInto("drinks/alcohol") fields ("text" -> "coors light is a coors beer by molson") id 4,
-      indexInto("drinks/alcohol") fields ("text" -> "Anheuser-Busch brews a cider called Strongbow") id 6,
-      indexInto("drinks/alcohol") fields ("text" -> "Gordons popular gin UK") id 7,
-      indexInto("drinks/alcohol") fields ("text" -> "coors regular is another coors beer by molson") id 8,
-      indexInto("drinks/alcohol") fields ("text" -> "Hendricks upmarket gin UK") id 9
+      indexInto("drinks/category") fields("name" → "alcohol") id 1,
+      indexInto("drinks/drink") fields ("text" -> "coors light is a coors beer by molson") id 4 parent "1",
+      indexInto("drinks/drink") fields ("text" -> "Anheuser-Busch brews a cider called Strongbow") id 6 parent "1",
+      indexInto("drinks/drink") fields ("text" -> "Gordons popular gin UK") id 7 parent "1",
+      indexInto("drinks/drink") fields ("text" -> "coors regular is another coors beer by molson") id 8 parent "1",
+      indexInto("drinks/drink") fields ("text" -> "Hendricks upmarket gin UK") id 9 parent "1"
     ).refresh(RefreshPolicy.IMMEDIATE)
   }.await
 
@@ -31,7 +35,7 @@ class MoreLikeThisQueryTest extends WordSpec with Matchers with ElasticSugar {
 
     "find matches based on input text" in {
       val resp = client.execute {
-        search("drinks" / "alcohol") query {
+        search("drinks" / "drink") query {
           moreLikeThisQuery("text")
             .likeTexts("coors") minTermFreq 1 minDocFreq 1
         }
@@ -40,20 +44,31 @@ class MoreLikeThisQueryTest extends WordSpec with Matchers with ElasticSugar {
     }
 
     "find matches based on doc refs" in {
-      val resp = client.execute {
-        search("drinks" / "alcohol").query {
+      val ref = DocumentRef("drinks", "drink", "4")
+      val resp1 = client.execute {
+        search("drinks" / "drink").query {
           moreLikeThisQuery("text")
-            .likeDocs(DocumentRef("drinks", "alcohol", "4")) minTermFreq 1 minDocFreq 1
+            .likeItems(MoreLikeThisItem(ref, Some("2"))) minTermFreq 1 minDocFreq 1
         }
       }.await
-      resp.hits.map(_.id).toSet shouldBe Set("8")
+      resp1.hits.map(_.id).toSet shouldBe Set()
+
+      val resp2 = client.execute {
+        search("drinks" / "drink").query {
+          moreLikeThisQuery("text")
+            .likeItems(MoreLikeThisItem(ref, Some("1"))) minTermFreq 1 minDocFreq 1
+        }
+      }.await
+      resp2.hits.map(_.id).toSet shouldBe Set("8")
     }
 
     "support artifical docs" in {
       val resp = client.execute {
-        search("drinks" / "alcohol").query {
+        search("drinks" / "drink").query {
           moreLikeThisQuery("text")
-            .artificialDocs(ArtificialDocument("drinks", "alcohol", """{ "text" : "gin" }""")) minTermFreq 1 minDocFreq 1
+            .artificialDocs(
+              ArtificialDocument("drinks", "drink", """{ "text" : "gin" }""", Some("1"))
+            ) minTermFreq 1 minDocFreq 1
         }
       }.await
       resp.hits.map(_.id).toSet shouldBe Set("7", "9")

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -14,7 +14,7 @@ object Build extends AutoPlugin {
     val CatsVersion = "0.9.0"
     val CirceVersion = "0.7.1"
     val CommonsIoVersion = "2.4"
-    val ElasticsearchVersion = "5.4.0"
+    val ElasticsearchVersion = "5.4.1"
     val ExtsVersion = "1.44.0"
     val JacksonVersion = "2.8.8"
     val Json4sVersion = "3.5.1"


### PR DESCRIPTION
`more_like_this` query does not work for parent-child relationship without explicit routing parameter, and there was no way to specify it. 

I changed `MoreLikeThisItem` a bit , but it should support old API calls.

ElasticSearch team recently fixed a linked bug https://github.com/elastic/elasticsearch/issues/23699 (routing parameter in `more_like_this` was ignored), so Elastic version had to be updated to 5.4.1