### PR TITLE
Always request version on search

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/SearchBodyBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/SearchBodyBuilderFn.scala
@@ -15,6 +15,7 @@ object SearchBodyBuilderFn {
 
     val builder = XContentFactory.jsonBuilder()
 
+    builder.field("version", true)
     request.pref.foreach(builder.field("preference", _))
     request.routing.foreach(builder.field("routing", _))
     request.timeout.map(_.toMillis + "ms").foreach(builder.field("timeout", _))

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/aggs/MaxBucketAggBuilderTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/aggs/MaxBucketAggBuilderTest.scala
@@ -18,6 +18,6 @@ class MaxBucketAggBuilderTest extends FunSuite with Matchers {
       maxBucketAgg("max_monthly_sales", "sales_per_month>sales")
     )
     SearchBodyBuilderFn(search).string() shouldBe
-      """{"aggs":{"sales_per_month":{"date_histogram":{"interval":"1M","field":"date"},"aggs":{"sales":{"sum":{"field":"price"}}}},"max_monthly_sales":{"max_bucket":{"buckets_path":"sales_per_month>sales"}}}}"""
+      """{"version":true,"aggs":{"sales_per_month":{"date_histogram":{"interval":"1M","field":"date"},"aggs":{"sales":{"sum":{"field":"price"}}}},"max_monthly_sales":{"max_bucket":{"buckets_path":"sales_per_month>sales"}}}}"""
   }
 }

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/SearchBodyFnTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/SearchBodyFnTest.scala
@@ -12,7 +12,7 @@ class SearchBodyFnTest extends FunSuite with Matchers {
       .matchedFields("text", "text.ngram", "text.japanese")
     }
     SearchBodyBuilderFn(request).string() shouldBe
-      """{"highlight":{"fields":{"text":{"matched_fields":["text","text.ngram","text.japanese"]}}}}"""
+      """{"version":true,"highlight":{"fields":{"text":{"matched_fields":["text","text.ngram","text.japanese"]}}}}"""
   }
   test("highlight with 'highlighterType' generates 'type' field.") {
     val request = search("example" / "1") highlighting {
@@ -20,7 +20,7 @@ class SearchBodyFnTest extends FunSuite with Matchers {
         .highlighterType("fvh")
     }
     SearchBodyBuilderFn(request).string() shouldBe
-      """{"highlight":{"fields":{"text":{"type":"fvh"}}}}"""
+      """{"version":true,"highlight":{"fields":{"text":{"type":"fvh"}}}}"""
   }
   test("highlight with 'boundaryChars' generates 'boundary_chars' field.") {
     val request = search("example" / "1") highlighting {
@@ -28,6 +28,6 @@ class SearchBodyFnTest extends FunSuite with Matchers {
         .boundaryChars("test")
     }
     SearchBodyBuilderFn(request).string() shouldBe
-      """{"highlight":{"fields":{"text":{"boundary_chars":"test"}}}}"""
+      """{"version":true,"highlight":{"fields":{"text":{"boundary_chars":"test"}}}}"""
   }
 }


### PR DESCRIPTION
https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-version.html
I see no reason to leave it off, specially given that `version` on `SearchHit` is non-optional.