### PR TITLE
Fix partitioned terms aggregation (fixes  #1153)

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/TermsAggregationBuilder.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/TermsAggregationBuilder.scala
@@ -24,8 +24,10 @@ object TermsAggregationBuilder {
         builder.array("exclude", incexc.include.toArray)
     }
     agg.includePartition.foreach { incpart =>
-      builder.field("partition", incpart.partition)
-      builder.field("num_partitions", incpart.numPartitions)
+      val includeBuilder = builder.startObject("include")
+      includeBuilder.field("partition", incpart.partition)
+      includeBuilder.field("num_partitions", incpart.numPartitions)
+      includeBuilder.endObject()
     }
     agg.minDocCount.foreach(builder.field("min_doc_count", _))
     agg.shardMinDocCount.foreach(builder.field("shard_min_doc_count", _))


### PR DESCRIPTION
 - The includePartition method on a terms aggregation adds the
   incorrect structure to the query JSON. It adds the "partition"
   and "num_partitions" fields directly to the aggregation object.
   Instead it should add them to a new object under key "include".
 - This commit fixes that and adds a test that verifies paritioned
   terms aggregation works.