### PR TITLE
Make it possible to make http request with http entity from InputStream/File

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/HttpClient.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/HttpClient.scala
@@ -1,5 +1,7 @@
 package com.sksamuel.elastic4s.http
 
+import java.io.{InputStream, File}
+
 import cats.Show
 import com.sksamuel.elastic4s.ElasticsearchClientUri
 import com.sksamuel.exts.Logging
@@ -68,11 +70,15 @@ trait HttpRequestClient extends Logging {
   def close(): Unit
 }
 
-case class HttpResponse(statusCode: Int, entity: Option[HttpEntity], headers: Map[String, String])
-case class HttpEntity(content: String, contentType: Option[String])
+case class HttpResponse(statusCode: Int, entity: Option[HttpEntity.StringEntity], headers: Map[String, String])
+sealed trait HttpEntity
 object HttpEntity {
   def apply(content: String): HttpEntity = HttpEntity(content, "application/json; charset=utf-8")
-  def apply(content: String, contentType: String): HttpEntity = HttpEntity(content, Some(contentType))
+  def apply(content: String, contentType: String): HttpEntity = StringEntity(content, Some(contentType))
+
+  case class StringEntity(content: String, contentType: Option[String]) extends HttpEntity
+  case class InputStreamEntity(content: InputStream, contentType: Option[String]) extends HttpEntity
+  case class FileEntity(content: File, contentType: Option[String]) extends HttpEntity
 }
 
 object HttpClient extends Logging {

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/ResponseHandler.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/ResponseHandler.scala
@@ -20,7 +20,7 @@ trait ResponseHandler[U] {
 // if the content encoding header is null, then UTF-8 is assumed
 object ResponseHandler extends Logging {
 
-  def json(entity: HttpEntity): JsonNode = fromEntity[JsonNode](entity)
+  def json(entity: HttpEntity.StringEntity): JsonNode = fromEntity[JsonNode](entity)
 
   def fromNode[U: Manifest](node: JsonNode): U = {
     logger.debug(s"Attempting to unmarshall json node to ${manifest.runtimeClass.getName}")
@@ -30,7 +30,7 @@ object ResponseHandler extends Logging {
 
   def fromResponse[U: Manifest](response: HttpResponse): U = fromEntity(response.entity.get)
 
-  def fromEntity[U: Manifest](entity: HttpEntity): U = {
+  def fromEntity[U: Manifest](entity: HttpEntity.StringEntity): U = {
     logger.debug(s"Attempting to unmarshall response to ${manifest.runtimeClass.getName}")
     val charset = entity.contentType.getOrElse("UTF-8")
     implicit val codec = Codec(Charset.forName(charset))


### PR DESCRIPTION
The idea is that in memory constrained/sending large document environment we could provide custom HttpExecutable which provide an InputStream generated json on the fly or write the content to file to avoid memory overhead due to building json string for current string based http entity