### PR TITLE
Remove debug print from MoreLikeThisQueryBuilderFn

### DIFF
--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/queries/MoreLikeThisQueryBuilderFn.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/queries/MoreLikeThisQueryBuilderFn.scala
@@ -18,8 +18,6 @@ object MoreLikeThisQueryBuilderFn {
       new MoreLikeThisQueryBuilder.Item(doc.index, doc.`type`, builder).routing(doc.routing.orNull)
     }
 
-    println(docs)
-
     val builder = QueryBuilders.moreLikeThisQuery(
       q.fields.toArray,
       if (q.likeTexts.isEmpty) null else q.likeTexts.toArray,


### PR DESCRIPTION
Debug print in this function add a lot of noise to our logs. This patch removes it.

Please also apply this to 5.4.x.