### PR TITLE
Fix missing otherBucket and otherBucketKey in KeyedFilters request

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/KeyedFiltersAggregationBuilder.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/KeyedFiltersAggregationBuilder.scala
@@ -9,15 +9,17 @@ object KeyedFiltersAggregationBuilder {
 
     val builder = XContentFactory.jsonBuilder()
 
-    val filters = {
-      builder.startObject("filters")
-      agg.filters.map(map => {
-        builder.rawField(map._1, QueryBuilderFn(map._2))
-      })
-      builder.endObject()
-    }
+    builder.startObject("filters")
+    agg.otherBucket.foreach(builder.field("other_bucket", _))
+    agg.otherBucketKey.foreach(builder.field("other_bucket_key", _))
 
-    builder.rawField("filters", filters)
+    builder.startObject("filters")
+    agg.filters.map(map => {
+      builder.rawField(map._1, QueryBuilderFn(map._2))
+    })
+    builder.endObject()
+
+    builder.endObject()
 
     SubAggsBuilderFn(agg, builder)
     AggMetaDataFn(agg, builder)


### PR DESCRIPTION
The options were available in the definition but were never written into the request to ES.

Added tests for this issue