### PR TITLE
Use "source" instead of the deprecated "inline" key for scripts

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/script/ScriptDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/script/ScriptDefinition.scala
@@ -4,7 +4,7 @@ import scala.language.implicitConversions
 
 case class ScriptDefinition(script: String,
                             lang: Option[String] = None,
-                            scriptType: ScriptType = ScriptType.Inline,
+                            scriptType: ScriptType = ScriptType.Source,
                             params: Map[String, Any] = Map.empty,
                             options: Map[String, String] = Map.empty) {
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/script/ScriptType.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/script/ScriptType.scala
@@ -4,8 +4,12 @@ sealed trait ScriptType
 object ScriptType {
   def valueOf(str: String): ScriptType = str.toLowerCase match {
     case "inline" => Inline
+    case "source" => Source
     case "stored" => Stored
   }
+  @deprecated("use Source", "6.0.0")
   case object Inline extends ScriptType
+
+  case object Source extends ScriptType
   case object Stored extends ScriptType
 }

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/ScriptBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/ScriptBuilderFn.scala
@@ -12,7 +12,7 @@ object ScriptBuilderFn {
     script.lang.foreach(builder.field("lang", _))
 
     script.scriptType match {
-      case ScriptType.Inline => builder.field("inline", script.script)
+      case ScriptType.Inline => builder.field("source", script.script)
     }
 
     if (script.params.nonEmpty) {

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/ScriptBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/ScriptBuilderFn.scala
@@ -12,7 +12,8 @@ object ScriptBuilderFn {
     script.lang.foreach(builder.field("lang", _))
 
     script.scriptType match {
-      case ScriptType.Inline => builder.field("source", script.script)
+      case ScriptType.Source => builder.field("source", script.script)
+      case ScriptType.Inline => builder.field("inline", script.script)
     }
 
     if (script.params.nonEmpty) {

--- a/elastic4s-http/src/test/resources/score_script.json
+++ b/elastic4s-http/src/test/resources/score_script.json
@@ -1,7 +1,7 @@
 {
   "script_score": {
     "script": {
-      "inline": "some script",
+      "source": "some script",
       "lang": "java",
       "params": {
         "param1": "value1",

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/ScriptBuilderFnTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/ScriptBuilderFnTest.scala
@@ -7,26 +7,26 @@ class ScriptBuilderFnTest extends FunSuite with Matchers {
 
   test("should handle recursive maps") {
     ScriptBuilderFn(ScriptDefinition("myscript", params = Map("a" -> 1.2, "b" -> Map("c" -> true, "d" -> List(Map("e" -> 3)))))).string shouldBe
-      """{"inline":"myscript","params":{"a":1.2,"b":{"c":true,"d":[{"e":3}]}}}"""
+      """{"source":"myscript","params":{"a":1.2,"b":{"c":true,"d":[{"e":3}]}}}"""
   }
 
   test("should handle lists of maps") {
     ScriptBuilderFn(ScriptDefinition("myscript", params = Map("a" -> 1.2, "b" -> Map("c" -> true, "d" -> List(Map("e" -> 3)))))).string shouldBe
-      """{"inline":"myscript","params":{"a":1.2,"b":{"c":true,"d":[{"e":3}]}}}"""
+      """{"source":"myscript","params":{"a":1.2,"b":{"c":true,"d":[{"e":3}]}}}"""
   }
 
   test("should handle recursive lists") {
     ScriptBuilderFn(ScriptDefinition("myscript", params = Map("a" -> List(List(List("foo")))))).string shouldBe
-      """{"inline":"myscript","params":{"a":[[["foo"]]]}}"""
+      """{"source":"myscript","params":{"a":[[["foo"]]]}}"""
   }
 
   test("should handle maps of lists") {
     ScriptBuilderFn(ScriptDefinition("myscript", params = Map("a" -> List(3, 2, 1)))).string shouldBe
-      """{"inline":"myscript","params":{"a":[3,2,1]}}"""
+      """{"source":"myscript","params":{"a":[3,2,1]}}"""
   }
 
   test("should handle mixed lists") {
     ScriptBuilderFn(ScriptDefinition("myscript", params = Map("a" -> List(List(true, 1.2, List("foo"), Map("w" -> "wibble")))))).string shouldBe
-      """{"inline":"myscript","params":{"a":[[true,1.2,["foo"],{"w":"wibble"}]]}}"""
+      """{"source":"myscript","params":{"a":[[true,1.2,["foo"],{"w":"wibble"}]]}}"""
   }
 }

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/aggs/RangeAggregationBuilderTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/aggs/RangeAggregationBuilderTest.scala
@@ -47,7 +47,7 @@ class RangeAggregationBuilderTest extends FunSuite with Matchers {
       .range(50, 1000)
 
     RangeAggregationBuilder(agg).string() shouldBe
-      """{"range":{"field":"price","script":{"lang":"painless","inline":"doc['price'].value"},"ranges":[{"from":0.0,"to":50.0},{"from":50.0,"to":1000.0}]}}"""
+      """{"range":{"field":"price","script":{"lang":"painless","source":"doc['price'].value"},"ranges":[{"from":0.0,"to":50.0},{"from":50.0,"to":1000.0}]}}"""
   }
 
   test("range aggregation with a keyed parameter setted to true should generate expected json") {

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/update/UpdateByQueryBodyFnTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/update/UpdateByQueryBodyFnTest.scala
@@ -13,7 +13,7 @@ class UpdateByQueryBodyFnTest extends WordSpec with JsonSugar {
       "script is specified" in {
         val q = updateIn("test" / "type").query(matchQuery("field", 123)).script(ScriptDefinition("script", Some("painless")))
         UpdateByQueryBodyFn(q).string() should matchJson(
-          """{"query":{"match":{"field":{"query":123}}},"script":{"lang":"painless","inline":"script"}}"""
+          """{"query":{"match":{"field":{"query":123}}},"script":{"lang":"painless","source":"script"}}"""
         )
       }
       "script is not specified" in {

--- a/elastic4s-tests/src/test/resources/json/search/search_aggregations_avg.json
+++ b/elastic4s-tests/src/test/resources/json/search/search_aggregations_avg.json
@@ -6,7 +6,7 @@
                 "field": "grade",
                 "script": {
                     "lang": "lua",
-                    "inline": "doc['grade'].value"
+                    "source": "doc['grade'].value"
                 }
             }
         }

--- a/elastic4s-tests/src/test/resources/json/search/search_aggregations_count.json
+++ b/elastic4s-tests/src/test/resources/json/search/search_aggregations_count.json
@@ -6,7 +6,7 @@
                 "field": "grade",
                 "script": {
                     "lang": "lua",
-                    "inline": "doc['grade'].value"
+                    "source": "doc['grade'].value"
                 }
             }
         }

--- a/elastic4s-tests/src/test/resources/json/search/search_aggregations_max.json
+++ b/elastic4s-tests/src/test/resources/json/search/search_aggregations_max.json
@@ -6,7 +6,7 @@
                 "field": "grade",
                 "script": {
                     "lang": "lua",
-                    "inline": "doc['grade'].value"
+                    "source": "doc['grade'].value"
                 }
             }
         }

--- a/elastic4s-tests/src/test/resources/json/search/search_aggregations_min.json
+++ b/elastic4s-tests/src/test/resources/json/search/search_aggregations_min.json
@@ -6,7 +6,7 @@
                 "field": "grade",
                 "script": {
                     "lang": "lua",
-                    "inline": "doc['grade'].value",
+                    "source": "doc['grade'].value",
                     "params": {
                         "apple": "bad"
                     }

--- a/elastic4s-tests/src/test/resources/json/search/search_aggregations_sum.json
+++ b/elastic4s-tests/src/test/resources/json/search/search_aggregations_sum.json
@@ -6,7 +6,7 @@
                 "field": "grade",
                 "script": {
                     "lang": "lua",
-                    "inline": "doc['grade'].value",
+                    "source": "doc['grade'].value",
                     "params": {
                         "classsize": "30",
                         "room": "101A"

--- a/elastic4s-tests/src/test/resources/json/search/search_function_score.json
+++ b/elastic4s-tests/src/test/resources/json/search/search_function_score.json
@@ -21,7 +21,7 @@
                 {
                     "script_score": {
                         "script": {
-                            "inline": "some script here"
+                            "source": "some script here"
                         }
                     },
                     "weight": 0.5

--- a/elastic4s-tests/src/test/resources/json/search/search_script_field_poc.json
+++ b/elastic4s-tests/src/test/resources/json/search/search_script_field_poc.json
@@ -7,7 +7,7 @@
         "balance": {
             "script": {
                 "lang": "native",
-                "inline": "portfolioscript",
+                "source": "portfolioscript",
                 "params": {
                     "fieldName": "rate_of_return"
                 }
@@ -16,7 +16,7 @@
         "date": {
             "script": {
                 "lang": "groovy",
-                "inline": "doc['date'].value"
+                "source": "doc['date'].value"
             }
         }
     }

--- a/elastic4s-tests/src/test/resources/json/search/search_script_filter.json
+++ b/elastic4s-tests/src/test/resources/json/search/search_script_filter.json
@@ -3,7 +3,7 @@
     "post_filter": {
         "script": {
             "script": {
-                "inline": "doc['creationYear'].value > 2013"
+                "source": "doc['creationYear'].value > 2013"
             }
         }
     }

--- a/elastic4s-tests/src/test/resources/json/search/search_sort_script.json
+++ b/elastic4s-tests/src/test/resources/json/search/search_sort_script.json
@@ -5,7 +5,7 @@
         {
             "_script": {
                 "script": {
-                    "inline": "document.score",
+                    "source": "document.score",
                     "lang": "java"
                 },
                 "type": "number",

--- a/elastic4s-tests/src/test/resources/json/search/search_sort_script_params.json
+++ b/elastic4s-tests/src/test/resources/json/search/search_sort_script_params.json
@@ -5,7 +5,7 @@
         {
             "_script": {
                 "script": {
-                    "inline": "doc.score",
+                    "source": "doc.score",
                     "lang": "painless",
                     "params": {
                         "param1": "value1",


### PR DESCRIPTION
Hi!
I'm getting a bunch of warnings when using ES 5.6. Apparently, the "inline" key will no longer be supported for ES 6.0. 
https://github.com/elastic/elasticsearch/issues/26823

Note that it breaks compatibility with ES 5.5.

What do you think? Any feedback is appreciated, and thanks for maintaining this!