### PR TITLE
Add compound word token filter to DSL

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/analyzers/TokenFilter.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/analyzers/TokenFilter.scala
@@ -422,3 +422,59 @@ case class ShingleTokenFilter(name: String,
   def tokenSeperator(sep: String): ShingleTokenFilter = copy(token_separator = sep)
   def fillerToken(filler: String): ShingleTokenFilter = copy(filler_token = filler)
 }
+
+sealed trait CompoundWordTokenFilterType {
+  def name: String
+}
+case object HyphenationDecompounder extends CompoundWordTokenFilterType {
+  override def name = "hyphenation_decompounder"
+}
+
+case object DictionaryDecompounder extends CompoundWordTokenFilterType {
+  override def name = "dictionary_decompounder"
+}
+
+
+case class CompoundWordTokenFilter(name: String,
+                                   `type`: CompoundWordTokenFilterType,
+                                   wordList: Iterable[String] = Nil,
+                                   wordListPath: Option[String] = None,
+                                   hyphenationPatternsPath: Option[String] = None,
+                                   minWordSize: Option[Int] = None,
+                                   minSubwordSize: Option[Int] = None,
+                                   maxSubwordSize: Option[Int] = None,
+                                   onlyLongestMatch: Option[Boolean] = None)
+  extends TokenFilterDefinition {
+
+  val filterType = `type`.name
+
+  override def build(source: XContentBuilder): Unit = {
+    if (wordList.nonEmpty) {
+      source.array("word_list", wordList.toArray)
+    }
+    wordListPath.foreach(source.field("word_list_path", _))
+    hyphenationPatternsPath.foreach(source.field("hyphenation_patterns_path", _))
+    minWordSize.foreach(source.field("min_word_size", _))
+    minSubwordSize.foreach(source.field("min_subword_size", _))
+    maxSubwordSize.foreach(source.field("max_subword_size", _))
+    onlyLongestMatch.foreach(source.field("only_longest_match", _))
+  }
+
+  def wordList(wordList: Iterable[String]): CompoundWordTokenFilter =
+    copy(wordList = wordList)
+  def wordList(word: String, rest: String*): CompoundWordTokenFilter =
+    copy(wordList = word +: rest)
+  def wordListPath(wordListPath: String): CompoundWordTokenFilter =
+    copy(wordListPath = wordListPath.some)
+  def hyphenationPatternsPath(hyphenationPatternsPath: String): CompoundWordTokenFilter =
+    copy(hyphenationPatternsPath = hyphenationPatternsPath.some)
+  def minWordSize(minWordSize: Int): CompoundWordTokenFilter =
+    copy(minWordSize = minWordSize.some)
+  def minSubwordSize(minSubwordSize: Int): CompoundWordTokenFilter =
+    copy(minSubwordSize = minSubwordSize.some)
+  def maxSubwordSize(maxSubwordSize: Int): CompoundWordTokenFilter =
+    copy(maxSubwordSize = maxSubwordSize.some)
+  def onlyLongestMatch(onlyLongestMatch: Boolean): CompoundWordTokenFilter =
+    copy(onlyLongestMatch = onlyLongestMatch.some)
+}
+

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/analyzers/TokenFilterDsl.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/analyzers/TokenFilterDsl.scala
@@ -43,4 +43,7 @@ trait TokenFilterDsl {
   def uniqueTokenFilter(name: String): UniqueTokenFilter = UniqueTokenFilter(name)
 
   def wordDelimiterTokenFilter(name: String): WordDelimiterTokenFilter = WordDelimiterTokenFilter(name)
+
+  def compoundWordTokenFilter(name: String, `type`: CompoundWordTokenFilterType) =
+    CompoundWordTokenFilter(name, `type`)
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/analyzers/CompoundWordTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/analyzers/CompoundWordTokenFilterTest.scala
@@ -1,0 +1,34 @@
+package com.sksamuel.elastic4s.analyzers
+
+import org.scalatest.{Matchers, WordSpec}
+
+class CompoundWordTokenFilterTest extends WordSpec with TokenFilterDsl with Matchers {
+
+  "CompoundWordTokenFilter builder" should {
+    "set type" in {
+      compoundWordTokenFilter("testy", DictionaryDecompounder).json.string shouldBe """{"type":"dictionary_decompounder"}"""
+    }
+    "set word list" in {
+      compoundWordTokenFilter("testy", HyphenationDecompounder).wordList("boo", "foo").json.string shouldBe """{"type":"hyphenation_decompounder","word_list":["boo","foo"]}"""
+    }
+    "set word list path" in {
+      compoundWordTokenFilter("testy", HyphenationDecompounder).wordListPath("config/word.txt").json.string shouldBe """{"type":"hyphenation_decompounder","word_list_path":"config/word.txt"}"""
+    }
+    "set hyphenation patterns path" in {
+      compoundWordTokenFilter("testy", HyphenationDecompounder).wordListPath("config/hyphens.txt").json.string shouldBe """{"type":"hyphenation_decompounder","word_list_path":"config/hyphens.txt"}"""
+    }
+    "set min word size" in {
+      compoundWordTokenFilter("testy", HyphenationDecompounder).minWordSize(7).json.string shouldBe """{"type":"hyphenation_decompounder","min_word_size":7}"""
+    }
+    "set min subword size" in {
+      compoundWordTokenFilter("testy", HyphenationDecompounder).minSubwordSize(3).json.string shouldBe """{"type":"hyphenation_decompounder","min_subword_size":3}"""
+    }
+    "set max subword size" in {
+      compoundWordTokenFilter("testy", HyphenationDecompounder).maxSubwordSize(18).json.string shouldBe """{"type":"hyphenation_decompounder","max_subword_size":18}"""
+    }
+    "set only longest match" in {
+      compoundWordTokenFilter("testy", HyphenationDecompounder).onlyLongestMatch(true).json.string shouldBe """{"type":"hyphenation_decompounder","only_longest_match":true}"""
+    }
+  }
+}
+


### PR DESCRIPTION
Thanks for this great library!

I found that this was missing from the DSL so added it. The documentation can be found [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-compound-word-tokenfilter.html)

