### PR TITLE
Add InnerHit.sort property to retrieve calculated sort score for sort…

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/responses.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/responses.scala
@@ -47,7 +47,8 @@ case class SearchHit(@JsonProperty("_id") id: String,
             nested = hits.get("_nested").map(_.asInstanceOf[Map[String, AnyRef]]).getOrElse(Map.empty),
             score = hits("_score").asInstanceOf[Double],
             source = hits("_source").asInstanceOf[Map[String, AnyRef]],
-            highlight = hits.get("highlight").map(_.asInstanceOf[Map[String, Seq[String]]]).getOrElse(Map.empty)
+            highlight = hits.get("highlight").map(_.asInstanceOf[Map[String, Seq[String]]]).getOrElse(Map.empty),
+            sort = hits.get("sort").map(_.asInstanceOf[Seq[Double]]).getOrElse(Seq.empty)
           )
         }
       )
@@ -69,7 +70,8 @@ case class InnerHits(total: Int,
 case class InnerHit(nested: Map[String, AnyRef],
                     score: Double,
                     source: Map[String, AnyRef],
-                    highlight: Map[String, Seq[String]])
+                    highlight: Map[String, Seq[String]],
+                    sort: Seq[Double])
 
 case class SearchResponse(took: Int,
                           @JsonProperty("timed_out") isTimedOut: Boolean,


### PR DESCRIPTION
…ed inner hits

A query such as:

`                        "inner_hits": {
                            "name": "location.geo",
                            "sort": [
                                {
                                    "_geo_distance": {
                                        "distance_type": "plane",
                                        "mode": "min",
                                        "nested_path": "location",
                                        "location.geo": [
                                            [
                                                -118.2735595703125,
                                                34.063804626464844
                                            ]
                                        ],
                                        "order": "asc"
                                    }
                                }
                            ]
                        }`

results in a response with a "sort" calculation in the inner_hits. This is particularly useful for determining the distance a location is from a specified point (which is my use case). In any case, it is in the elasticsearch return so it seems to me it should be in the case class for InnerHit in the client. 

Thanks for your consideration.