### PR TITLE
Renaming abortOnVersionConflict to proceedOnConflicts

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/delete/DeleteByQueryDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/delete/DeleteByQueryDefinition.scala
@@ -10,7 +10,7 @@ case class DeleteByQueryDefinition(indexesAndTypes: IndexesAndTypes,
                                    query: QueryDefinition,
                                    requestsPerSecond: Option[Float] = None,
                                    maxRetries: Option[Int] = None,
-                                   abortOnVersionConflict: Option[Boolean] = None,
+                                   proceedOnConflicts: Option[Boolean] = None,
                                    refresh: Option[RefreshPolicy] = None,
                                    waitForActiveShards: Option[Int] = None,
                                    retryBackoffInitialTime: Option[FiniteDuration] = None,
@@ -19,8 +19,12 @@ case class DeleteByQueryDefinition(indexesAndTypes: IndexesAndTypes,
                                    shouldStoreResult: Option[Boolean] = None,
                                    size: Option[Int] = None) {
 
+  def proceedOnConflicts(proceedOnConflicts: Boolean): DeleteByQueryDefinition =
+    copy(proceedOnConflicts = proceedOnConflicts.some)
+
+  @deprecated("use proceedOnConflicts")
   def abortOnVersionConflict(abortOnVersionConflict: Boolean): DeleteByQueryDefinition =
-    copy(abortOnVersionConflict = abortOnVersionConflict.some)
+    proceedOnConflicts(abortOnVersionConflict)
 
   def refresh(refresh: RefreshPolicy): DeleteByQueryDefinition = copy(refresh = refresh.some)
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/update/UpdateByQueryDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/update/UpdateByQueryDefinition.scala
@@ -11,7 +11,7 @@ case class UpdateByQueryDefinition(sourceIndexes: Indexes,
                                    query: QueryDefinition,
                                    requestsPerSecond: Option[Float] = None,
                                    maxRetries: Option[Int] = None,
-                                   abortOnVersionConflict: Option[Boolean] = None,
+                                   proceedOnConflicts: Option[Boolean] = None,
                                    pipeline: Option[String] = None,
                                    refresh: Option[Boolean] = None,
                                    script: Option[ScriptDefinition] = None,
@@ -21,8 +21,12 @@ case class UpdateByQueryDefinition(sourceIndexes: Indexes,
                                    shouldStoreResult: Option[Boolean] = None,
                                    size: Option[Int] = None) {
 
+  def proceedOnConflicts(proceedOnConflicts: Boolean): UpdateByQueryDefinition =
+    copy(proceedOnConflicts = proceedOnConflicts.some)
+
+  @deprecated("use proceedOnConflicts")
   def abortOnVersionConflict(abortOnVersionConflict: Boolean): UpdateByQueryDefinition =
-    copy(abortOnVersionConflict = abortOnVersionConflict.some)
+    proceedOnConflicts(abortOnVersionConflict)
 
   def refresh(refresh: Boolean): UpdateByQueryDefinition = copy(refresh = refresh.some)
 

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/delete/DeleteImplicits.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/delete/DeleteImplicits.scala
@@ -36,7 +36,7 @@ trait DeleteImplicits {
         s"/${request.indexesAndTypes.indexes.mkString(",")}/${request.indexesAndTypes.types.mkString(",")}/_delete_by_query"
 
       val params = scala.collection.mutable.Map.empty[String, String]
-      if (request.abortOnVersionConflict.contains(true)) {
+      if (request.proceedOnConflicts.contains(true)) {
         params.put("conflicts", "proceed")
       }
       request.requestsPerSecond.map(_.toString).foreach(params.put("requests_per_second", _))

--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/delete/DeleteExecutables.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/delete/DeleteExecutables.scala
@@ -48,7 +48,7 @@ trait DeleteExecutables {
       d.timeout.map(_.toNanos).map(TimeValue.timeValueNanos).foreach(builder.timeout)
       d.retryBackoffInitialTime.map(_.toNanos).map(TimeValue.timeValueNanos).foreach(builder.setRetryBackoffInitialTime)
       d.shouldStoreResult.foreach(builder.setShouldStoreResult)
-      d.abortOnVersionConflict.foreach(builder.abortOnVersionConflict)
+      d.proceedOnConflicts.foreach(builder.abortOnVersionConflict)
     }
 
     override def apply(client: Client, d: DeleteByQueryDefinition): Future[BulkByScrollResponse] = {

--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/update/UpdateExecutables.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/update/UpdateExecutables.scala
@@ -29,7 +29,7 @@ trait UpdateExecutables {
       t.timeout.map(_.toNanos).map(TimeValue.timeValueNanos).foreach(builder.timeout)
       t.retryBackoffInitialTime.map(_.toNanos).map(TimeValue.timeValueNanos).foreach(builder.setRetryBackoffInitialTime)
       t.shouldStoreResult.foreach(builder.setShouldStoreResult)
-      t.abortOnVersionConflict.foreach(builder.abortOnVersionConflict)
+      t.proceedOnConflicts.foreach(builder.abortOnVersionConflict)
       t.pipeline.foreach(builder.setPipeline)
       t.script.map(ScriptBuilder.apply).foreach(builder.script)
       injectFuture(builder.execute(_))


### PR DESCRIPTION
Renaming `abortOnVersionConflict` to `proceedOnConflicts` as agreed in https://github.com/sksamuel/elastic4s/issues/954