### PR TITLE
fix inner hits for HasChild (backport of PR 1017)

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/nested/HasChildBodyFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/nested/HasChildBodyFn.scala
@@ -19,6 +19,7 @@ object HasChildBodyFn {
     q.ignoreUnmapped.foreach(builder.field("ignore_unmapped", _))
     q.boost.foreach(builder.field("boost", _))
     q.queryName.foreach(builder.field("_name", _))
+    q.innerHit.foreach(inner => builder.rawField("inner_hits", InnerHitQueryBodyFn(inner).bytes, XContentType.JSON))
     builder.endObject()
     builder.endObject()
     builder

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/nested/InnerHitQueryBodyFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/nested/InnerHitQueryBodyFn.scala
@@ -11,6 +11,9 @@ object InnerHitQueryBodyFn {
   def apply(d: InnerHitDefinition): XContentBuilder = {
     val builder = XContentFactory.jsonBuilder()
     builder.startObject()
+    if (d.name.trim.nonEmpty) {
+      builder.field("name", d.name)
+    }
     d.from.foreach(builder.field("from", _))
     d.explain.foreach(builder.field("explain", _))
     d.fetchSource.foreach(builder.field("_source", _))

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/collapse/CollapseBuilderFnTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/collapse/CollapseBuilderFnTest.scala
@@ -16,6 +16,6 @@ class CollapseBuilderFnTest extends FunSuite with Matchers {
       .inner(InnerHitDefinition("name").size(1))
       .maxConcurrentGroupSearches(8)
     CollapseBuilderFn.apply(c).string shouldBe
-      """{"field":"something","max_concurrent_group_searches":8,"inner_hits":{"size":1}}"""
+      """{"field":"something","max_concurrent_group_searches":8,"inner_hits":{"name":"name","size":1}}"""
   }
 }

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/HasChildBodyFnTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/HasChildBodyFnTest.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.elastic4s.http.search.queries
 
 import com.sksamuel.elastic4s.http.search.queries.nested.HasChildBodyFn
-import com.sksamuel.elastic4s.searches.queries.HasChildQueryDefinition
+import com.sksamuel.elastic4s.searches.queries.{HasChildQueryDefinition, InnerHitDefinition}
 import com.sksamuel.elastic4s.searches.queries.matches.MatchQueryDefinition
 import org.apache.lucene.search.join.ScoreMode
 import org.scalatest.{FunSuite, Matchers}
@@ -14,7 +14,8 @@ class HasChildBodyFnTest extends FunSuite with Matchers {
       .minMaxChildren(2, 10)
       .ignoreUnmapped(true)
       .queryName("myquery")
+      .innerHit(InnerHitDefinition("inners"))
     HasChildBodyFn(q).string() shouldBe
-      """{"has_child":{"type":"blog_tag","min_children":2,"max_children":10,"score_mode":"sum","query":{"match":{"tag":{"query":"something"}}},"ignore_unmapped":true,"boost":1.2,"_name":"myquery"}}"""
+      """{"has_child":{"type":"blog_tag","min_children":2,"max_children":10,"score_mode":"sum","query":{"match":{"tag":{"query":"something"}}},"ignore_unmapped":true,"boost":1.2,"_name":"myquery","inner_hits":{"name":"inners"}}}"""
   }
 }

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/HasParentBodyFnTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/HasParentBodyFnTest.scala
@@ -14,6 +14,6 @@ class HasParentBodyFnTest extends FunSuite with Matchers {
       .innerHit(InnerHitDefinition("inners"))
       .queryName("myquery")
     HasParentBodyFn(q).string() shouldBe
-      """{"has_parent":{"parent_type":"blog","query":{"match":{"tag":{"query":"something"}}},"ignore_unmapped":true,"score":true,"boost":1.2,"inner_hits":{},"_name":"myquery"}}"""
+      """{"has_parent":{"parent_type":"blog","query":{"match":{"tag":{"query":"something"}}},"ignore_unmapped":true,"score":true,"boost":1.2,"inner_hits":{"name":"inners"},"_name":"myquery"}}"""
   }
 }

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/InnerHitQueryBodyFnTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/InnerHitQueryBodyFnTest.scala
@@ -1,0 +1,24 @@
+package com.sksamuel.elastic4s.http.search.queries
+
+import com.sksamuel.elastic4s.http.search.queries.nested.InnerHitQueryBodyFn
+import com.sksamuel.elastic4s.searches.HighlightFieldDefinition
+import com.sksamuel.elastic4s.searches.queries.InnerHitDefinition
+import org.scalatest.{FunSuite, Matchers}
+
+class InnerHitQueryBodyFnTest extends FunSuite with Matchers {
+
+  test("inner hit should generate expected json") {
+    val q = InnerHitDefinition("inners")
+      .from(2)
+      .explain(false)
+      .trackScores(true)
+      .version(true)
+      .size(2)
+      .docValueFields(List("df1", "df2"))
+      .storedFieldNames(List("field1", "field2"))
+      .highlighting(HighlightFieldDefinition("hlField"))
+
+    InnerHitQueryBodyFn(q).string() shouldBe
+      """{"name":"inners","from":2,"explain":false,"track_scores":true,"version":true,"size":2,"docvalue_fields":["df1","df2"],"stored_fields":["field1","field2"],"highlight":{"fields":{"hlField":{}}}}"""
+  }
+}


### PR DESCRIPTION
This fixes the issue described in #1017 for the 5.4.x branch.

Had to remove `.sortBy` from `InnerHitQueryBodyFnTest` origin test since
the implementation on the 5.4.x branch isn't complete.