### PR TITLE
Fix SpanFirstQueryBodyFn

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/queries/span/SpanMultiTermQueryDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/queries/span/SpanMultiTermQueryDefinition.scala
@@ -21,5 +21,3 @@ case class SpanFirstQueryDefinition(query: SpanQueryDefinition,
   def boost(boost: Double): SpanFirstQueryDefinition = copy(boost = boost.some)
   def queryName(queryName: String): SpanFirstQueryDefinition = copy(queryName = queryName.some)
 }
-
-

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/span/SpanFirstQueryBodyFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/span/SpanFirstQueryBodyFn.scala
@@ -7,7 +7,9 @@ import com.sksamuel.elastic4s.searches.queries.span.SpanFirstQueryDefinition
 object SpanFirstQueryBodyFn {
   def apply(q: SpanFirstQueryDefinition): XContentBuilder = {
     val builder = XContentFactory.jsonBuilder()
-    builder.rawField("span_first", QueryBuilderFn(q.query))
+    builder.startObject("span_first")
+    builder.rawField("match", QueryBuilderFn(q.query))
+    builder.field("end", q.end)
     q.boost.foreach(builder.field("boost", _))
     q.queryName.foreach(builder.field("_name", _))
     builder.endObject()

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/span/SpanFirstQueryBodyFnTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/span/SpanFirstQueryBodyFnTest.scala
@@ -1,0 +1,34 @@
+package com.sksamuel.elastic4s.http.search.queries.span
+
+import com.sksamuel.elastic4s.searches.queries.span.{SpanFirstQueryDefinition, SpanTermQueryDefinition}
+import org.scalatest.FunSuite
+
+import scala.util.parsing.json.JSON
+
+class SpanFirstQueryBodyFnTest extends FunSuite {
+
+  test("SpanFirstQueryBodyFn apply should return appropriate XContentBuilder") {
+    val builder = SpanFirstQueryBodyFn.apply(SpanFirstQueryDefinition(
+      SpanTermQueryDefinition("field1", "value1"),
+      end = 5,
+      boost = Some(2.0),
+      queryName = Some("rootName")
+    ))
+
+    val actual = JSON.parseRaw(builder.string())
+    val expected = JSON.parseRaw(
+      """
+        |{
+        |   "span_first":{
+        |     "match":{
+        |       "span_term":{"field1":"value1"}
+        |     },
+        |     "end":5,
+        |     "boost":2.0,
+        |     "_name":"rootName"
+        |   }
+        |}""".stripMargin)
+
+    assert(actual === expected)
+  }
+}


### PR DESCRIPTION
This was throwing an exception, because the writer was closing one object too many. But also, the inner query needs to be nested under a `"match"` field, as per: https://www.elastic.co/guide/en/elasticsearch/reference/6.0/query-dsl-span-first-query.html