### PR TITLE
added geocentroid to http agg

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/AggregationBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/AggregationBuilderFn.scala
@@ -18,6 +18,7 @@ object AggregationBuilderFn {
       case agg: FilterAggregationDefinition => FilterAggregationBuilder(agg)
       case agg: FiltersAggregationDefinition => FiltersAggregationBuilder(agg)
       case agg: KeyedFiltersAggregationDefinition => KeyedFiltersAggregationBuilder(agg)
+      case agg: GeoCentroidAggregationDefinition => GeoCentroidAggregationBuilder(agg)
       case agg: GeoBoundsAggregationDefinition => GeoBoundsAggregationBuilder(agg)
       case agg: GeoHashGridAggregationDefinition => GeoHashGridAggregationBuilder(agg)
       case agg: MaxAggregationDefinition => MaxAggregationBuilder(agg)

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/GeoBoundsAggregationBuilder.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/GeoBoundsAggregationBuilder.scala
@@ -17,9 +17,9 @@ object GeoBoundsAggregationBuilder {
       builder.rawField("script", ScriptBuilderFn(script))
     }
 
-    SubAggsBuilderFn(agg, builder)
-    AggMetaDataFn(agg, builder)
+    builder.endObject()
 
-    builder
+    AggMetaDataFn(agg, builder)
+    builder.endObject()
   }
 }

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/GeoCentroidAggregationBuilder.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/GeoCentroidAggregationBuilder.scala
@@ -16,9 +16,9 @@ object GeoCentroidAggregationBuilder {
       builder.rawField("script", ScriptBuilderFn(script))
     }
 
-    SubAggsBuilderFn(agg, builder)
-    AggMetaDataFn(agg, builder)
+    builder.endObject()
 
-    builder
+    AggMetaDataFn(agg, builder)
+    builder.endObject()
   }
 }

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/GeoCentroidAggregationBuilder.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/GeoCentroidAggregationBuilder.scala
@@ -1,0 +1,24 @@
+package com.sksamuel.elastic4s.http.search.aggs
+
+import com.sksamuel.elastic4s.http.ScriptBuilderFn
+import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
+import com.sksamuel.elastic4s.searches.aggs.GeoCentroidAggregationDefinition
+
+object GeoCentroidAggregationBuilder {
+  def apply(agg: GeoCentroidAggregationDefinition): XContentBuilder = {
+
+    val builder = XContentFactory.obj.startObject("geo_centroid")
+
+    agg.field.foreach(builder.field("field", _))
+    agg.format.foreach(builder.field("format", _))
+    agg.missing.foreach(builder.autofield("missing", _))
+    agg.script.foreach { script =>
+      builder.rawField("script", ScriptBuilderFn(script))
+    }
+
+    SubAggsBuilderFn(agg, builder)
+    AggMetaDataFn(agg, builder)
+
+    builder
+  }
+}

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/GeoHashGridAggregationBuilder.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/GeoHashGridAggregationBuilder.scala
@@ -13,9 +13,10 @@ object GeoHashGridAggregationBuilder {
     agg.size.foreach(builder.field("size", _))
     agg.shardSize.foreach(builder.field("shard_size", _))
 
+    builder.endObject()
+
     SubAggsBuilderFn(agg, builder)
     AggMetaDataFn(agg, builder)
-
-    builder
+    builder.endObject()
   }
 }


### PR DESCRIPTION
@sksamuel closes #1199 and #1198 

https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket.html
states that 

> Bucket aggregations, as opposed to metrics aggregations, can hold sub-aggregations.

so we may want to differentiate between different types of aggregations