### PR TITLE
Fixed crash during building sorting by GeoDistance

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/SortContentBuilder.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/SortContentBuilder.scala
@@ -45,7 +45,9 @@ object ScoreSortContentBuilder {
 object GeoDistanceSortContentBuilder {
   def apply(fs: GeoDistanceSortDefinition): XContentBuilder = {
 
-    val builder = XContentFactory.jsonBuilder().startObject("_geo_distance")
+    val builder = XContentFactory.jsonBuilder()
+    builder.startObject()
+    builder.startObject("_geo_distance")
 
     if (fs.points.nonEmpty) {
       val point = fs.points.head


### PR DESCRIPTION
Structure of builder should be similar to ScoreSort and starts with empty object