### PR TITLE
Refactored geo shape query model to support multiple shapes

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/json/XContentBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/json/XContentBuilder.scala
@@ -33,6 +33,35 @@ class XContentBuilder(root: JsonNode) {
     this
   }
 
+  def array(field: String, doubles: Array[Array[Array[Array[Double]]]]): XContentBuilder = {
+    startArray(field)
+    doubles.foreach { second =>
+      val secondArray = array.addArray()
+      second.foreach { third =>
+        val thirdArray = secondArray.addArray()
+        third.foreach { inner =>
+          val value = thirdArray.addArray()
+          inner.foreach(value.add)
+        }
+      }
+    }
+    endArray()
+    this
+  }
+
+  def array(field: String, doubles: Array[Array[Array[Double]]]): XContentBuilder = {
+    startArray(field)
+    doubles.foreach { nested =>
+      val outer = array.addArray()
+      nested.foreach { inner =>
+        val value = outer.addArray()
+        inner.foreach(value.add)
+      }
+    }
+    endArray()
+    this
+  }
+
   def array(field: String, doubles: Array[Array[Double]]): XContentBuilder = {
     startArray(field)
     doubles.foreach { nested =>
@@ -78,13 +107,23 @@ class XContentBuilder(root: JsonNode) {
     this
   }
 
-  def rawField(name: String, builder: XContentBuilder): XContentBuilder = rawField(name, builder.string)
+  def array(field: String, builder: Array[XContentBuilder]): XContentBuilder = {
+    startArray(field)
+    builder.foreach { b =>
+      val raw = new RawValue(b.string())
+      array.addRawValue(raw)
+    }
+    endArray()
+    this
+  }
+
+  def rawField(name: String, builder: XContentBuilder): XContentBuilder = rawField(name, builder.string())
   def rawField(name: String, content: String): XContentBuilder = {
     obj.putRawValue(name, new RawValue(content))
     this
   }
 
-  def rawValue(value: XContentBuilder): this.type = rawValue(value.string)
+  def rawValue(value: XContentBuilder): this.type = rawValue(value.string())
   def rawValue(value: String): this.type = {
     array.addRawValue(new RawValue(value))
     this

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/queries/geo/GeoShapeQueryDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/queries/geo/GeoShapeQueryDefinition.scala
@@ -74,7 +74,7 @@ case class GeoShapeQueryDefinition(field: String,
   def queryName(queryName: String): GeoShapeQueryDefinition = copy(queryName = queryName.some)
   def strategy(strategy: SpatialStrategy): GeoShapeQueryDefinition = copy(strategy = strategy.some)
 
-  def inlineShape(shape: ShapeDefinition) = InlineShape(shape)
+  def inlineShape(shape: ShapeDefinition) = copy(shape = InlineShape(shape))
   def preindexedShape(id: String, index: Index, `type`: String, path: String) =
     copy(shape = PreindexedShape(id, index, `type`, path))
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/queries/geo/GeoShapeQueryDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/queries/geo/GeoShapeQueryDefinition.scala
@@ -1,11 +1,64 @@
 package com.sksamuel.elastic4s.searches.queries.geo
 
 import com.sksamuel.elastic4s.Index
+import com.sksamuel.elastic4s.searches.GeoPoint
 import com.sksamuel.elastic4s.searches.queries.QueryDefinition
+import com.sksamuel.elastic4s.searches.queries.geo.Shapes.{Circle, Polygon}
 import com.sksamuel.exts.OptionImplicits._
 
-trait Shape
-case class InlineShape(geoShapeType: GeoShapeType, coordinates: Seq[(Double, Double)]) extends Shape
+
+sealed trait ShapeDefinition {
+  def geoShapeType: GeoShapeType
+}
+
+sealed trait SingleShape extends ShapeDefinition
+
+case class PointShape(point: GeoPoint) extends SingleShape {
+  def geoShapeType: GeoShapeType = GeoShapeType.POINT
+}
+
+case class CircleShape(circle: Circle) extends SingleShape {
+  def geoShapeType: GeoShapeType = GeoShapeType.CIRCLE
+}
+
+case class PolygonShape(polygon: Polygon) extends SingleShape {
+  def geoShapeType: GeoShapeType = GeoShapeType.POLYGON
+}
+
+case class MultiPointShape(points: Seq[GeoPoint]) extends SingleShape {
+  def geoShapeType: GeoShapeType = GeoShapeType.MULTIPOINT
+}
+
+case class LineStringShape(
+  p1: GeoPoint,
+  p2: GeoPoint,
+  path: GeoPoint*
+) extends SingleShape {
+  def geoShapeType: GeoShapeType = GeoShapeType.LINESTRING
+}
+
+case class EnvelopeShape(
+  upperLeft: GeoPoint,
+  lowerRight: GeoPoint
+) extends SingleShape {
+  def geoShapeType: GeoShapeType = GeoShapeType.ENVELOPE
+}
+
+case class MultiLineStringShape(coordinates: Seq[Seq[GeoPoint]]) extends SingleShape {
+  def geoShapeType: GeoShapeType = GeoShapeType.MULTILINESTRING
+}
+
+case class MultiPolygonShape(coordinate: Seq[Polygon]) extends SingleShape {
+  def geoShapeType: GeoShapeType = GeoShapeType.MULTIPOLYGON
+}
+
+sealed trait CollectionShape extends ShapeDefinition
+case class GeometryCollectionShape(shapes: Seq[SingleShape]) extends CollectionShape {
+  def geoShapeType: GeoShapeType = GeoShapeType.GEOMETRYCOLLECTION
+}
+
+sealed trait Shape
+case class InlineShape(shape: ShapeDefinition) extends Shape
 case class PreindexedShape(id: String, index: Index, `type`: String, path: String) extends Shape
 
 case class GeoShapeQueryDefinition(field: String,
@@ -21,8 +74,9 @@ case class GeoShapeQueryDefinition(field: String,
   def queryName(queryName: String): GeoShapeQueryDefinition = copy(queryName = queryName.some)
   def strategy(strategy: SpatialStrategy): GeoShapeQueryDefinition = copy(strategy = strategy.some)
 
-  def inlineShape(shapeType: GeoShapeType, coords: Seq[(Double, Double)]) = copy(shape = InlineShape(shapeType, coords))
-  def preindexedShape(id: String, index: Index, `type`: String, path: String) = copy(shape = PreindexedShape(id, index, `type`, path))
+  def inlineShape(shape: ShapeDefinition) = InlineShape(shape)
+  def preindexedShape(id: String, index: Index, `type`: String, path: String) =
+    copy(shape = PreindexedShape(id, index, `type`, path))
 
   def ignoreUnmapped(ignore: Boolean): GeoShapeQueryDefinition = copy(ignoreUnmapped = ignore.some)
 }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/queries/geo/Shapes.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/queries/geo/Shapes.scala
@@ -1,0 +1,11 @@
+package com.sksamuel.elastic4s.searches.queries.geo
+
+import com.sksamuel.elastic4s.DistanceUnit
+import com.sksamuel.elastic4s.searches.GeoPoint
+
+object Shapes {
+
+  case class Polygon(points: Seq[GeoPoint], holes: Option[Seq[GeoPoint]])
+
+  case class Circle(point: GeoPoint, distance: (Double, DistanceUnit))
+}

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/geo/GeoShapeQueryBodyFnTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/geo/GeoShapeQueryBodyFnTest.scala
@@ -1,0 +1,366 @@
+package com.sksamuel.elastic4s.http.search.queries.geo
+
+import com.sksamuel.elastic4s.DistanceUnit
+import com.sksamuel.elastic4s.searches.GeoPoint
+import com.sksamuel.elastic4s.searches.queries.geo.Shapes.{Circle, Polygon}
+import com.sksamuel.elastic4s.searches.queries.geo._
+import org.scalatest.{FunSuite, GivenWhenThen, Matchers}
+
+class GeoShapeQueryBodyFnTest extends FunSuite with Matchers with GivenWhenThen {
+
+  test("Should correctly build geo shape point search query") {
+    Given("Some point query")
+    val query = GeoShapeQueryDefinition(
+      "location",
+      InlineShape(
+        PointShape(GeoPoint(-77.03653, 38.897676))
+      )
+    )
+
+    When("Geo shape query is built")
+    val queryBody = GeoShapeQueryBodyFn(query)
+
+    Then("query should have right field and coordinate")
+    queryBody.string() shouldEqual pointQuery
+  }
+
+  test("Should correctly build geo shape envelope query") {
+    Given("Some envelope query")
+    val query = GeoShapeQueryDefinition(
+      "location",
+      InlineShape(
+        EnvelopeShape(
+          upperLeft = GeoPoint(-45.0, 45.0),
+          lowerRight = GeoPoint(45.0, -45.0)
+        )
+      )
+    )
+
+    When("Geo shape query is built")
+    val queryBody = GeoShapeQueryBodyFn(query)
+
+    Then("query should have right field and coordinates")
+    queryBody.string() shouldEqual envelopeQuery
+  }
+
+  test("Should correctly build geo shape multipoint query") {
+    Given("Some multipoint query")
+    val query = GeoShapeQueryDefinition(
+      "location",
+      InlineShape(
+        MultiPointShape(Seq(GeoPoint(102.0,2.0),GeoPoint(102.0,3.0)))
+      )
+    )
+
+    When("Geo shape query is built")
+    val queryBody = GeoShapeQueryBodyFn(query)
+
+    Then("query should have right field and coordinates")
+    queryBody.string() shouldEqual multiPointQuery
+  }
+
+  test("Should correctly build geo shape linestring query") {
+    Given("Some linestring query")
+    val query = GeoShapeQueryDefinition(
+      "location",
+      InlineShape(
+        LineStringShape(GeoPoint(-77.03653, 38.897676),GeoPoint(-77.009051, 38.889939))
+      )
+    )
+
+    When("Geo shape query is built")
+    val queryBody = GeoShapeQueryBodyFn(query)
+
+    Then("query should have right field and coordinates")
+    queryBody.string() shouldEqual lineStringQuery
+
+  }
+
+  test("Should correctly build geo shape multilinestring query") {
+    Given("Some multi linestring query")
+    val query = GeoShapeQueryDefinition(
+      "location",
+      InlineShape(
+        MultiLineStringShape(Seq(
+          Seq(GeoPoint(102.0, 2.0), GeoPoint(103.0, 2.0), GeoPoint(103.0, 3.0), GeoPoint(102.0, 3.0)),
+          Seq(GeoPoint(100.0, 0.0), GeoPoint(101.0, 0.0), GeoPoint(101.0, 1.0), GeoPoint(100.0, 1.0)),
+          Seq(GeoPoint(100.2, 0.2), GeoPoint(100.8, 0.2), GeoPoint(100.8, 0.8), GeoPoint(100.2, 0.8))
+        ))
+      )
+    )
+
+    When("Geo shape query is built")
+    val queryBody = GeoShapeQueryBodyFn(query)
+
+    Then("query should have right field and coordinates")
+    queryBody.string() shouldEqual multiLineStringQuery
+  }
+
+  test("Should correctly build geo shape circle search query") {
+    Given("Some circle query")
+    val query = GeoShapeQueryDefinition(
+      "location",
+      InlineShape(
+        CircleShape(Circle(GeoPoint(23.23,100.23),(100.0,DistanceUnit.Meters)))
+      )
+    )
+
+    When("Geo shape query is built")
+    val queryBody = GeoShapeQueryBodyFn(query)
+
+    Then("query should have right field, coordinates and radius")
+    queryBody.string() shouldEqual circleQuery
+  }
+
+  test("Should correctly build geo shape geometry collection search query") {
+    Given("Some collection shape query")
+    val query = GeoShapeQueryDefinition(
+      "location",
+      InlineShape(
+        GeometryCollectionShape(
+          Seq(
+            CircleShape(Circle(GeoPoint(23.23,100.23),(100.0,DistanceUnit.Meters))),
+            PointShape(GeoPoint(23.23,100.23))
+          )
+        )
+      )
+    )
+
+    When("Geo shape query is built")
+    val queryBody = GeoShapeQueryBodyFn(query)
+
+    Then("query should have all shapes in collection specified")
+    queryBody.string() shouldEqual geometryCollectionQuery
+  }
+
+  test("Should correctly build geo shape polygon search query") {
+    Given("Some polygon shape query")
+    val query = GeoShapeQueryDefinition(
+      "location",
+      InlineShape(
+        PolygonShape(Polygon(
+          points = Seq(
+            GeoPoint(100.0, 0.0),
+            GeoPoint(101.0, 0.0),
+            GeoPoint(101.0, 1.0),
+            GeoPoint(100.0, 1.0),
+            GeoPoint(100.0, 0.0)
+          ),
+          holes = Some(
+            Seq(
+              GeoPoint(100.2, 0.2),
+              GeoPoint(100.8, 0.2),
+              GeoPoint(100.8, 0.8),
+              GeoPoint(100.2, 0.8),
+              GeoPoint(100.2, 0.2)
+            )
+          ))
+        )
+      )
+    )
+
+
+    When("Geo shape query is built")
+    val queryBody = GeoShapeQueryBodyFn(query)
+
+    Then("query should have right field and coordinates")
+    queryBody.string() shouldEqual polygonQuery
+  }
+
+  test("Should correctly build geo shape multipolygon search query") {
+    Given("Some multipolygon shape query")
+    val query = GeoShapeQueryDefinition(
+      "location",
+      InlineShape(
+        MultiPolygonShape(
+          Seq(
+            Polygon(
+              points = Seq(
+                GeoPoint(102.0, 2.0),
+                GeoPoint(103.0, 2.0),
+                GeoPoint(103.0, 3.0),
+                GeoPoint(102.0, 3.0),
+                GeoPoint(102.0, 2.0)
+              ),
+              holes = None
+            ),
+            Polygon(
+              points = Seq(
+                GeoPoint(100.0, 0.0),
+                GeoPoint(101.0, 0.0),
+                GeoPoint(101.0, 1.0),
+                GeoPoint(100.0, 1.0),
+                GeoPoint(100.0, 0.0)
+              ),
+              holes = Some(
+                Seq(
+                  GeoPoint(100.2, 0.2),
+                  GeoPoint(100.8, 0.2),
+                  GeoPoint(100.8, 0.8),
+                  GeoPoint(100.2, 0.8),
+                  GeoPoint(100.2, 0.2)
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+
+    When("Geo shape query is built")
+    val queryBody = GeoShapeQueryBodyFn(query)
+
+    Then("query should have right field and coordinates")
+    queryBody.string() shouldEqual multiPolygonQuery
+  }
+
+  def polygonQuery =
+  """
+    |{
+    |   "geo_shape":{
+    |      "location":{
+    |         "shape":{
+    |            "type":"polygon",
+    |            "coordinates":[
+    |               [[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]],
+    |               [[100.2,0.2],[100.8,0.2],[100.8,0.8],[100.2,0.8],[100.2,0.2]]
+    |            ]
+    |         }
+    |      }
+    |   }
+    |}
+  """.stripMargin.replaceAllLiterally(" ", "").replace("\n", "")
+
+  def multiPolygonQuery =
+  """
+    |{
+    |   "geo_shape":{
+    |      "location":{
+    |         "shape":{
+    |            "type":"multipolygon",
+    |            "coordinates":[
+    |               [ [[102.0,2.0],[103.0,2.0],[103.0,3.0],[102.0,3.0],[102.0,2.0]] ],
+    |               [ [[100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0],[100.0,0.0]],
+    |                 [[100.2,0.2],[100.8,0.2],[100.8,0.8],[100.2,0.8],[100.2,0.2]] ]
+    |            ]
+    |         }
+    |      }
+    |   }
+    |}
+  """.stripMargin.replaceAllLiterally(" ", "").replace("\n", "")
+
+  def pointQuery =
+  """
+    |{
+    |   "geo_shape":{
+    |      "location":{
+    |         "shape":{
+    |            "type":"point",
+    |            "coordinates":[-77.03653, 38.897676]
+    |         }
+    |      }
+    |   }
+    |}
+  """.stripMargin.replaceAllLiterally(" ", "").replace("\n", "")
+
+  def envelopeQuery =
+  """
+    |{
+    |   "geo_shape":{
+    |      "location":{
+    |         "shape":{
+    |            "type":"envelope",
+    |            "coordinates":[ [-45.0,45.0],[45.0,-45.0] ]
+    |         }
+    |      }
+    |   }
+    |}
+  """.stripMargin.replaceAllLiterally(" ", "").replace("\n", "")
+
+  def multiPointQuery =
+  """
+    |{
+    |   "geo_shape":{
+    |      "location":{
+    |         "shape":{
+    |            "type":"multipoint",
+    |            "coordinates":[ [102.0,2.0],[102.0,3.0] ]
+    |         }
+    |      }
+    |   }
+    |}
+  """.stripMargin.replaceAllLiterally(" ", "").replace("\n", "")
+
+  def lineStringQuery =
+  """
+    |{
+    |   "geo_shape":{
+    |      "location":{
+    |         "shape":{
+    |            "type":"linestring",
+    |            "coordinates":[ [-77.03653,38.897676],[-77.009051,38.889939] ]
+    |         }
+    |      }
+    |   }
+    |}
+  """.stripMargin.replaceAllLiterally(" ", "").replace("\n", "")
+
+  def multiLineStringQuery =
+  """
+    |{
+    |   "geo_shape":{
+    |      "location":{
+    |         "shape":{
+    |            "type":"multilinestring",
+    |            "coordinates":[
+    |               [ [102.0,2.0],[103.0,2.0],[103.0,3.0],[102.0,3.0] ],
+    |               [ [100.0,0.0],[101.0,0.0],[101.0,1.0],[100.0,1.0] ],
+    |               [ [100.2,0.2],[100.8,0.2],[100.8,0.8],[100.2,0.8] ]
+    |            ]
+    |         }
+    |      }
+    |   }
+    |}
+  """.stripMargin.replaceAllLiterally(" ", "").replace("\n", "")
+
+  def circleQuery =
+  """|
+    |{
+    |   "geo_shape":{
+    |      "location":{
+    |         "shape":{
+    |            "type":"circle",
+    |            "coordinates":[23.23,100.23],
+    |            "radius":"100.0m"
+    |         }
+    |      }
+    |   }
+    |}
+  """.stripMargin.replaceAllLiterally(" ", "").replace("\n", "")
+
+  def geometryCollectionQuery =
+  """
+    |{
+    |   "geo_shape":{
+    |      "location":{
+    |         "shape":{
+    |            "type":"geometrycollection",
+    |            "geometries":[
+    |               {
+    |                  "type":"circle",
+    |                  "coordinates":[23.23,100.23],
+    |                  "radius":"100.0m"
+    |               },
+    |               {
+    |                  "type":"point",
+    |                  "coordinates":[23.23,100.23]
+    |               }
+    |            ]
+    |         }
+    |      }
+    |   }
+    |}
+  """.stripMargin.replaceAllLiterally(" ", "").replace("\n", "")
+}
+
+


### PR DESCRIPTION
Hi,

I tried to use the reworked geoshape query builder in the http module, but could not get it to work. I think the the main problem is that InlineShape is modeled as a sequence of points when in fact not all shapes looks like that. E.g. Circle has a different shape from Polygon etc.

I've made an attempt to fix this by refactoring the geo shape query builder a bit. All of the shapes defined in this document should now be supported:

https://www.elastic.co/guide/en/elasticsearch/reference/current/geo-shape.html

Changes:
- Add new ADTs to represent the single geojson shapes and  GeometryCollection which is a collection of geojson shapes
- Refactor GeoShapeQueryBodyFn query builder to support the new geo shape model
- Change GeoShapeQueryDefinition to work with the new model
- Add query builder test for each query

What do you think? I'm happy to make adjustments if you have suggestions.
