### PR TITLE
add index_options to keyword field

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/CommonFieldBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/CommonFieldBuilder.scala
@@ -113,6 +113,7 @@ object FieldBuilderFn {
         keyword.eagerGlobalOrdinals.foreach(builder.field("eager_global_ordinals", _))
         keyword.ignoreAbove.foreach(builder.field("ignore_above", _))
         keyword.similarity.foreach(builder.field("similarity", _))
+        keyword.indexOptions.foreach(builder.field("index_options", _))
 
     }
     builder.endObject()

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/KeywordFieldDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/KeywordFieldDefinition.scala
@@ -55,6 +55,8 @@ case class KeywordFieldDefinition(name: String,
   override def store(b: Boolean): T = copy(store = b.some)
 
   override def termVector(t: String): T = copy(termVector = t.some)
+
+  def indexOptions(indexOptions: String): T = copy(indexOptions = indexOptions.some)
 }
 
 


### PR DESCRIPTION
Added missing [`index_options`](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-options.html) option to `keyword` field.