### PR TITLE
Add sub aggregation rather than replacing previously added ones

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/aggs/AggregationDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/aggs/AggregationDefinition.scala
@@ -11,11 +11,11 @@ trait AggregationDefinition extends AbstractAggregation {
 
   def subaggs: Seq[AbstractAggregation]
 
-  def subagg(agg: AbstractAggregation): T = subaggs(agg)
+  def subagg(agg: AbstractAggregation): T = subaggs(agg, subaggs: _*)
   def subaggs(first: AbstractAggregation, rest: AbstractAggregation*): T = subaggs(first +: rest)
   def subaggs(aggs: Iterable[AbstractAggregation]): T = subAggregations(aggs)
 
-  def subAggregation(agg: AbstractAggregation): T = subAggregations(agg)
+  def subAggregation(agg: AbstractAggregation): T = subAggregations(agg, subaggs: _*)
   def subAggregations(first: AbstractAggregation, rest: AbstractAggregation*): T = subAggregations(first +: rest)
   def subAggregations(aggs: Iterable[AbstractAggregation]): T
 }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/aggs/AggregationDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/aggs/AggregationDefinition.scala
@@ -11,11 +11,11 @@ trait AggregationDefinition extends AbstractAggregation {
 
   def subaggs: Seq[AbstractAggregation]
 
-  def subagg(agg: AbstractAggregation): T = subaggs(agg, subaggs: _*)
+  def addSubagg(agg: AbstractAggregation): T = subaggs(subaggs :+ agg)
   def subaggs(first: AbstractAggregation, rest: AbstractAggregation*): T = subaggs(first +: rest)
   def subaggs(aggs: Iterable[AbstractAggregation]): T = subAggregations(aggs)
 
-  def subAggregation(agg: AbstractAggregation): T = subAggregations(agg, subaggs: _*)
+  def addSubAggregation(agg: AbstractAggregation): T = subAggregations(subaggs :+ agg)
   def subAggregations(first: AbstractAggregation, rest: AbstractAggregation*): T = subAggregations(first +: rest)
   def subAggregations(aggs: Iterable[AbstractAggregation]): T
 }

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/aggs/MaxBucketAggBuilderTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/aggs/MaxBucketAggBuilderTest.scala
@@ -12,7 +12,7 @@ class MaxBucketAggBuilderTest extends FunSuite with Matchers {
 
   test("max bucket agg should match the spec") {
     val search = SearchDefinition("myindex" / "mytype").aggs(
-      dateHistogramAgg("sales_per_month", "date").interval(DateHistogramInterval.Month).subagg(
+      dateHistogramAgg("sales_per_month", "date").interval(DateHistogramInterval.Month).addSubagg(
         sumAgg("sales", "price")
       ),
       maxBucketAgg("max_monthly_sales", "sales_per_month>sales")

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
@@ -649,7 +649,7 @@ class SearchDslTest extends FlatSpec with MockitoSugar with JsonSugar with OneIn
 
   it should "generate correct json for top hits aggregation" in {
     val req = search("music") types "bands" aggs {
-      termsAggregation("top-tags") field "tags" size 3 order TermsOrder("count", true) subAggregation (
+      termsAggregation("top-tags") field "tags" size 3 order TermsOrder("count", true) addSubAggregation (
         topHitsAggregation("top_tag_hits") size 1 sortBy {
           fieldSort("last_activity_date") order SortOrder.Desc
         } fetchSource(Array("title"), Array.empty)

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/aggs/ChildrenAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/aggs/ChildrenAggregationHttpTest.scala
@@ -48,8 +48,8 @@ class ChildrenAggregationHttpTest extends FlatSpec with Matchers with ElasticDsl
     // so we're finding the top term per month
     val resp = http.execute {
       search("childrenaggs").matchAllQuery().aggs(
-        dateHistogramAgg("agg1", "date").interval(DateHistogramInterval.Month).subagg(
-          childrenAggregation("agg2", "answer").subagg(
+        dateHistogramAgg("agg1", "date").interval(DateHistogramInterval.Month).addSubagg(
+          childrenAggregation("agg2", "answer").addSubagg(
             termsAgg("agg3", "text").size(1)
           )
         )

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/aggs/FilterAggregationDslTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/aggs/FilterAggregationDslTest.scala
@@ -13,7 +13,7 @@ class FilterAggregationDslTest extends FlatSpec with Matchers with ElasticApi {
           .gte("now-1y")
           .to("now")
       )
-    ).subAggregation(
+    ).addSubAggregation(
       dateHistogramAggregation("per_month")
         .field("some_date_field")
         .interval(DateHistogramInterval.Month)

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/aggs/TermsAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/aggs/TermsAggregationHttpTest.scala
@@ -97,7 +97,7 @@ class TermsAggregationHttpTest extends FreeSpec with DiscoveryLocalNodeProvider 
 
       val resp = http.execute {
         search("termsagg/curry").matchAllQuery().aggs {
-          termsAgg("agg1", "strength").subagg(
+          termsAgg("agg1", "strength").addSubagg(
             termsAgg("agg2", "origin")
           )
         }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/aggs/TopHitsAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/aggs/TopHitsAggregationHttpTest.scala
@@ -31,7 +31,7 @@ class TopHitsAggregationHttpTest extends FreeSpec with DiscoveryLocalNodeProvide
 
       val resp = http.execute {
         search("tophits/landmarks").matchAllQuery().aggs {
-          termsAgg("agg1", "location").subagg(
+          termsAgg("agg1", "location").addSubagg(
             topHitsAgg("agg2").sortBy(fieldSort("name"))
           )
         }


### PR DESCRIPTION
The AggregationDefinition replaces all aggregations at once; particularly when using the singleton methods "subagg" and "subAggregation" this is unexpected.

This PR adds the provided sub aggregation to the list of aggregations already present in the definition.

The behavior of the multi-aggregate methods "subaggs" and "subAggregations" has been left unchanged, as expectations when those are invoked multiple times are not so clear.  Furthermore, the current behavior gives users the option of clearing the list of sub aggregations.