### PR TITLE
Include explanations in search hits

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/responses.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/responses.scala
@@ -3,6 +3,7 @@ package com.sksamuel.elastic4s.http.search
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.sksamuel.elastic4s.get.HitField
 import com.sksamuel.elastic4s.http.{Shards, SourceAsContentBuilder}
+import com.sksamuel.elastic4s.http.explain.Explanation
 import com.sksamuel.elastic4s.{Hit, HitReader}
 
 case class SearchHit(@JsonProperty("_id") id: String,
@@ -10,6 +11,7 @@ case class SearchHit(@JsonProperty("_id") id: String,
                      @JsonProperty("_type") `type`: String,
                      @JsonProperty("_score") score: Float,
                      @JsonProperty("_parent") parent: Option[String],
+                     @JsonProperty("_explanation") explanation: Option[Explanation],
                      private val _source: Map[String, AnyRef],
                      fields: Map[String, AnyRef],
                      highlight: Map[String, Seq[String]],

--- a/elastic4s-testkit/src/main/scala/com/sksamuel/elastic4s/testkit/ResponseConverter.scala
+++ b/elastic4s-testkit/src/main/scala/com/sksamuel/elastic4s/testkit/ResponseConverter.scala
@@ -122,6 +122,7 @@ object ResponseConverterImplicits {
             x.index,
             x.`type`,
             x.score,
+            None,
             None, // TODO
             x.sourceAsMap.asScalaNested,
             x.fields.mapValues(_.value),

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchHttpTest.scala
@@ -106,6 +106,11 @@ class SearchHttpTest
         search("chess" / "openings") query matchAllQuery() sortBy fieldSort("name")
       }.await.hits.hits.map(_.sourceField("name")) shouldBe Array("modern defence", "queen gambit")
     }
+    "support explain" in {
+      http.execute {
+        search("chess").explain(true).matchAllQuery().limit(2)
+      }.await.hits.hits.head.explanation.isDefined shouldBe true
+    }
     "support limits" in {
       http.execute {
         search("chess").matchAllQuery().limit(2)


### PR DESCRIPTION
This feature exists on trunk already (99f8e2da964169), but I have backported it to 5.4.x release, to make it available to those using ElasticSearch 5.3.x.