### PR TITLE
Add InnerHit.sort property for inner_hits sort calculations

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/responses.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/responses.scala
@@ -47,7 +47,8 @@ case class SearchHit(@JsonProperty("_id") id: String,
             nested = hits.get("_nested").map(_.asInstanceOf[Map[String, AnyRef]]).getOrElse(Map.empty),
             score = hits("_score").asInstanceOf[Double],
             source = hits("_source").asInstanceOf[Map[String, AnyRef]],
-            highlight = hits.get("highlight").map(_.asInstanceOf[Map[String, Seq[String]]]).getOrElse(Map.empty)
+            highlight = hits.get("highlight").map(_.asInstanceOf[Map[String, Seq[String]]]).getOrElse(Map.empty),
+            sort = hits.get("sort").map(_.asInstanceOf[Seq[Double]]).getOrElse(Seq.empty)
           )
         }
       )
@@ -69,7 +70,8 @@ case class InnerHits(total: Int,
 case class InnerHit(nested: Map[String, AnyRef],
                     score: Double,
                     source: Map[String, AnyRef],
-                    highlight: Map[String, Seq[String]])
+                    highlight: Map[String, Seq[String]],
+                    sort: Seq[Double])
 
 case class SearchResponse(took: Int,
                           @JsonProperty("timed_out") isTimedOut: Boolean,

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/responses.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/responses.scala
@@ -48,7 +48,7 @@ case class SearchHit(@JsonProperty("_id") id: String,
             score = hits("_score").asInstanceOf[Double],
             source = hits("_source").asInstanceOf[Map[String, AnyRef]],
             highlight = hits.get("highlight").map(_.asInstanceOf[Map[String, Seq[String]]]).getOrElse(Map.empty),
-            sort = hits.get("sort").map(_.asInstanceOf[Seq[Double]]).getOrElse(Seq.empty)
+            sort = hits.get("sort").map(_.asInstanceOf[Seq[AnyRef]]).getOrElse(Seq.empty)
           )
         }
       )
@@ -71,7 +71,7 @@ case class InnerHit(nested: Map[String, AnyRef],
                     score: Double,
                     source: Map[String, AnyRef],
                     highlight: Map[String, Seq[String]],
-                    sort: Seq[Double])
+                    sort: Seq[AnyRef])
 
 case class SearchResponse(took: Int,
                           @JsonProperty("timed_out") isTimedOut: Boolean,


### PR DESCRIPTION
An example of where this is useful is in retrieving the geo distance of a nested object to determine the actual distance from a queried/filtered point.

This in an inner_hits filter:

`
    "sort": [
        {
            "_geo_distance": {
                "mode": "min",
                "offices.geo": [
                    [
                        -118.2735595703125,
                        34.063804626464844
                    ]
                ],
                "order": "asc"
            }
        }
    ]`

Will produce a "sort" property of the inner_hits json that contains the distance of that specific office. 

If nothing else, it is something returned by Elastic Search... it seems like a good thing to have in the elastic4s case class.

Thank you for your consideration.