### PR TITLE
#1100 Fixed SpanNearQueryBIdyFn.scala to generate span_near ES query …

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/span/SpanNearQueryBodyFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/span/SpanNearQueryBodyFn.scala
@@ -1,6 +1,7 @@
 package com.sksamuel.elastic4s.http.search.queries.span
 
 import com.sksamuel.elastic4s.http.search.queries.QueryBuilderFn
+import com.sksamuel.elastic4s.http.search.queries.span.XContentBuilderExtensions._
 import com.sksamuel.elastic4s.searches.queries.span.SpanNearQueryDefinition
 import org.elasticsearch.common.xcontent.{XContentBuilder, XContentFactory}
 
@@ -9,11 +10,9 @@ object SpanNearQueryBodyFn {
     val builder = XContentFactory.jsonBuilder()
 
     builder.startObject()
-    builder.startObject("span_or")
+    builder.startObject("span_near")
     builder.startArray("clauses")
-    q.clauses.foreach { clause =>
-      builder.rawValue(QueryBuilderFn(clause).bytes)
-    }
+    builder.rawArrayValue(q.clauses.map(QueryBuilderFn.apply))
     builder.endArray()
 
     builder.field("slop", q.slop)

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/span/SpanOrQueryBodyFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/span/SpanOrQueryBodyFn.scala
@@ -1,6 +1,7 @@
 package com.sksamuel.elastic4s.http.search.queries.span
 
 import com.sksamuel.elastic4s.http.search.queries.QueryBuilderFn
+import com.sksamuel.elastic4s.http.search.queries.span.XContentBuilderExtensions._
 import com.sksamuel.elastic4s.searches.queries.span.SpanOrQueryDefinition
 import org.elasticsearch.common.xcontent.{XContentBuilder, XContentFactory}
 
@@ -11,9 +12,7 @@ object SpanOrQueryBodyFn {
     builder.startObject()
     builder.startObject("span_or")
     builder.startArray("clauses")
-    q.clauses.foreach { clause =>
-      builder.rawValue(QueryBuilderFn(clause).bytes)
-    }
+    builder.rawArrayValue(q.clauses.map(QueryBuilderFn.apply))
     builder.endArray()
 
     q.boost.foreach(builder.field("boost", _))

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/span/XContentBuilderExtensions.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/span/XContentBuilderExtensions.scala
@@ -1,0 +1,51 @@
+package com.sksamuel.elastic4s.http.search.queries.span
+
+import org.elasticsearch.common.bytes.BytesArray
+import org.elasticsearch.common.xcontent.XContentBuilder
+
+object XContentBuilderExtensions {
+  private val CommaByte: Byte = ','
+
+  implicit class RichXContentBuilder(builder: XContentBuilder) {
+    /**
+      * Default XContentFactory.rawValue method does not add comma symbol between array elements.
+      * This is low level workaround method to insert comma byte between array elements bytes.
+      *
+      * NOTE: we can't do builder.rawValue(SINGLE_COMMA_BYTE) so we first need to build entire array object in memory.
+      * NOTE: intentionally using low level methods to obtain max speed.
+      *
+      * @return original builder
+      */
+    def rawArrayValue(arrayObjects: Seq[XContentBuilder]): XContentBuilder = {
+      val elementsBytes: List[Array[Byte]] = arrayObjects.map(_.bytes.toBytesRef.bytes).toList
+
+      elementsBytes match {
+        case Nil =>
+        case head :: tail =>
+          val resultBytes = allocateResultByteArray(elementsBytes)
+          var currentDistPos = copyInternal(head, resultBytes, 0)
+          tail.foreach(bytes => {
+            resultBytes(currentDistPos) = CommaByte
+            currentDistPos += 1
+            currentDistPos += copyInternal(bytes, resultBytes, currentDistPos)
+          })
+          builder.rawValue(new BytesArray(resultBytes))
+      }
+
+      builder
+    }
+  }
+
+  private def copyInternal(src: Array[Byte], dist: Array[Byte], distPos: Int): Int = {
+    val srcLength = src.length
+    System.arraycopy(src, 0, dist, distPos, srcLength)
+    srcLength
+  }
+
+  private def allocateResultByteArray(elementsBytes: Seq[Array[Byte]]) = {
+    val commasCount = elementsBytes.size - 1
+    val totalBufferSize = elementsBytes.map(_.length).sum + commasCount
+    new Array[Byte](totalBufferSize)
+  }
+}
+

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/span/SpanNearQueryBodyFnTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/span/SpanNearQueryBodyFnTest.scala
@@ -1,0 +1,38 @@
+package com.sksamuel.elastic4s.http.search.queries.span
+
+import com.sksamuel.elastic4s.searches.queries.span.{SpanNearQueryDefinition, SpanTermQueryDefinition}
+import org.scalatest.FunSuite
+
+import scala.util.parsing.json.JSON
+
+class SpanNearQueryBodyFnTest extends FunSuite {
+
+  test("SpanNearQueryBodyFn apply should return appropriate XContentBuilder") {
+    val builder = SpanNearQueryBodyFn.apply(SpanNearQueryDefinition(
+      Seq(
+        SpanTermQueryDefinition("field1", "value1", Some("name1"), Some(4.0)),
+        SpanTermQueryDefinition("field2", "value2", Some("name2"), Some(7.0))
+      ),
+      slop = 42, boost = Some(2.0), inOrder = Some(true), queryName = Some("rootName")
+    ))
+
+    val actual = JSON.parseRaw(builder.string())
+    val expected = JSON.parseRaw(
+      """
+        |{
+        |   "span_near":{
+        |     "clauses":[
+        |         {"span_term":{"field1":"value1","boost":4.0,"_name":"name1"}},
+        |         {"span_term":{"field2":"value2","boost":7.0,"_name":"name2"}}
+        |      ],
+        |      "slop":42,
+        |      "in_order":true,
+        |      "boost":2.0,
+        |      "_name":"rootName"
+        |    }
+        |}""".stripMargin)
+
+    assert(actual === expected)
+  }
+
+}

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/span/SpanOrQueryBodyFnTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/span/SpanOrQueryBodyFnTest.scala
@@ -1,0 +1,36 @@
+package com.sksamuel.elastic4s.http.search.queries.span
+
+import com.sksamuel.elastic4s.searches.queries.span.{SpanNearQueryDefinition, SpanOrQueryDefinition, SpanTermQueryDefinition}
+import org.scalatest.FunSuite
+
+import scala.util.parsing.json.JSON
+
+class SpanOrQueryBodyFnTest extends FunSuite {
+
+  test("SpanOrQueryBodyFn apply should return appropriate XContentBuilder") {
+    val builder = SpanOrQueryBodyFn.apply(SpanOrQueryDefinition(
+      Seq(
+        SpanTermQueryDefinition("field1", "value1", Some("name1"), Some(4.0)),
+        SpanTermQueryDefinition("field2", "value2", Some("name2"), Some(7.0))
+      ),
+      boost = Some(2.0), queryName = Some("rootName")
+    ))
+
+    val actual = JSON.parseRaw(builder.string())
+    val expected = JSON.parseRaw(
+      """
+        |{
+        |   "span_or":{
+        |     "clauses":[
+        |         {"span_term":{"field1":"value1","boost":4.0,"_name":"name1"}},
+        |         {"span_term":{"field2":"value2","boost":7.0,"_name":"name2"}}
+        |      ],
+        |      "boost":2.0,
+        |      "_name":"rootName"
+        |    }
+        |}""".stripMargin)
+
+    assert(actual === expected)
+  }
+
+}

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/span/XContentBuilderExtensionsTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/span/XContentBuilderExtensionsTest.scala
@@ -1,0 +1,56 @@
+package com.sksamuel.elastic4s.http.search.queries.span
+
+import com.sksamuel.elastic4s.http.search.queries.span.XContentBuilderExtensions._
+import org.elasticsearch.common.xcontent.{XContentBuilder, XContentFactory}
+import org.scalatest.FunSuite
+
+import scala.util.parsing.json.JSON
+
+class XContentBuilderExtensionsTest extends FunSuite {
+
+  test("RichXContentBuilder.rawArrayValue should write not write bytes for empty array") {
+    val builder = XContentFactory.jsonBuilder()
+    builder.startArray()
+    builder.rawArrayValue(Seq())
+    builder.endArray()
+
+    val actual = JSON.parseRaw(builder.string())
+    val expected = JSON.parseRaw("""[]""")
+    assert(actual === expected)
+  }
+
+  test("RichXContentBuilder.rawArrayValue should write bytes array with one element") {
+    val builder = XContentFactory.jsonBuilder()
+    builder.startArray()
+    builder.rawArrayValue(Seq(getSimpleObject("f1", "v1")))
+    builder.endArray()
+
+    val actual = JSON.parseRaw(builder.string())
+    val expected = JSON.parseRaw("""[{"f1": "v1"}]""")
+    assert(actual === expected)
+  }
+
+  test("RichXContentBuilder.rawArrayValue should write bytes array many elements") {
+    val builder = XContentFactory.jsonBuilder()
+    builder.startArray()
+    builder.rawArrayValue(Seq(
+      getSimpleObject("f1", "v1"),
+      getSimpleObject("f2", "v2"),
+      getSimpleObject("f3", "v3")
+    ))
+    builder.endArray()
+
+    val actual = JSON.parseRaw(builder.string())
+    val expected = JSON.parseRaw(
+      """[
+        |   {"f1": "v1"},
+        |   {"f2": "v2"},
+        |   {"f3": "v3"}
+        |]""".stripMargin)
+    assert(actual === expected)
+  }
+
+  private def getSimpleObject(field: String, value: String): XContentBuilder = {
+    XContentFactory.jsonBuilder().startObject().field(field, value).endObject()
+  }
+}


### PR DESCRIPTION
This bug affects all versions.
see SpanNearQueryBodyFn.scala:
builder.startObject("span_or")
I believe this is caused by copypasting.
The fix is tiny: just replace span_or with span_near in all versions.

I cathed it in 5.4 version which actually contains another bug in above classes:
builder.rawValue inside an array does not add any comma between array entries.