### PR TITLE
Adding leading slash to IndexExists as in all other endpoints.

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/admin/IndexAdminImplicits.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/admin/IndexAdminImplicits.scala
@@ -79,7 +79,7 @@ trait IndexAdminImplicits extends IndexShowImplicits {
     override def execute(client: RestClient,
                          request: IndexExistsDefinition): Future[IndexExistsResponse] = {
 
-      val endpoint = request.index
+      val endpoint = s"/${request.index}"
       logger.debug(s"Connecting to $endpoint for indexes exists check")
       val resp = client.performRequest("HEAD", endpoint)
       Future.successful(IndexExistsResponse(resp.getStatusLine.getStatusCode == 200))


### PR DESCRIPTION
Hello,

As I was getting a BadRequest response trying to make an IndexExists call. I saw that the endpoint generated was something like this:
`https://search-h3se7w645ergom*****.eu-west-1.es.amazonaws.com:443index_name_bla`

So I found that in the IndexAdminImplicits the implementation for IndexExists was the only one without a leading '/'. I added it and now the end point is correctly generated like `https://search-h3se7w645ergom*****.eu-west-1.es.amazonaws.com:443/index_name_bla`.

I think that it is right now, but I wonder how nobody notice it before.

Thanks and I hope it helps :).