### PR TITLE
timezone in date range fix (backport to 5.4.x)

### DIFF
--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/aggs/DateRangeBuilder.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/aggs/DateRangeBuilder.scala
@@ -15,7 +15,7 @@ object DateRangeBuilder {
     agg.format.foreach(builder.format)
     agg.script.map(ScriptBuilder.apply).foreach(builder.script)
     agg.keyed(builder.keyed)
-    agg.timeZone(builder.timeZone)
+    agg.timeZone.foreach(builder.timeZone)
 
     agg.unboundedFromRanges.foreach {
       case (Some(key), str: String) => builder.addUnboundedFrom(key, str)


### PR DESCRIPTION
fixes #1063

By the way are you going to support Elasticsearch 5.5.x?