### PR TITLE
Analysers in template

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/IndexTemplateImplicits.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/IndexTemplateImplicits.scala
@@ -71,7 +71,7 @@ object CreateIndexTemplateBodyFn {
     if (create.mappings.nonEmpty) {
       builder.startObject("mappings")
       create.mappings.foreach { mapping =>
-        builder.rawValue(MappingBuilderFn.buildWithName(mapping, mapping.`type`))
+        builder.rawField(mapping.`type`, MappingBuilderFn.build(mapping))
       }
       builder.endObject()
     }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/JsonSugar.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/JsonSugar.scala
@@ -21,7 +21,7 @@ trait JsonSugar extends Matchers {
         right should not be null
       }
 
-      val expectedJson = mapper.readTree(left)
+      val expectedJson = mapper.readTree(right)
       val actualJson = mapper.readTree(left)
 
       MatchResult(

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/indexes/CreateIndexShowTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/indexes/CreateIndexShowTest.scala
@@ -24,7 +24,7 @@ class CreateIndexShowTest extends WordSpec with Matchers with JsonSugar with Ela
         ) refreshInterval 10.seconds shards 4 replicas 2
       }
 
-      CreateIndexShow.show(req) should matchJson("""{"settings":{"index":{"number_of_shards":4,"number_of_replicas":2,"refresh_interval":"10000ms"}},"mappings":{"characters":{"_timestamp":{"enabled":true},"properties":{"name":{"type":"string"},"location":{"type":"string"}}},"locations":{"_all":{"enabled":true},"_source":{"enabled":true},"numeric_detection":false,"properties":{"name":{"type":"string"},"continent":{"type":"string"},"iswinter":{"type":"integer"}}}}}""")
+      CreateIndexShow.show(req) should matchJson("""{"settings":{"index":{"number_of_shards":4,"number_of_replicas":2,"refresh_interval":"10000ms"}},"mappings":{"characters":{"properties":{"name":{"type":"string"},"location":{"type":"string"}}},"locations":{"_all":{"enabled":true},"_source":{"enabled":true},"numeric_detection":false,"properties":{"name":{"type":"string"},"continent":{"type":"string"},"iswinter":{"type":"integer"}}}}}""")
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/indexes/CreateIndexTemplateDefinitionShowTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/indexes/CreateIndexTemplateDefinitionShowTest.scala
@@ -1,0 +1,31 @@
+package com.sksamuel.elastic4s.indexes
+
+import com.sksamuel.elastic4s.JsonSugar
+import com.sksamuel.elastic4s.analyzers.{CustomAnalyzerDefinition, KeywordTokenizer, LowercaseTokenFilter}
+import com.sksamuel.elastic4s.http.ElasticDsl
+import org.scalatest.{Matchers, WordSpec}
+
+class CreateIndexTemplateDefinitionShowTest extends WordSpec with Matchers with JsonSugar with ElasticDsl {
+
+  "CreateIndexTemplateDefinition" should {
+    "have a show typeclass implementation" in {
+      val req =
+        createTemplate("matchme.*").pattern("matchme.*").mappings(
+          mapping("characters").fields(
+            stringField("name"),
+            stringField("location")
+          )
+        ).analysis(
+          CustomAnalyzerDefinition(
+            "default",
+            KeywordTokenizer,
+            LowercaseTokenFilter
+          )
+        )
+        .order(1)
+        .settings(Map("number_of_shards" -> 4))
+
+      CreateIndexTemplateShow.show(req) should matchJson("""{"template":"matchme.*","order":1,"settings":{"number_of_shards":4,"analysis":{"analyzer":{"default":{"type":"custom","tokenizer":"keyword","filter":["lowercase"]}}}},"mappings":{"characters":{"properties":{"name":{"type":"string"},"location":{"type":"string"}}}}}""")
+    }
+  }
+}

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/indexes/CreateIndexTemplateDefinitionTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/indexes/CreateIndexTemplateDefinitionTest.scala
@@ -1,7 +1,6 @@
 package com.sksamuel.elastic4s.indexes
 
 import com.sksamuel.elastic4s.ElasticApi
-import com.sksamuel.elastic4s.ElasticDsl.{intField, keywordField}
 import com.sksamuel.elastic4s.http.ElasticDsl
 import com.sksamuel.elastic4s.testkit.DiscoveryLocalNodeProvider
 import org.scalatest.{BeforeAndAfter, Matchers, WordSpec}
@@ -49,5 +48,4 @@ class CreateIndexTemplateDefinitionTest extends WordSpec
       resp.head.mappings("sometype1").keySet shouldBe Set("field1", "field2", "field3", "field4")
     }
   }
-
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/MultiSearchShowTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/MultiSearchShowTest.scala
@@ -20,24 +20,33 @@ class MultiSearchShowTest extends WordSpec with Matchers with JsonSugar with Ela
                                        |{
                                        |  "query" : {
                                        |    "term" : {
-                                       |      "name" : "snow"
+                                       |      "name" : {
+                                       |        "value": "snow",
+                                       |        "boost" : 1.0
+                                       |      }
                                        |    }
                                        |  }
                                        |},
                                        |{
                                        |  "query" : {
                                        |    "term" : {
-                                       |      "name" : "tyrion"
+                                       |      "name": {
+                                       |        "value" : "tyrion",
+                                       |        "boost" : 1.0
+                                       |      }
                                        |    }
                                        |  }
                                        |},
                                        |{
                                        |  "query" : {
                                        |    "term" : {
-                                       |      "name" : "brienne"
+                                       |      "name" : {
+                                       |        "value" : "brienne",
+                                       |        "boost" : 1.0
+                                       |      }
                                        |    }
                                        |  }
-                                       |}]""")
+                                       |}]""".stripMargin)
     }
   }
 }


### PR DESCRIPTION
I noticed that analyzers defined in a template were not included in the JSON that was submitted by the HttpClient. I created a fix for that and, to be able to test it easily, also added a Show typeclass for the CreateIndexTemplateDefinition type.