### PR TITLE
Fix createTemplate json serialization

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/IndexTemplateImplicits.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/IndexTemplateImplicits.scala
@@ -63,7 +63,7 @@ object CreateIndexTemplateBodyFn {
     if (create.mappings.nonEmpty) {
       builder.startObject("mappings")
       create.mappings.foreach { mapping =>
-        builder.rawValue(MappingContentBuilder.buildWithName(mapping, mapping.`type`))
+        builder.rawField(mapping.`type`, MappingContentBuilder.build(mapping))
       }
       builder.endObject()
     }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/indexes/CreateIndexTemplateDefinitionTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/indexes/CreateIndexTemplateDefinitionTest.scala
@@ -1,19 +1,53 @@
 package com.sksamuel.elastic4s.indexes
 
-import org.scalatest.WordSpec
+import com.sksamuel.elastic4s.ElasticApi
+import com.sksamuel.elastic4s.ElasticDsl.{intField, keywordField}
+import com.sksamuel.elastic4s.http.ElasticDsl
+import com.sksamuel.elastic4s.testkit.DiscoveryLocalNodeProvider
+import org.scalatest.{BeforeAndAfter, Matchers, WordSpec}
 
-class CreateIndexTemplateDefinitionTest extends WordSpec {
+import scala.util.Try
 
-  import com.sksamuel.elastic4s.ElasticDsl._
+class CreateIndexTemplateDefinitionTest extends WordSpec
+  with Matchers
+  with BeforeAndAfter
+  with ElasticApi
+  with ElasticDsl
+  with DiscoveryLocalNodeProvider  {
 
-  private val req = createTemplate("my_template").pattern("matchme.*").mappings(
-    mapping("sometype1").fields(
-      keywordField("field1"),
-      geopointField("field2")
-    ),
-    mapping("sometype2").fields(
-      keywordField("field3"),
-      intField("field4")
-    )
-  )
+  before {
+    Try {
+      http.execute {
+        deleteIndex("matchme.template")
+      }.await
+    }
+  }
+
+  "Create Index Template HTTP request" should {
+    "create and use the template for an index" in {
+      http.execute {
+        createTemplate("matchme.*").pattern("matchme.*").mappings(
+          mapping("sometype1").fields(
+            keywordField("field1"),
+            geopointField("field2"),
+            keywordField("field3"),
+            intField("field4")
+          )
+        )
+      }.await
+
+      http.execute {
+        createIndex("matchme.template").shards(1).waitForActiveShards(1)
+      }.await
+
+      val resp = http.execute {
+        getMapping("matchme.template")
+      }.await
+
+      resp.map(_.index) shouldBe Seq("matchme.template")
+      resp.head.mappings.keySet shouldBe Set("sometype1")
+      resp.head.mappings("sometype1").keySet shouldBe Set("field1", "field2", "field3", "field4")
+    }
+  }
+
 }


### PR DESCRIPTION
With release 6.0.0-M1 and 6.0.0-SNAPSHOT I ran into the issue where the `createTemplate` from the HttpClient threw an exception that an `ObjectNode` cannot be cast into an `ArrayNode`. I needed this in our own code so I made a fix that we are using now. I also implemented the test, although I could only get it to run for the HttpClient. There seems to be some kind of incompatibility for the TcpClient where that always fails.

Issue #935 might be related but it looks like it has a different cause that was already fixed in the 6.0.0 releases.