### PR TITLE
Added explicit 'not implemented' errors to aggregation and query builder functions

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/AggregationBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/AggregationBuilderFn.scala
@@ -36,6 +36,9 @@ object AggregationBuilderFn {
       case agg: MaxBucketDefinition => MaxBucketPipelineAggBuilder(agg)
       case agg: SumBucketDefinition => SumBucketPipelineAggBuilder(agg)
       case agg: BucketScriptDefinition => BucketScriptPipelineAggBuilder(agg)
+
+      // Not implemented
+      case ni => throw new NotImplementedError(s"Aggregation ${ni.getClass.getName} has not yet been implemented for the HTTP client.")
     }
     builder
   }

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/QueryBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/QueryBuilderFn.scala
@@ -24,6 +24,7 @@ object QueryBuilderFn {
     case q: ConstantScoreDefinition => ConstantScoreBodyFn(q)
     case q: DisMaxQueryDefinition => DisMaxQueryBodyFn(q)
     case q: ExistsQueryDefinition => ExistsQueryBodyFn(q)
+    case q: FunctionScoreQueryDefinition => FunctionScoreQueryBuilderFn(q)
     case q: FuzzyQueryDefinition => FuzzyQueryBodyFn(q)
     case q: GeoBoundingBoxQueryDefinition => GeoBoundingBoxQueryBodyFn(q)
     case q: GeoDistanceQueryDefinition => GeoDistanceQueryBodyFn(q)
@@ -47,6 +48,7 @@ object QueryBuilderFn {
     case q: RawQueryDefinition => RawQueryBodyFn(q)
     case q: RegexQueryDefinition => RegexQueryBodyFn(q)
     case q: ScriptQueryDefinition => ScriptQueryBodyFn(q)
+    case q: ScriptScoreDefinition => ScriptScoreQueryBodyFn(q)
     case s: SimpleStringQueryDefinition => SimpleStringBodyFn(s)
     case s: SpanContainingQueryDefinition => SpanContainingQueryBodyFn(s)
     case s: SpanFirstQueryDefinition => SpanFirstQueryBodyFn(s)
@@ -60,7 +62,8 @@ object QueryBuilderFn {
     case t: TermsQueryDefinition[_] => TermsQueryBodyFn(t)
     case q: TypeQueryDefinition => TypeQueryBodyFn(q)
     case q: WildcardQueryDefinition => WildcardQueryBodyFn(q)
-    case q: FunctionScoreQueryDefinition => FunctionScoreQueryBuilderFn(q)
-    case q: ScriptScoreDefinition => ScriptScoreQueryBodyFn(q)
+
+    // Not implemented
+    case ni => throw new NotImplementedError(s"Query ${ni.getClass.getName} has not yet been implemented for the HTTP client.")
   }
 }

--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/QueryBuilderFn.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/QueryBuilderFn.scala
@@ -53,5 +53,8 @@ object QueryBuilderFn {
     case q: TermsLookupQueryDefinition => TermsLookupQueryBuilderFn(q)
     case q: TypeQueryDefinition => QueryBuilders.typeQuery(q.`type`)
     case q: WildcardQueryDefinition => WildcardQueryBuilderFn(q)
+
+    // Not implemented
+    case ni => throw new NotImplementedError(s"Query ${ni.getClass.getName} has not yet been implemented for the TCP client.")
   }
 }

--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/aggs/AggregationBuilderFn.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/aggs/AggregationBuilderFn.scala
@@ -54,5 +54,8 @@ object AggregationBuilderFn {
     case p: PercentilesBucketDefinition => PercentilesBucketPipelineBuilder(p).asRight
     case p: StatsBucketDefinition => StatsBucketPipelineBuilder(p).asRight
     case p: SumBucketDefinition => SumBucketPipelineBuilder(p).asRight
+
+    // Not implemented
+    case ni => throw new NotImplementedError(s"Aggregation ${ni.getClass.getName} has not yet been implemented for the TCP client.")
   }
 }


### PR DESCRIPTION
I think an explicit exception explaining that a given query or aggregation hasn't been implemented should be more user friendly than a `MatchError` (which might make the user think they've done something wrong, at first).