### PR TITLE
all_fields support in query string without breaking API, #1098

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/text/QueryStringBodyFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/text/QueryStringBodyFn.scala
@@ -27,12 +27,17 @@ object QueryStringBodyFn {
     s.tieBreaker.foreach(builder.field("tie_breaker", _))
     s.rewrite.map(_.toString).foreach(builder.field("rewrite", _))
 
+
     if (s.fields.nonEmpty) {
       val fields = s.fields.map {
         case (name, 0.0D) => name
         case (name, boost) => s"$name^$boost"
       }.toArray
       builder.field("fields", fields)
+    } else {
+      if (s.defaultField == None) {
+        builder.field("all_fields", true)
+      }
     }
 
     builder.field("query", s.query)

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/HighlightFieldBuilderFnTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/HighlightFieldBuilderFnTest.scala
@@ -61,6 +61,17 @@ class HighlightFieldBuilderFnTest extends FunSuite with Matchers {
     HighlightFieldBuilderFn(Iterable(highlight)).string() shouldBe
       """{"fields":{"text":{"highlight_query":{"match":{"body":{"query":"foo"}}}}}}"""
   }
+
+  test("'query' generates 'highlight_query' field without providing the query field (search for value in all fields.).") {
+    // Given
+    val highlight =
+      HighlightFieldDefinition("text")
+        .query(query("foo"))
+    // Then
+    HighlightFieldBuilderFn(Iterable(highlight)).string() shouldBe
+      """{"fields":{"text":{"highlight_query":{"query_string":{"all_fields":true,"query":"foo"}}}}}"""
+  }
+
   test("'matchedFields' generates proper 'matched_fields' field as array field.") {
     // Given
     val highlight =

--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/queries/QueryStringBuilderFn.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/queries/QueryStringBuilderFn.scala
@@ -29,6 +29,7 @@ object QueryStringBuilderFn {
     query.rewrite.foreach(builder.rewrite)
     query.splitOnWhitespace.foreach(builder.splitOnWhitespace)
     query.tieBreaker.map(_.toFloat).foreach(builder.tieBreaker)
+    builder.useAllFields(query.fields.isEmpty && query.defaultField == None)
     builder
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/highlight/HighlightTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/highlight/HighlightTest.scala
@@ -104,5 +104,16 @@ class HighlightTest extends WordSpec with Matchers with ElasticDsl with DualElas
       fragments.size shouldBe 1
       fragments.head.trim shouldBe "out new <em>life</em> and"
     }
+
+    "use highlight query without query fields provided." in {
+      val resp = execute {
+        search("intros" / "tv") query matchQuery("text", "frontier") highlighting (
+          highlight("text") fragmentSize 20 query query("life")
+          )
+      }.await
+      val fragments = resp.hits.hits.head.highlightFragments("text")
+      fragments.size shouldBe 1
+      fragments.head.trim shouldBe "out new <em>life</em> and"
+    }
   }
 }


### PR DESCRIPTION
Not the ideal implementation but it is least intrusive than other solutions. It will set all_fields to true only in case there the query is not including any fields and there is no default_field defined.