### PR TITLE
Fix 1085: handle 200 response status code when indexing

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/IndexImplicits.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/IndexImplicits.scala
@@ -16,7 +16,7 @@ trait IndexImplicits extends IndexShowImplicits {
 
     override def responseHandler: ResponseHandler[Either[IndexFailure, IndexResponse]] = new ResponseHandler[Either[IndexFailure, IndexResponse]] {
       override def doit(response: HttpResponse): Either[IndexFailure, IndexResponse] = response.statusCode match {
-        case 201 => Right(ResponseHandler.fromEntity[IndexResponse](response.entity.getOrError("Index responses must have a body")))
+        case 201 | 200 => Right(ResponseHandler.fromEntity[IndexResponse](response.entity.getOrError("Index responses must have a body")))
         case 400 | 500 => Left(IndexFailure(response.entity.get.content))
         case _ => sys.error(response.toString)
       }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/indexes/IndexTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/indexes/IndexTest.scala
@@ -1,5 +1,7 @@
 package com.sksamuel.elastic4s.indexes
 
+import java.util.UUID
+
 import com.sksamuel.elastic4s.http.ElasticDsl
 import com.sksamuel.elastic4s.testkit.DiscoveryLocalNodeProvider
 import com.sksamuel.elastic4s.{Indexable, RefreshPolicy}
@@ -95,6 +97,16 @@ class IndexTest extends WordSpec with Matchers with ElasticDsl with DiscoveryLoc
         indexInto("electronics" / "electronics").fields("name" -> "super phone").refresh(RefreshPolicy.Immediate)
       }.await
       result.right.get.result shouldBe "created"
+    }
+    "return OK status if the document already exists" in {
+      val id = UUID.randomUUID()
+      http.execute {
+        indexInto("electronics" / "electronics").fields("name" -> "super phone").withId(id).refresh(RefreshPolicy.Immediate)
+      }.await
+      val result = http.execute {
+        indexInto("electronics" / "electronics").fields("name" -> "super phone").withId(id).refresh(RefreshPolicy.Immediate)
+      }.await
+      result.right.get.result shouldBe "updated"
     }
     "return Left when the request has an invalid index name" in {
       val result = http.execute {


### PR DESCRIPTION
When indexing an existing document (with the same id), elastic search
answers with a 200 response status.

fix https://github.com/sksamuel/elastic4s/issues/1085