### PR TITLE
Added terms lookup query support in http client

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/QueryBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/QueryBuilderFn.scala
@@ -13,7 +13,7 @@ import com.sksamuel.elastic4s.searches.queries.funcscorer.{FunctionScoreQueryDef
 import com.sksamuel.elastic4s.searches.queries.geo.{GeoBoundingBoxQueryDefinition, GeoDistanceQueryDefinition, GeoPolygonQueryDefinition, GeoShapeQueryDefinition}
 import com.sksamuel.elastic4s.searches.queries.matches._
 import com.sksamuel.elastic4s.searches.queries.span._
-import com.sksamuel.elastic4s.searches.queries.term.{TermQueryDefinition, TermsQueryDefinition}
+import com.sksamuel.elastic4s.searches.queries.term.{TermQueryDefinition, TermsLookupQueryDefinition, TermsQueryDefinition}
 import com.sksamuel.elastic4s.searches.queries.{IdQueryDefinition, _}
 
 object QueryBuilderFn {
@@ -58,6 +58,7 @@ object QueryBuilderFn {
     case s: SpanWithinQueryDefinition => SpanWithinQueryBodyFn(s)
     case t: TermQueryDefinition => TermQueryBodyFn(t)
     case t: TermsQueryDefinition[_] => TermsQueryBodyFn(t)
+    case t: TermsLookupQueryDefinition => TermsLookupQueryBodyFn(t)
     case q: TypeQueryDefinition => TypeQueryBodyFn(q)
     case q: WildcardQueryDefinition => WildcardQueryBodyFn(q)
     case q: FunctionScoreQueryDefinition => FunctionScoreQueryBuilderFn(q)

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/term/TermsLookupQueryBodyFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/term/TermsLookupQueryBodyFn.scala
@@ -1,0 +1,24 @@
+package com.sksamuel.elastic4s.http.search.queries.term
+
+import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
+import com.sksamuel.elastic4s.searches.queries.term.TermsLookupQueryDefinition
+
+object TermsLookupQueryBodyFn {
+  def apply(t: TermsLookupQueryDefinition): XContentBuilder = {
+
+    val builder = XContentFactory.jsonBuilder().startObject("terms")
+
+    builder.startObject(t.field)
+    builder.field("index", t.termsLookup.ref.index)
+    builder.field("type", t.termsLookup.ref.`type`)
+    builder.field("id", t.termsLookup.ref.id)
+
+    builder.field("path", t.termsLookup.path)
+    t.termsLookup.routing.foreach(builder.field("routing", _))
+    builder.endObject()
+
+    t.queryName.foreach(builder.field("_name", _))
+
+    builder.endObject().endObject()
+  }
+}

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/term/TermsQueryBodyFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/term/TermsQueryBodyFn.scala
@@ -12,14 +12,18 @@ object TermsQueryBodyFn {
       builder.startArray(t.field)
       t.values.foreach(builder.autovalue)
       builder.endArray()
+    } else {
+      builder.startObject(t.field)
+      t.ref.foreach { ref =>
+        builder.field("index", ref.index)
+        builder.field("type", ref.`type`)
+        builder.field("id", ref.id)
+      }
+      t.path.foreach(builder.field("path", _))
+      t.routing.foreach(builder.field("routing", _))
+      builder.endObject()
     }
-    t.ref.foreach { ref =>
-      builder.field("index", ref.index)
-      builder.field("type", ref.`type`)
-      builder.field("id", ref.id)
-    }
-    t.path.foreach(builder.field("path", _))
-    t.routing.foreach(builder.field("routing", _))
+
     t.boost.foreach(builder.field("boost", _))
     t.queryName.foreach(builder.field("_name", _))
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/TermsLookupQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/TermsLookupQueryTest.scala
@@ -1,11 +1,11 @@
 package com.sksamuel.elastic4s.search
 
-import com.sksamuel.elastic4s.RefreshPolicy
+import com.sksamuel.elastic4s.{DocumentRef, RefreshPolicy}
 import com.sksamuel.elastic4s.http.ElasticDsl
 import com.sksamuel.elastic4s.testkit.DiscoveryLocalNodeProvider
 import org.scalatest.{FlatSpec, Matchers}
 
-class TermsQueryTest
+class TermsLookupQueryTest
   extends FlatSpec
     with DiscoveryLocalNodeProvider
     with Matchers
@@ -37,20 +37,10 @@ class TermsQueryTest
     ).refresh(RefreshPolicy.Immediate)
   }.await
 
-  "a terms query" should "find multiple terms using 'or'" in {
-
+  "a terms lookup query" should "lookup terms to search from a document in another index" in {
     val resp = http.execute {
-      search("lords") query termsQuery("name", "nelson", "byron")
-    }.await.right.get.result
-
-    resp.hits.hits.map(_.sourceAsString).toSet shouldBe Set("""{"name":"nelson"}""", """{"name":"byron"}""")
-  }
-
-  it should "lookup terms to search from a document in another index" in {
-    val resp = http.execute {
-      search("lords") query termsQuery("name", List.empty[String])
-        .ref("lordsfanclub", "fans", "lordsAppreciationFanClub")
-        .path("lordswelike")
+      search("lords") query termsLookupQuery("name", "lordswelike",
+        DocumentRef("lordsfanclub", "fans", "lordsAppreciationFanClub"))
     }.await.right.get.result
 
     resp.hits.hits.map(_.sourceAsString).toSet shouldBe Set("""{"name":"nelson"}""", """{"name":"edmure"}""")


### PR DESCRIPTION
Hi,
terms lookup query is broken in the http client.
I see there are two ways to specify it, a `ref` inside a `TermsQueryDefinition` or directly a `TermsLookupQueryDefinition`. 
I implemented both: the former was bugged (wrongly nested json) and the latter was missing in `QueryBuilderFn` (MatchError)