### PR TITLE
declare cats dependency in community build friendly way

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -52,7 +52,7 @@ object Build extends AutoPlugin {
     javacOptions := Seq("-source", "1.7", "-target", "1.7"),
     libraryDependencies ++= Seq(
       "com.sksamuel.exts"                     %% "exts"                     % ExtsVersion,
-      "org.typelevel"                         %% "cats"                     % CatsVersion,
+      "org.typelevel"                         %% "cats-core"                % CatsVersion,
       "org.slf4j"                             % "slf4j-api"                 % Slf4jVersion,
       "org.elasticsearch"                     % "elasticsearch"             % ElasticsearchVersion,
       "org.mockito"                           % "mockito-all"               % MockitoVersion        % "test",


### PR DESCRIPTION
this is needed to keep dbuild from getting confused (context: https://github.com/scala/community-builds/pull/649)

...but, it also seems more correct to me to declare the slimmer dependency.

this PR is against the 5.4.x branch; the same change
already exists on master (in 70833ba096d34c)