### PR TITLE
Fix inner hits propagation from HasChildren builder to JSON query

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/nested/HasChildBodyFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/nested/HasChildBodyFn.scala
@@ -18,6 +18,7 @@ object HasChildBodyFn {
     q.ignoreUnmapped.foreach(builder.field("ignore_unmapped", _))
     q.boost.foreach(builder.field("boost", _))
     q.queryName.foreach(builder.field("_name", _))
+    q.innerHit.foreach(inner => builder.rawField("inner_hits", InnerHitQueryBodyFn(inner)))
     builder.endObject()
     builder.endObject()
     builder

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/nested/InnerHitQueryBodyFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/nested/InnerHitQueryBodyFn.scala
@@ -9,6 +9,9 @@ object InnerHitQueryBodyFn {
 
   def apply(d: InnerHitDefinition): XContentBuilder = {
     val builder = XContentFactory.jsonBuilder()
+    if (d.name.trim.nonEmpty) {
+      builder.field("name", d.name)
+    }
     d.from.foreach(builder.field("from", _))
     d.explain.foreach(builder.field("explain", _))
 

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/collapse/CollapseBuilderFnTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/collapse/CollapseBuilderFnTest.scala
@@ -16,6 +16,6 @@ class CollapseBuilderFnTest extends FunSuite with Matchers {
       .inner(InnerHitDefinition("name").size(1))
       .maxConcurrentGroupSearches(8)
     CollapseBuilderFn.apply(c).string shouldBe
-      """{"field":"something","max_concurrent_group_searches":8,"inner_hits":{"size":1}}"""
+      """{"field":"something","max_concurrent_group_searches":8,"inner_hits":{"name":"name","size":1}}"""
   }
 }

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/HasChildBodyFnTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/HasChildBodyFnTest.scala
@@ -2,7 +2,7 @@ package com.sksamuel.elastic4s.http.search.queries
 
 import com.sksamuel.elastic4s.http.search.queries.nested.HasChildBodyFn
 import com.sksamuel.elastic4s.searches.ScoreMode
-import com.sksamuel.elastic4s.searches.queries.HasChildQueryDefinition
+import com.sksamuel.elastic4s.searches.queries.{HasChildQueryDefinition, InnerHitDefinition}
 import com.sksamuel.elastic4s.searches.queries.matches.MatchQueryDefinition
 import org.scalatest.{FunSuite, Matchers}
 
@@ -14,7 +14,8 @@ class HasChildBodyFnTest extends FunSuite with Matchers {
       .minMaxChildren(2, 10)
       .ignoreUnmapped(true)
       .queryName("myquery")
+      .innerHit(InnerHitDefinition("inners"))
     HasChildBodyFn(q).string() shouldBe
-      """{"has_child":{"type":"blog_tag","min_children":2,"max_children":10,"score_mode":"min","query":{"match":{"tag":{"query":"something"}}},"ignore_unmapped":true,"boost":1.2,"_name":"myquery"}}"""
+      """{"has_child":{"type":"blog_tag","min_children":2,"max_children":10,"score_mode":"min","query":{"match":{"tag":{"query":"something"}}},"ignore_unmapped":true,"boost":1.2,"_name":"myquery","inner_hits":{"name":"inners"}}}"""
   }
 }

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/InnerHitQueryBodyFnTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/InnerHitQueryBodyFnTest.scala
@@ -1,0 +1,26 @@
+package com.sksamuel.elastic4s.http.search.queries
+
+import com.sksamuel.elastic4s.http.search.queries.nested.InnerHitQueryBodyFn
+import com.sksamuel.elastic4s.searches.HighlightFieldDefinition
+import com.sksamuel.elastic4s.searches.queries.InnerHitDefinition
+import com.sksamuel.elastic4s.searches.sort.FieldSortDefinition
+import org.scalatest.{FunSuite, Matchers}
+
+class InnerHitQueryBodyFnTest extends FunSuite with Matchers {
+
+  test("inner hit should generate expected json") {
+    val q = InnerHitDefinition("inners")
+      .from(2)
+      .explain(false)
+      .trackScores(true)
+      .version(true)
+      .size(2)
+      .docValueFields(List("df1", "df2"))
+      .sortBy(FieldSortDefinition("sortField"))
+      .storedFieldNames(List("field1", "field2"))
+      .highlighting(HighlightFieldDefinition("hlField"))
+
+    InnerHitQueryBodyFn(q).string() shouldBe
+      """{"name":"inners","from":2,"explain":false,"track_scores":true,"version":true,"size":2,"docvalue_fields":["df1","df2"],"sort":[{"sortField":{"order":"asc"}}],"stored_fields":["field1","field2"],"highlight":{"fields":{"hlField":{}}}}"""
+  }
+}


### PR DESCRIPTION
This PR fixes propagation of `inner_hits` attribute of `has_child` query. Example:

```
val query = search("myidx").query(
    hasChildQuery("currencies")
        .query(matchQuery("referential", true))
        .scoreMode(ScoreMode.None)
        .innerHit(InnerHitDefinition("currencies"))
)
client.show(query)
```
would result into 
```
{
  "query": {
    "has_child": {
      "type": "currencies",
      "score_mode": "none",
      "query": {
        "match": { "referential": { "query": true } }
      }
    }
  }
}
```
Where `inner_hits` attribute is missing.


Also `name` attribute of `inner_hits` was not propagated. Fixed along the way in this PR as the two problems are tightly coupled.