### PR TITLE
Fix extended bounds error

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/DateHistogramAggregationBuilder.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/DateHistogramAggregationBuilder.scala
@@ -2,7 +2,7 @@ package com.sksamuel.elastic4s.http.search.aggs
 
 import com.sksamuel.elastic4s.http.ScriptBuilderFn
 import com.sksamuel.elastic4s.searches.aggs.DateHistogramAggregation
-import org.elasticsearch.common.xcontent.{XContentBuilder, XContentFactory, XContentType}
+import org.elasticsearch.common.xcontent.{ToXContent, XContentBuilder, XContentFactory, XContentType}
 
 object DateHistogramAggregationBuilder {
   def apply(agg: DateHistogramAggregation): XContentBuilder = {
@@ -20,7 +20,7 @@ object DateHistogramAggregationBuilder {
       builder.rawField("script", ScriptBuilderFn(script).bytes, XContentType.JSON)
     }
     agg.missing.foreach(builder.field("missing", _))
-    agg.extendedBounds.foreach(builder.field("extended_bounds", _))
+    agg.extendedBounds.foreach(_.toXContent(builder, ToXContent.EMPTY_PARAMS))
     builder.endObject()
     SubAggsBuilderFn(agg, builder)
     AggMetaDataFn(agg, builder)

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/aggs/DateHistogramAggregationBuilderTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/aggs/DateHistogramAggregationBuilderTest.scala
@@ -1,0 +1,20 @@
+package com.sksamuel.elastic4s.http.search.aggs
+
+import com.sksamuel.elastic4s.searches.aggs.DateHistogramAggregation
+import org.elasticsearch.search.aggregations.bucket.histogram.{DateHistogramInterval, ExtendedBounds}
+import org.scalatest.{FunSuite, Matchers}
+
+class DateHistogramAggregationBuilderTest extends FunSuite with Matchers {
+
+  test("date histogram aggregation with 'extendedBounds' should generate expected json") {
+    val agg = DateHistogramAggregation("sales_over_time")
+      .field("date")
+      .interval(DateHistogramInterval.DAY)
+      .extendedBounds(new ExtendedBounds("2015-01-01", "2017-01-01"))
+
+    DateHistogramAggregationBuilder(agg).string() shouldBe
+      """{"date_histogram":{"interval":"1d","field":"date","extended_bounds":{"min":"2015-01-01","max":"2017-01-01"}}}"""
+
+  }
+
+}

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/aggs/RangeAggregationBuilderTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/aggs/RangeAggregationBuilderTest.scala
@@ -50,7 +50,7 @@ class RangeAggregationBuilderTest extends FunSuite with Matchers {
       """{"range":{"field":"price","script":{"lang":"painless","inline":"doc['price'].value"},"ranges":[{"from":0.0,"to":50.0},{"from":50.0,"to":1000.0}]}}"""
   }
 
-  test("range aggregation with a keyed parameter setted to true should generate expected json") {
+  test("range aggregation with a keyed parameter set to true should generate expected json") {
     val agg = RangeAggregationDefinition("price_ranges")
       .field("price")
       .range(0, 50)
@@ -61,7 +61,7 @@ class RangeAggregationBuilderTest extends FunSuite with Matchers {
       """{"range":{"field":"price","keyed":true,"ranges":[{"from":0.0,"to":50.0},{"from":50.0,"to":1000.0}]}}"""
   }
 
-  test("range aggregation with a missing parameter setted should generate expected json") {
+  test("range aggregation with a missing parameter set should generate expected json") {
     val agg = RangeAggregationDefinition("price_ranges")
       .field("price")
       .missing(Int.box(0))


### PR DESCRIPTION
This is to fix the following error that I was getting when trying to use `extendedBounds`:

```
com.fasterxml.jackson.core.JsonGenerationException: Can not write a field name, expecting a value
	at com.fasterxml.jackson.core.JsonGenerator._reportError(JsonGenerator.java:1897)
	at com.fasterxml.jackson.core.json.UTF8JsonGenerator.writeFieldName(UTF8JsonGenerator.java:185)
	at org.elasticsearch.common.xcontent.json.JsonXContentGenerator.writeFieldName(JsonXContentGenerator.java:183)
	at org.elasticsearch.common.xcontent.XContentBuilder.field(XContentBuilder.java:246)
	at org.elasticsearch.common.xcontent.XContentBuilder.startObject(XContentBuilder.java:222)
	at org.elasticsearch.search.aggregations.bucket.histogram.ExtendedBounds.toXContent(ExtendedBounds.java:175)
	at org.elasticsearch.common.xcontent.XContentBuilder.value(XContentBuilder.java:853)
	at org.elasticsearch.common.xcontent.XContentBuilder.value(XContentBuilder.java:846)
	at org.elasticsearch.common.xcontent.XContentBuilder.field(XContentBuilder.java:838)
	at com.sksamuel.elastic4s.http.search.aggs.DateHistogramAggregationBuilder$$anonfun$apply$10.apply(DateHistogramAggregationBuilder.scala:26)
```