### PR TITLE
Handle null value in SourceAsContentBuilder

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/SourceAsContentBuilder.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/SourceAsContentBuilder.scala
@@ -25,6 +25,7 @@ object SourceAsContentBuilder {
             case x: Boolean => builder.field(key, x)
             case x: Long => builder.field(key, x)
             case x: Int => builder.field(key, x)
+            case null => builder.nullField(key)
           }
       }
     }

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/SourceAsContentBuilderTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/SourceAsContentBuilderTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.{FunSuite, Matchers}
 class SourceAsContentBuilderTest extends FunSuite with Matchers {
 
   test("source as content builder should handle tuples") {
-    val map = Map("name" -> "sammy", "teams" -> Seq(("football", "boro"), ("baseball", "phillies")))
-    SourceAsContentBuilder(map).string() shouldBe """{"name":"sammy","teams":[["football","boro"],["baseball","phillies"]]}"""
+    val map = Map("name" -> "sammy", "teams" -> Seq(("football", "boro"), ("baseball", "phillies")), "projects" -> null)
+    SourceAsContentBuilder(map).string() shouldBe """{"name":"sammy","teams":[["football","boro"],["baseball","phillies"]],"projects":null}"""
   }
 }


### PR DESCRIPTION
When a null value exists in the Map passed to the SourceAsContentBuilder, none of the types matches and a MatchError is thrown.  So handle this case explicitly.