### PR TITLE
Fix SpanMultiTermQueryBodyFn

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/span/SpanMultiTermQueryBodyFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/span/SpanMultiTermQueryBodyFn.scala
@@ -7,9 +7,11 @@ import com.sksamuel.elastic4s.searches.queries.span.SpanMultiTermQueryDefinition
 object SpanMultiTermQueryBodyFn {
   def apply(q: SpanMultiTermQueryDefinition): XContentBuilder = {
     val builder = XContentFactory.jsonBuilder()
-    builder.rawField("span_multi", QueryBuilderFn(q.query))
+    builder.startObject("span_multi")
+    builder.rawField("match", QueryBuilderFn(q.query))
     q.boost.foreach(builder.field("boost", _))
     q.queryName.foreach(builder.field("_name", _))
+    builder.endObject()
     builder.endObject()
   }
 }

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/span/SpanMultiTermQueryBodyFnTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/span/SpanMultiTermQueryBodyFnTest.scala
@@ -1,0 +1,33 @@
+package com.sksamuel.elastic4s.http.search.queries.span
+
+import com.sksamuel.elastic4s.searches.queries.PrefixQueryDefinition
+import com.sksamuel.elastic4s.searches.queries.span.SpanMultiTermQueryDefinition
+import org.scalatest.FunSuite
+
+import scala.util.parsing.json.JSON
+
+class SpanMultiTermQueryBodyFnTest extends FunSuite {
+
+  test("SpanMultiTermQueryBodyFn apply should return appropriate XContentBuilder") {
+    val builder = SpanMultiTermQueryBodyFn.apply(SpanMultiTermQueryDefinition(
+      PrefixQueryDefinition("user", "ki"),
+      boost = Some(2.0),
+      queryName = Some("rootName")
+    ))
+
+    val actual = JSON.parseRaw(builder.string())
+    val expected = JSON.parseRaw(
+      """
+        |{
+        |    "span_multi":{
+        |        "match":{
+        |            "prefix" : { "user" :  { "value" : "ki" } }
+        |        },
+        |        "boost":2.0,
+        |        "_name":"rootName"
+        |    }
+        |}""".stripMargin)
+
+    assert(actual === expected)
+  }
+}


### PR DESCRIPTION
Analogous fix to https://github.com/sksamuel/elastic4s/pull/1121, in accordance with https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-multi-term-query.html 🙂 