### PR TITLE
(copy from 5.4 to master) Fixed SpanNearQueryBIdyFn.scala to generate span_near ES query instead of span_or query 

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/span/SpanNearQueryBodyFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/span/SpanNearQueryBodyFn.scala
@@ -6,8 +6,10 @@ import com.sksamuel.elastic4s.searches.queries.span.SpanNearQueryDefinition
 
 object SpanNearQueryBodyFn {
   def apply(q: SpanNearQueryDefinition): XContentBuilder = {
+    val builder = XContentFactory.jsonBuilder()
 
-    val builder = XContentFactory.jsonBuilder().startObject("span_or").startArray("clauses")
+    builder.startObject("span_near")
+    builder.startArray("clauses")
     q.clauses.foreach { clause =>
       builder.rawValue(QueryBuilderFn(clause))
     }

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/span/SpanNearQueryBodyFnTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/span/SpanNearQueryBodyFnTest.scala
@@ -1,0 +1,38 @@
+package com.sksamuel.elastic4s.http.search.queries.span
+
+import com.sksamuel.elastic4s.searches.queries.span.{SpanNearQueryDefinition, SpanTermQueryDefinition}
+import org.scalatest.FunSuite
+
+import scala.util.parsing.json.JSON
+
+class SpanNearQueryBodyFnTest extends FunSuite {
+
+  test("SpanNearQueryBodyFn apply should return appropriate XContentBuilder") {
+    val builder = SpanNearQueryBodyFn.apply(SpanNearQueryDefinition(
+      Seq(
+        SpanTermQueryDefinition("field1", "value1", Some("name1"), Some(4.0)),
+        SpanTermQueryDefinition("field2", "value2", Some("name2"), Some(7.0))
+      ),
+      slop = 42, boost = Some(2.0), inOrder = Some(true), queryName = Some("rootName")
+    ))
+
+    val actual = JSON.parseRaw(builder.string())
+    val expected = JSON.parseRaw(
+      """
+        |{
+        |   "span_near":{
+        |     "clauses":[
+        |         {"span_term":{"field1":"value1","boost":4.0,"_name":"name1"}},
+        |         {"span_term":{"field2":"value2","boost":7.0,"_name":"name2"}}
+        |      ],
+        |      "slop":42,
+        |      "in_order":true,
+        |      "boost":2.0,
+        |      "_name":"rootName"
+        |    }
+        |}""".stripMargin)
+
+    assert(actual === expected)
+  }
+
+}

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/span/SpanOrQueryBodyFnTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/span/SpanOrQueryBodyFnTest.scala
@@ -1,0 +1,36 @@
+package com.sksamuel.elastic4s.http.search.queries.span
+
+import com.sksamuel.elastic4s.searches.queries.span.{SpanNearQueryDefinition, SpanOrQueryDefinition, SpanTermQueryDefinition}
+import org.scalatest.FunSuite
+
+import scala.util.parsing.json.JSON
+
+class SpanOrQueryBodyFnTest extends FunSuite {
+
+  test("SpanOrQueryBodyFn apply should return appropriate XContentBuilder") {
+    val builder = SpanOrQueryBodyFn.apply(SpanOrQueryDefinition(
+      Seq(
+        SpanTermQueryDefinition("field1", "value1", Some("name1"), Some(4.0)),
+        SpanTermQueryDefinition("field2", "value2", Some("name2"), Some(7.0))
+      ),
+      boost = Some(2.0), queryName = Some("rootName")
+    ))
+
+    val actual = JSON.parseRaw(builder.string())
+    val expected = JSON.parseRaw(
+      """
+        |{
+        |   "span_or":{
+        |     "clauses":[
+        |         {"span_term":{"field1":"value1","boost":4.0,"_name":"name1"}},
+        |         {"span_term":{"field2":"value2","boost":7.0,"_name":"name2"}}
+        |      ],
+        |      "boost":2.0,
+        |      "_name":"rootName"
+        |    }
+        |}""".stripMargin)
+
+    assert(actual === expected)
+  }
+
+}


### PR DESCRIPTION
did not include XContentBuilderExtentions due to this bug is not present in master branch