### PR TITLE
Inner hits for has parent 5.4.x

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/nested/HasParentBodyFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/nested/HasParentBodyFn.scala
@@ -16,6 +16,7 @@ object HasParentBodyFn {
     if (q.score)
       builder.field("score", true)
     q.boost.foreach(builder.field("boost", _))
+    q.innerHit.foreach(inner => builder.rawField("inner_hits", InnerHitQueryBodyFn(inner).bytes, XContentType.JSON))
     q.queryName.foreach(builder.field("_name", _))
     builder.endObject()
     builder.endObject()

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/responses.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/responses.scala
@@ -43,7 +43,7 @@ case class SearchHit(@JsonProperty("_id") id: String,
         max_score = v("max_score").asInstanceOf[Double],
         hits = v("hits").asInstanceOf[Seq[Map[String, AnyRef]]].map { hits =>
           InnerHit(
-            nested = hits("_nested").asInstanceOf[Map[String, AnyRef]],
+            nested = hits.get("_nested").map(_.asInstanceOf[Map[String, AnyRef]]).getOrElse(Map.empty),
             score = hits("_score").asInstanceOf[Double],
             source = hits("_source").asInstanceOf[Map[String, AnyRef]],
             highlight = hits.get("highlight").map(_.asInstanceOf[Map[String, Seq[String]]]).getOrElse(Map.empty)

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/HasParentBodyFnTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/HasParentBodyFnTest.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.elastic4s.http.search.queries
 
 import com.sksamuel.elastic4s.http.search.queries.nested.HasParentBodyFn
-import com.sksamuel.elastic4s.searches.queries.HasParentQueryDefinition
+import com.sksamuel.elastic4s.searches.queries.{HasParentQueryDefinition, InnerHitDefinition}
 import com.sksamuel.elastic4s.searches.queries.matches.MatchQueryDefinition
 import org.scalatest.{FunSuite, Matchers}
 
@@ -11,8 +11,9 @@ class HasParentBodyFnTest extends FunSuite with Matchers {
     val q = HasParentQueryDefinition("blog", MatchQueryDefinition("tag", "something"), true)
       .boost(1.2)
       .ignoreUnmapped(true)
+      .innerHit(InnerHitDefinition("inners"))
       .queryName("myquery")
     HasParentBodyFn(q).string() shouldBe
-      """{"has_parent":{"parent_type":"blog","query":{"match":{"tag":{"query":"something"}}},"ignore_unmapped":true,"score":true,"boost":1.2,"_name":"myquery"}}"""
+      """{"has_parent":{"parent_type":"blog","query":{"match":{"tag":{"query":"something"}}},"ignore_unmapped":true,"score":true,"boost":1.2,"inner_hits":{},"_name":"myquery"}}"""
   }
 }


### PR DESCRIPTION
Backport for 5.4.

https://github.com/sksamuel/elastic4s/issues/1044

Was thinking about backporting https://github.com/sksamuel/elastic4s/pull/1017 since they're related.