### PR TITLE
FiltersAggregations and KeyedFiltersAggregations for http

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/aggs/AggregationApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/aggs/AggregationApi.scala
@@ -36,6 +36,7 @@ trait AggregationApi {
     def queries(first: QueryDefinition, rest: QueryDefinition*): FiltersAggregationDefinition = queries(first +: rest)
     def queries(queries: Iterable[QueryDefinition]): FiltersAggregationDefinition =
       FiltersAggregationDefinition(name, queries)
+
     def queries(first: (String, QueryDefinition), rest: (String, QueryDefinition)*): KeyedFiltersAggregationDefinition = queries(first +: rest)
     def queries(queries: Iterable[(String, QueryDefinition)]): KeyedFiltersAggregationDefinition =
       KeyedFiltersAggregationDefinition(name, queries)

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/aggs/AggregationApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/aggs/AggregationApi.scala
@@ -36,7 +36,6 @@ trait AggregationApi {
     def queries(first: QueryDefinition, rest: QueryDefinition*): FiltersAggregationDefinition = queries(first +: rest)
     def queries(queries: Iterable[QueryDefinition]): FiltersAggregationDefinition =
       FiltersAggregationDefinition(name, queries)
-
     def queries(first: (String, QueryDefinition), rest: (String, QueryDefinition)*): KeyedFiltersAggregationDefinition = queries(first +: rest)
     def queries(queries: Iterable[(String, QueryDefinition)]): KeyedFiltersAggregationDefinition =
       KeyedFiltersAggregationDefinition(name, queries)

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggresponses.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggresponses.scala
@@ -180,6 +180,15 @@ trait HasAggregations {
 
   // bucket aggs
   def filter(name: String): FilterAggregationResult = FilterAggregationResult(name, agg(name)("doc_count").toString.toInt, agg(name))
+
+  // TODO: WIP
+  def filters(name: String): FiltersAggregationResult =
+    FiltersAggregationResult(
+      name,
+      agg(name)("buckets").asInstanceOf[Seq[Map[String, Any]]].map(m => UnnamedFilterAggregationResult(m("doc_count").toString.toLong, data = m)),
+      agg(name)
+  )
+
   def dateHistogram(name: String): DateHistogramAggResult = DateHistogramAggResult(name, agg(name))
   def dateRange(name: String): DateRangeAggResult = DateRangeAggResult(name, agg(name))
   def terms(name: String): TermsAggResult = TermsAggResult(name, agg(name))
@@ -221,4 +230,13 @@ trait BucketAggregation {
 
 case class FilterAggregationResult(name: String,
                                    docCount: Int,
+                                   private[elastic4s] val data: Map[String, Any]) extends BucketAggregation with HasAggregations
+
+case class UnnamedFilterAggregationResult(docCount: Long,
+                                          private[elastic4s] val data: Map[String, Any]) extends HasAggregations
+
+// TODO: WIP
+case class FiltersAggregationResult(
+                                   name: String,
+                                   aggResults: Seq[UnnamedFilterAggregationResult],
                                    private[elastic4s] val data: Map[String, Any]) extends BucketAggregation with HasAggregations

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/AggregationBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/AggregationBuilderFn.scala
@@ -14,6 +14,7 @@ object AggregationBuilderFn {
       case agg: DateHistogramAggregation => DateHistogramAggregationBuilder(agg)
       case agg: ExtendedStatsAggregationDefinition => ExtendedStatsAggregationBuilder(agg)
       case agg: FilterAggregationDefinition => FilterAggregationBuilder(agg)
+      case agg: FiltersAggregationDefinition => FiltersAggregationBuilder(agg)
       case agg: GeoHashGridAggregationDefinition => GeoHashGridAggregationBuilder(agg)
       case agg: MaxAggregationDefinition => MaxAggregationBuilder(agg)
       case agg: MinAggregationDefinition => MinAggregationBuilder(agg)

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/AggregationBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/AggregationBuilderFn.scala
@@ -15,6 +15,7 @@ object AggregationBuilderFn {
       case agg: ExtendedStatsAggregationDefinition => ExtendedStatsAggregationBuilder(agg)
       case agg: FilterAggregationDefinition => FilterAggregationBuilder(agg)
       case agg: FiltersAggregationDefinition => FiltersAggregationBuilder(agg)
+      case agg: KeyedFiltersAggregationDefinition => KeyedFiltersAggregationBuilder(agg)
       case agg: GeoHashGridAggregationDefinition => GeoHashGridAggregationBuilder(agg)
       case agg: MaxAggregationDefinition => MaxAggregationBuilder(agg)
       case agg: MinAggregationDefinition => MinAggregationBuilder(agg)

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/FiltersAggregationBuilder.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/FiltersAggregationBuilder.scala
@@ -1,0 +1,26 @@
+package com.sksamuel.elastic4s.http.search.aggs
+
+import com.sksamuel.elastic4s.http.search.queries.QueryBuilderFn
+import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
+import com.sksamuel.elastic4s.searches.aggs.FiltersAggregationDefinition
+
+object FiltersAggregationBuilder {
+  def apply(agg: FiltersAggregationDefinition): XContentBuilder = {
+
+    val builder = XContentFactory.jsonBuilder()
+
+    val filters = {
+      builder.startArray("filters")
+      val filters = agg.filters.map(QueryBuilderFn.apply).map(_.string).mkString(",")
+      builder.rawValue(filters)
+      builder.endArray()
+    }
+
+    builder.rawField("filters", filters)
+
+    SubAggsBuilderFn(agg, builder)
+    AggMetaDataFn(agg, builder)
+    builder
+  }
+}
+

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/KeyedFiltersAggregationBuilder.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/KeyedFiltersAggregationBuilder.scala
@@ -1,0 +1,27 @@
+package com.sksamuel.elastic4s.http.search.aggs
+
+import com.sksamuel.elastic4s.http.search.queries.QueryBuilderFn
+import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
+import com.sksamuel.elastic4s.searches.aggs.KeyedFiltersAggregationDefinition
+
+object KeyedFiltersAggregationBuilder {
+  def apply(agg: KeyedFiltersAggregationDefinition): XContentBuilder = {
+
+    val builder = XContentFactory.jsonBuilder()
+
+    val filters = {
+      builder.startObject("filters")
+      agg.filters.map(map => {
+        builder.rawField(map._1, QueryBuilderFn(map._2))
+      })
+      builder.endObject()
+    }
+
+    builder.rawField("filters", filters)
+
+    SubAggsBuilderFn(agg, builder)
+    AggMetaDataFn(agg, builder)
+    builder
+  }
+}
+

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/aggs/FiltersAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/aggs/FiltersAggregationHttpTest.scala
@@ -1,0 +1,51 @@
+package com.sksamuel.elastic4s.search.aggs
+
+import com.sksamuel.elastic4s.RefreshPolicy
+import com.sksamuel.elastic4s.http.ElasticDsl
+import com.sksamuel.elastic4s.testkit.DiscoveryLocalNodeProvider
+import org.scalatest.{FreeSpec, Matchers}
+
+import scala.util.Try
+
+class FiltersAggregationHttpTest extends FreeSpec with DiscoveryLocalNodeProvider with Matchers with ElasticDsl {
+
+  Try {
+    http.execute {
+      deleteIndex("filtersagg")
+    }.await
+  }
+
+  http.execute {
+    createIndex("filtersagg") mappings {
+      mapping("buildings") fields(
+        textField("name").fielddata(true),
+        intField("height").stored(true)
+      )
+    }
+  }.await
+
+  http.execute(
+    bulk(
+      indexInto("filtersagg/buildings") fields("name" -> "Willis Tower", "height" -> 1244),
+      indexInto("filtersagg/buildings") fields("name" -> "Burj Kalifa", "height" -> 2456),
+      indexInto("filtersagg/buildings") fields("name" -> "Tower of London", "height" -> 169),
+      indexInto("filtersagg/buildings") fields("name" -> "London Bridge", "height" -> 63)
+    ).refresh(RefreshPolicy.Immediate)
+  ).await
+
+  "filters agg" - {
+    "should create buckets matching the query" in {
+
+      val resp = http.execute {
+        search("filtersagg").matchAllQuery().aggs {
+          filtersAggregation("agg1").queries(Seq(matchQuery("name", "london"), matchQuery("name", "tower"))).subaggs {
+            sumAgg("agg2", "height")
+          }
+        }
+      }.await.right.get
+      resp.totalHits shouldBe 4
+      resp.aggs.filters("agg1").aggResults.map(_.docCount).sum shouldBe 4
+      resp.aggs.filters("agg1").aggResults.head.sum("agg2").value shouldBe 232
+    }
+  }
+}

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/aggs/KeyedFiltersAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/aggs/KeyedFiltersAggregationHttpTest.scala
@@ -1,0 +1,51 @@
+package com.sksamuel.elastic4s.search.aggs
+
+import com.sksamuel.elastic4s.RefreshPolicy
+import com.sksamuel.elastic4s.http.ElasticDsl
+import com.sksamuel.elastic4s.testkit.DiscoveryLocalNodeProvider
+import org.scalatest.{FreeSpec, Matchers}
+
+import scala.util.Try
+
+class KeyedFiltersAggregationHttpTest extends FreeSpec with DiscoveryLocalNodeProvider with Matchers with ElasticDsl {
+
+  Try {
+    http.execute {
+      deleteIndex("filtersagg")
+    }.await
+  }
+
+  http.execute {
+    createIndex("filtersagg") mappings {
+      mapping("buildings") fields(
+        textField("name").fielddata(true),
+        intField("height").stored(true)
+      )
+    }
+  }.await
+
+  http.execute(
+    bulk(
+      indexInto("filtersagg/buildings") fields("name" -> "Willis Tower", "height" -> 1244),
+      indexInto("filtersagg/buildings") fields("name" -> "Burj Kalifa", "height" -> 2456),
+      indexInto("filtersagg/buildings") fields("name" -> "Tower of London", "height" -> 169),
+      indexInto("filtersagg/buildings") fields("name" -> "London Bridge", "height" -> 63)
+    ).refresh(RefreshPolicy.Immediate)
+  ).await
+
+  "filters agg" - {
+    "should create buckets matching the query" in {
+
+      val resp = http.execute {
+        search("filtersagg").matchAllQuery().aggs {
+          filtersAggregation("agg1").queries(Seq("first" -> matchQuery("name", "london"), "second" -> matchQuery("name", "tower"))).subaggs {
+            sumAgg("agg2", "height")
+          }
+        }
+      }.await.right.get
+      resp.totalHits shouldBe 4
+      resp.aggs.keyedFilters("agg1").aggResults("first").docCount shouldBe 2
+      resp.aggs.keyedFilters("agg1").aggResults("first").sum("agg2").value shouldBe 232
+    }
+  }
+}


### PR DESCRIPTION
I noticed that FiltersAggregations were missing from the http client. These fill my needs for the moment, but I'm not 100% confident with aggregations so tell me if there's something I missed.

I wasn't sure whether to use named or unnamed filters for the keyed filters. Which would you prefer?