### PR TITLE
Remove hard-coded defaults from token filters

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/analyzers/TokenFilterDsl.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/analyzers/TokenFilterDsl.scala
@@ -24,11 +24,11 @@ trait TokenFilterDsl {
 
   def shingleTokenFilter(name: String): ShingleTokenFilter = ShingleTokenFilter(name)
 
-  def snowballTokenFilter(name: String): SnowballTokenFilter = SnowballTokenFilter(name)
+  def snowballTokenFilter(name: String, language: String): SnowballTokenFilter = SnowballTokenFilter(name, language)
 
   def stemmerOverrideTokenFilter(name: String): StemmerOverrideTokenFilter = StemmerOverrideTokenFilter(name)
 
-  def stemmerTokenFilter(name: String): StemmerTokenFilter = StemmerTokenFilter(name)
+  def stemmerTokenFilter(name: String, language: String): StemmerTokenFilter = StemmerTokenFilter(name, language)
 
   def stopTokenFilter(name: String): StopTokenFilter = StopTokenFilter(name)
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/analyzers/CommonGramsTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/analyzers/CommonGramsTokenFilterTest.scala
@@ -5,23 +5,32 @@ import org.scalatest.{Matchers, WordSpec}
 class CommonGramsTokenFilterTest extends WordSpec with TokenFilterDsl with Matchers {
 
   "CommonGramsTokenFilter builder" should {
+    "not set any defaults" in {
+      commonGramsTokenFilter("testy").json.string shouldBe """{"type":"common_grams"}"""
+    }
     "set common words" in {
       commonGramsTokenFilter("testy")
         .commonWords("the", "and")
         .json
-        .string shouldBe """{"type":"common_grams","common_words":["the","and"],"ignore_case":false,"query_mode":false}"""
+        .string shouldBe """{"type":"common_grams","common_words":["the","and"]}"""
+    }
+    "set common words path" in {
+      commonGramsTokenFilter("testy")
+        .commonWordsPath("some/file.txt")
+        .json
+        .string shouldBe """{"type":"common_grams","common_words_path":"some/file.txt"}"""
     }
     "set ignore case" in {
       commonGramsTokenFilter("testy")
         .ignoreCase(true)
         .json
-        .string shouldBe """{"type":"common_grams","ignore_case":true,"query_mode":false}"""
+        .string shouldBe """{"type":"common_grams","ignore_case":true}"""
     }
     "set query mode" in {
       commonGramsTokenFilter("testy")
         .queryMode(true)
         .json
-        .string shouldBe """{"type":"common_grams","ignore_case":false,"query_mode":true}"""
+        .string shouldBe """{"type":"common_grams","query_mode":true}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/analyzers/EdgeNGramTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/analyzers/EdgeNGramTokenFilterTest.scala
@@ -5,17 +5,20 @@ import org.scalatest.{Matchers, WordSpec}
 class EdgeNGramTokenFilterTest extends WordSpec with TokenFilterDsl with Matchers {
 
   "EdgeNGramTokenFilter builder" should {
+    "not set any defaults" in {
+      edgeNGramTokenFilter("testy").json.string shouldBe """{"type":"edgeNGram"}"""
+    }
     "set min and max ngrams" in {
       edgeNGramTokenFilter("testy")
         .minMaxGrams(3, 4)
         .json
-        .string shouldBe """{"type":"edgeNGram","min_gram":3,"max_gram":4,"side":"front"}"""
+        .string shouldBe """{"type":"edgeNGram","min_gram":3,"max_gram":4}"""
     }
     "set token chars" in {
       edgeNGramTokenFilter("testy")
         .side("backside")
         .json
-        .string shouldBe """{"type":"edgeNGram","min_gram":1,"max_gram":2,"side":"backside"}"""
+        .string shouldBe """{"type":"edgeNGram","side":"backside"}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/analyzers/NGramTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/analyzers/NGramTokenFilterTest.scala
@@ -5,6 +5,9 @@ import org.scalatest.{Matchers, WordSpec}
 class NGramTokenFilterTest extends WordSpec with TokenFilterDsl with Matchers {
 
   "NGramTokenFilter builder" should {
+    "not set any defaults" in {
+      ngramTokenFilter("testy").json.string shouldBe """{"type":"nGram"}"""
+    }
     "set min and max ngrams" in {
       ngramTokenFilter("testy").minMaxGrams(3, 4).json.string shouldBe """{"type":"nGram","min_gram":3,"max_gram":4}"""
     }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/analyzers/SnowballTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/analyzers/SnowballTokenFilterTest.scala
@@ -6,7 +6,7 @@ class SnowballTokenFilterTest extends WordSpec with TokenFilterDsl with Matchers
 
   "SnowballTokenFilter builder" should {
     "set language" in {
-      snowballTokenFilter("testy").lang("vulcan").json.string shouldBe """{"type":"snowball","language":"vulcan"}"""
+      snowballTokenFilter("testy", "vulcan").json.string shouldBe """{"type":"snowball","language":"vulcan"}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/analyzers/StemmerTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/analyzers/StemmerTokenFilterTest.scala
@@ -6,7 +6,7 @@ class StemmerTokenFilterTest extends WordSpec with TokenFilterDsl with Matchers 
 
   "StemmerTokenFilter builder" should {
     "set language" in {
-      stemmerTokenFilter("testy").lang("vulcan").json.string shouldBe """{"type":"stemmer","name":"vulcan"}"""
+      stemmerTokenFilter("testy", "vulcan").json.string shouldBe """{"type":"stemmer","name":"vulcan"}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/indexes/CreateIndexApiTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/indexes/CreateIndexApiTest.scala
@@ -51,7 +51,7 @@ class CreateIndexApiTest extends FlatSpec with MockitoSugar with JsonSugar with 
         StandardTokenizer("myTokenizer1", 900),
         lengthTokenFilter("myTokenFilter2").min(0).max(10),
         uniqueTokenFilter("myTokenFilter3").onlyOnSamePosition(true),
-        stemmerTokenFilter("myFrenchStemmerTokenFilter").lang("french"),
+        stemmerTokenFilter("myFrenchStemmerTokenFilter", "french"),
         PatternReplaceTokenFilter("prTokenFilter", "pattern", "rep"),
         WordDelimiterTokenFilter("myWordDelimiterTokenFilter")
           .generateWordParts(true)
@@ -71,7 +71,7 @@ class CreateIndexApiTest extends FlatSpec with MockitoSugar with JsonSugar with 
         stopTokenFilter("myTokenFilter1").enablePositionIncrements(true).ignoreCase(true),
         ReverseTokenFilter,
         LimitTokenCountTokenFilter("myTokenFilter5").maxTokenCount(5).consumeAllTokens(false),
-        EdgeNGramTokenFilter("myEdgeNGramTokenFilter", minGram = 3, maxGram = 50),
+        edgeNGramTokenFilter("myEdgeNGramTokenFilter").minGram(3).maxGram(50).side("front"),
         StemmerOverrideTokenFilter("stemmerTokenFilter", Array("rule1", "rule2")),
         HtmlStripCharFilter,
         MappingCharFilter("mapping_charfilter", "ph" -> "f", "qu" -> "q"),
@@ -114,7 +114,7 @@ class CreateIndexApiTest extends FlatSpec with MockitoSugar with JsonSugar with 
         StopTokenFilter("myTokenFilter1").enablePositionIncrements(true).ignoreCase(true),
         ReverseTokenFilter,
         LimitTokenCountTokenFilter("myTokenFilter5").maxTokenCount(5).consumeAllTokens(false),
-        EdgeNGramTokenFilter("myEdgeNGramTokenFilter", minGram = 3, maxGram = 50),
+        edgeNGramTokenFilter("myEdgeNGramTokenFilter").minGram(3).maxGram(50).side("front"),
         StemmerOverrideTokenFilter("stemmerTokenFilter", Array("rule1", "rule2")),
         HtmlStripCharFilter,
         MappingCharFilter("mapping_charfilter", "ph" -> "f", "qu" -> "q"),


### PR DESCRIPTION
This should remove the rest of the hard-coded defaults.