### PR TITLE
Make Jackson deserialization work proper for some generics

### DIFF
--- a/elastic4s-jackson/src/main/scala/com/sksamuel/elastic4s/jackson/ElasticJackson.scala
+++ b/elastic4s-jackson/src/main/scala/com/sksamuel/elastic4s/jackson/ElasticJackson.scala
@@ -1,8 +1,8 @@
 package com.sksamuel.elastic4s.jackson
 
-import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
 import com.sksamuel.elastic4s._
 import com.sksamuel.exts.Logging
 
@@ -18,7 +18,7 @@ object ElasticJackson {
       }
     }
 
-    implicit def JacksonJsonHitReader[T](implicit mapper: ObjectMapper = JacksonSupport.mapper,
+    implicit def JacksonJsonHitReader[T](implicit mapper: ObjectMapper with ScalaObjectMapper = JacksonSupport.mapper,
                                          manifest: Manifest[T]): HitReader[T] = new HitReader[T] {
       override def read(hit: Hit): Either[Throwable, T] = {
         require(hit.sourceAsString != null)
@@ -32,7 +32,7 @@ object ElasticJackson {
           if (!node.has("_timestamp")) hit.sourceFieldOpt("_timestamp").collect {
             case f => f.toString
           }.foreach(node.put("_timestamp", _))
-          Right(mapper.readValue[T](mapper.writeValueAsBytes(node), manifest.runtimeClass.asInstanceOf[Class[T]]))
+          Right(mapper.readValue[T](mapper.writeValueAsBytes(node)))
         } catch {
           case NonFatal(e) => Left(e)
         }


### PR DESCRIPTION
Warning: this change breaks this test (but perhaps not the feature being tested):
```scala
"support custom mapper" in {

      implicit val mapper: ObjectMapper = mock[ObjectMapper]
      Mockito.when(mapper.readTree(org.mockito.Matchers.anyString)).thenReturn(mock[ObjectNode])

      val resp = client.execute {
        search("jacksontest" / "characters").query("breaking")
      }.await
      // our custom mapper will just return null so that should be returned
      resp.to[Character].toList shouldBe List(null)
    }
```

This fixes serialization of objects shaped like `SomeType[Generic1, Generic2]` because `ScalaObjectMapper.constructType[T]` handle all corner cases while `manifest.runtimeClass.asInstanceOf[Class[T]]` is too simplistic.

