### PR TITLE
Added support for Typeless Parent/Child, added join type

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/TypesApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/TypesApi.scala
@@ -19,6 +19,7 @@ trait TypesApi {
   def geoshapeField(name: String): GeoshapeFieldDefinition = GeoshapeFieldDefinition(name)
   def intField(name: String): BasicFieldDefinition = BasicFieldDefinition(name, "integer")
   def ipField(name: String): BasicFieldDefinition = BasicFieldDefinition(name, "ip")
+  def joinField(name: String): JoinFieldDefinition = JoinFieldDefinition(name)
   def keywordField(name: String): KeywordFieldDefinition = KeywordFieldDefinition(name)
   def longField(name: String): BasicFieldDefinition = BasicFieldDefinition(name, "long")
   def nestedField(name: String): NestedFieldDefinition = NestedFieldDefinition(name)

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/FieldBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/FieldBuilderFn.scala
@@ -91,6 +91,13 @@ object FieldBuilderFn {
         geo.format.foreach(builder.field("format", _))
         geo.ignoreMalformed.foreach(builder.field("ignore_malformed", _))
 
+      case join: JoinFieldDefinition =>
+        builder.startObject("relations")
+        join.relations.foreach { case (parent, child) =>
+          builder.field(parent, child)
+        }
+        builder.endObject()
+
       case obj: ObjectFieldDefinition =>
         obj.dynamic.foreach(builder.field("dynamic", _))
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/FieldType.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/FieldType.scala
@@ -14,6 +14,7 @@ object FieldType {
   case object IpType extends FieldType("ip")
   case object GeoPointType extends FieldType("geo_point")
   case object GeoShapeType extends FieldType("geo_shape")
+  case object JoinType extends FieldType("join")
   case object KeywordType extends FieldType("keyword")
   case object LongType extends FieldType("long")
   case object NestedType extends FieldType("nested")

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/JoinFieldDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/JoinFieldDefinition.scala
@@ -1,0 +1,59 @@
+package com.sksamuel.elastic4s.mappings
+
+import com.sksamuel.exts.OptionImplicits._
+
+case class JoinFieldDefinition(name: String,
+                               analyzer: Option[String] = None,
+                               boost: Option[Double] = None,
+                               copyTo: Seq[String] = Nil,
+                               docValues: Option[Boolean] = None,
+                               dynamic: Option[String] = None,
+                               enabled: Option[Boolean] = None,
+                               includeInAll: Option[Boolean] = None,
+                               index: Option[String] = None,
+                               indexOptions: Option[String] = None,
+                               fields: Seq[FieldDefinition] = Nil,
+                               norms: Option[Boolean] = None,
+                               normalizer: Option[String] = None,
+                               nullable: Option[Boolean] = None,
+                               nullValue: Option[Any] = None,
+                               searchAnalyzer: Option[String] = None,
+                               store: Option[Boolean] = None,
+                               termVector: Option[String] = None,
+                               relations: Map[String, String] = Map.empty
+                              ) extends FieldDefinition {
+
+  type T = JoinFieldDefinition
+  override def `type` = "object"
+
+  override def boost(boost: Double): T = copy(boost = boost.some)
+  override def docValues(docValues: Boolean): T = copy(docValues = docValues.some)
+  def dynamic(dynamic: String): T = copy(dynamic = dynamic.some)
+  def dynamic(dynamic: Boolean): T = copy(dynamic = dynamic.toString.some)
+
+  def relations(map: Map[String, String]): T = copy(relations = relations)
+
+  override def analyzer(analyzer: String): T = copy(analyzer = analyzer.some)
+  override def normalizer(normalizer: String): T = copy(normalizer = normalizer.some)
+  override def searchAnalyzer(analyzer: String): T = copy(searchAnalyzer = analyzer.some)
+
+  override def nullable(nullable: Boolean): T = copy(nullable = nullable.some)
+  override def nullValue(nullvalue: Any): T = copy(nullValue = nullvalue.some)
+
+  override def fields(fields: Iterable[FieldDefinition]): T = copy(fields = fields.toSeq)
+
+  override def copyTo(first: String, rest: String*): T = copyTo(first +: rest)
+  override def copyTo(copyTo: Iterable[String]): T = copy(copyTo = copyTo.toSeq)
+
+  override def enabled(enabled: Boolean): T = copy(enabled = enabled.some)
+
+  override def includeInAll(includeInAll: Boolean): T = copy(includeInAll = includeInAll.some)
+
+  override def index(index: Boolean): T = copy(index = index.toString.some)
+
+  override def norms(norms: Boolean): T = copy(norms = norms.some)
+
+  override def store(b: Boolean): T = copy(store = b.some)
+
+  override def termVector(t: String): T = copy(termVector = t.some)
+}


### PR DESCRIPTION
Elasticsearch 5.6.x supports join type; this pull request add its support to Elastic4s.