### PR TITLE
add travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,11 @@
 language: scala
+cache:
+  directories:
+    - $HOME/.ivy2/cache
+    - $HOME/.sbt
+before_cache:
+  - find $HOME/.sbt -name "*.lock" | xargs rm
+  - find $HOME/.ivy2 -name "ivydata-*.properties" | xargs rm
 before_script:
 - sudo chmod +x /usr/local/bin/sbt
 scala:


### PR DESCRIPTION
I found that travis cache is not configured. This will reduce travis build time.

[sbt doc](http://www.scala-sbt.org/0.13/docs/Travis-CI-with-sbt.html)