### PR TITLE
1188-fix-address-aws-normalized-uri-encoding

### DIFF
--- a/elastic4s-aws/src/main/scala/com/sksamuel/elastic4s/aws/StringToSign.scala
+++ b/elastic4s-aws/src/main/scala/com/sksamuel/elastic4s/aws/StringToSign.scala
@@ -15,8 +15,8 @@ case class StringToSign(service: String,
   val credentialsScope = s"$date/$region/$service/aws4_request"
 
   override def toString(): String =
-    s"$Algorithm\n" +
-      s"$dateTime\n" +
-      s"$credentialsScope\n" +
-      s"${canonicalRequest.toHashString.toLowerCase}"
+    s"""$Algorithm
+       |$dateTime
+       |$credentialsScope
+       |${canonicalRequest.toHashString.toLowerCase}""".stripMargin
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/aws/CanonicalRequestTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/aws/CanonicalRequestTest.scala
@@ -17,6 +17,17 @@ class CanonicalRequestTest extends WordSpec with Matchers with SharedTestData{
         |content-type;host;x-amz-date
         |e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855""".stripMargin
 
+    val resultWithForbiddenCharacters =
+      s"""GET
+        |/path/to/resource$encodedForbiddenCharactersAndMore
+        |Action=ListUsers&Version=2010-05-08
+        |content-type:application/x-www-form-urlencoded; charset=utf-8
+        |host:es.amazonaws.com
+        |x-amz-date:20150830T123600Z
+        |
+        |content-type;host;x-amz-date
+        |e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855""".stripMargin
+
     val resultWithPayload =
       """POST
         |/path/to/resource
@@ -37,5 +48,11 @@ class CanonicalRequestTest extends WordSpec with Matchers with SharedTestData{
       val canonicalRequest = CanonicalRequest(httpPostRequest)
       canonicalRequest.toString shouldBe(resultWithPayload)
     }
+
+    "be able to be encode a url with forbidden characters making sure it follows RFC 3986" in {
+      val canonicalRequest = CanonicalRequest(httpWithForbiddenCharacters)
+      canonicalRequest.toString shouldBe(resultWithForbiddenCharacters)
+    }
+
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/aws/SharedTestData.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/aws/SharedTestData.scala
@@ -1,6 +1,7 @@
 package com.sksamuel.elastic4s.aws
 
 import java.io.ByteArrayInputStream
+import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
 import org.apache.http.client.methods.{HttpGet, HttpPost}
@@ -16,6 +17,16 @@ trait SharedTestData {
   val awsKey = "AKIDEXAMPLE"
   val awsSecret = "YNexysRYkuJmLzyNKfotrkEEWWwTEiOgXPEHHGsp"
   val awsSessionToken = "ThisIsASessionToken"
+  val forbiddenCharactersAndMore =  URLEncoder.encode("!@#$%ˆ&*()/to[]{};'", "UTF-8")
+  val encodedForbiddenCharactersAndMore = "%2521%2540%2523%2524%2525%25CB%2586%2526%2A%2528%2529%252Fto%255B%255D%257B%257D%253B%2527"
+
+  def httpWithForbiddenCharacters = {
+    val request = new HttpGet(s"https://es.amazonaws.com/path/to/resource${forbiddenCharactersAndMore}?Action=ListUsers&Version=2010-05-08")
+    request.addHeader("x-amz-date", dateTime)
+    request.addHeader("Host", host)
+    request.addHeader("content-type", "application/x-www-form-urlencoded; charset=utf-8")
+    request
+  }
 
   def httpGetRequest = {
     val request = new HttpGet("https://es.amazonaws.com/path/to/resource?Action=ListUsers&Version=2010-05-08")

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -19,7 +19,7 @@ object Build extends AutoPlugin {
     val JacksonVersion = "2.9.2"
     val Json4sVersion = "3.5.3"
     val SprayJsonVersion = "1.3.4"
-    val AWSJavaSdkVersion = "1.11.217"
+    val AWSJavaSdkVersion = "1.11.253"
     val Log4jVersion = "2.9.1"
     val LuceneVersion = "7.0.1"
     val MockitoVersion = "1.9.5"


### PR DESCRIPTION
Fixes #1188 

Not surprisingly java URLEncoder does not respect RFC 3986. Had to some fixes and added a test that covers url forbidden characters. 