### PR TITLE
JavaClientExceptionWrapper eats parent exception stack trace 

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/ElasticsearchJavaRestClient.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/ElasticsearchJavaRestClient.scala
@@ -11,7 +11,7 @@ import org.elasticsearch.client.{ResponseException, ResponseListener, RestClient
 import scala.concurrent.{Future, Promise}
 import scala.io.{Codec, Source}
 
-case class JavaClientExceptionWrapper(t: Throwable) extends RuntimeException
+case class JavaClientExceptionWrapper(t: Throwable) extends RuntimeException(t)
 
 // an implementation of the elastic4s HttpRequestClient that wraps the elasticsearch java client
 class ElasticsearchJavaRestClient(client: RestClient) extends HttpRequestClient {


### PR DESCRIPTION
Stack traces disappear because of the missing constructor parameter

```
com.sksamuel.elastic4s.http.JavaClientExceptionWrapper: null
   at com.sksamuel.elastic4s.http.ElasticsearchJavaRestClient$$anon$1.onFailure(ElasticsearchJavaRestClient.scala:40) ~[com.sksamuel.elastic4s.elastic4s-http_2.12-6.1.1.jar:6.1.1]
   at org.elasticsearch.client.RestClient$FailureTrackingResponseListener.onDefinitiveFailure(RestClient.java:608) ~[org.elasticsearch.client.elasticsearch-rest-client-6.1.1.jar:6.1.1]
   at org.elasticsearch.client.RestClient$1.retryIfPossible(RestClient.java:399) ~[org.elasticsearch.client.elasticsearch-rest-client-6.1.1.jar:6.1.1]
   at org.elasticsearch.client.RestClient$1.failed(RestClient.java:378) ~[org.elasticsearch.client.elasticsearch-rest-client-6.1.1.jar:6.1.1]
   at org.apache.http.concurrent.BasicFuture.failed(BasicFuture.java:134) ~[org.apache.httpcomponents.httpcore-4.4.5.jar:4.4.5]
   at org.apache.http.impl.nio.client.AbstractClientExchangeHandler.failed(AbstractClientExchangeHandler.java:419) ~[org.apache.httpcomponents.httpasyncclient-4.1.2.jar:4.1.2]
   at org.apache.http.impl.nio.client.AbstractClientExchangeHandler.connectionRequestFailed(AbstractClientExchangeHandler.java:335) ~[org.apache.httpcomponents.httpasyncclient-4.1.2.jar:4.1.2]
   at org.apache.http.impl.nio.client.AbstractClientExchangeHandler.access$100(AbstractClientExchangeHandler.java:62) ~[org.apache.httpcomponents.httpasyncclient-4.1.2.jar:4.1.2]
   at org.apache.http.impl.nio.client.AbstractClientExchangeHandler$1.failed(AbstractClientExchangeHandler.java:378) ~[org.apache.httpcomponents.httpasyncclient-4.1.2.jar:4.1.2]
   at org.apache.http.concurrent.BasicFuture.failed(BasicFuture.java:134) ~[org.apache.httpcomponents.httpcore-4.4.5.jar:4.4.5]
   at org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager$InternalPoolEntryCallback.failed(PoolingNHttpClientConnectionManager.java:504) ~[org.apache.httpcomponents.httpasyncclient-4.1.2.jar:4.1.2]
   at org.apache.http.concurrent.BasicFuture.failed(BasicFuture.java:134) ~[org.apache.httpcomponents.httpcore-4.4.5.jar:4.4.5]
   at org.apache.http.nio.pool.AbstractNIOConnPool.fireCallbacks(AbstractNIOConnPool.java:454) ~[org.apache.httpcomponents.httpcore-nio-4.4.5.jar:4.4.5]
   at org.apache.http.nio.pool.AbstractNIOConnPool.release(AbstractNIOConnPool.java:323) ~[org.apache.httpcomponents.httpcore-nio-4.4.5.jar:4.4.5]
   at org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager.releaseConnection(PoolingNHttpClientConnectionManager.java:303) ~[org.apache.httpcomponents.httpasyncclient-4.1.2.jar:4.1.2]
   at org.apache.http.impl.nio.client.AbstractClientExchangeHandler.releaseConnection(AbstractClientExchangeHandler.java:239) ~[org.apache.httpcomponents.httpasyncclient-4.1.2.jar:4.1.2]
   at org.apache.http.impl.nio.client.MainClientExec.responseCompleted(MainClientExec.java:387) ~[org.apache.httpcomponents.httpasyncclient-4.1.2.jar:4.1.2]
   at org.apache.http.impl.nio.client.DefaultClientExchangeHandlerImpl.responseCompleted(DefaultClientExchangeHandlerImpl.java:168) ~[org.apache.httpcomponents.httpasyncclient-4.1.2.jar:4.1.2]
   at org.apache.http.nio.protocol.HttpAsyncRequestExecutor.processResponse(HttpAsyncRequestExecutor.java:436) ~[org.apache.httpcomponents.httpcore-nio-4.4.5.jar:4.4.5]
   at org.apache.http.nio.protocol.HttpAsyncRequestExecutor.inputReady(HttpAsyncRequestExecutor.java:326) ~[org.apache.httpcomponents.httpcore-nio-4.4.5.jar:4.4.5]
   at org.apache.http.impl.nio.DefaultNHttpClientConnection.consumeInput(DefaultNHttpClientConnection.java:265) ~[org.apache.httpcomponents.httpcore-nio-4.4.5.jar:4.4.5]
   at org.apache.http.impl.nio.client.InternalIODispatch.onInputReady(InternalIODispatch.java:81) ~[org.apache.httpcomponents.httpasyncclient-4.1.2.jar:4.1.2]
   at org.apache.http.impl.nio.client.InternalIODispatch.onInputReady(InternalIODispatch.java:39) ~[org.apache.httpcomponents.httpasyncclient-4.1.2.jar:4.1.2]
   at org.apache.http.impl.nio.reactor.AbstractIODispatch.inputReady(AbstractIODispatch.java:114) ~[org.apache.httpcomponents.httpcore-nio-4.4.5.jar:4.4.5]
   at org.apache.http.impl.nio.reactor.BaseIOReactor.readable(BaseIOReactor.java:162) ~[org.apache.httpcomponents.httpcore-nio-4.4.5.jar:4.4.5]
   at org.apache.http.impl.nio.reactor.AbstractIOReactor.processEvent(AbstractIOReactor.java:337) ~[org.apache.httpcomponents.httpcore-nio-4.4.5.jar:4.4.5]
   at org.apache.http.impl.nio.reactor.AbstractIOReactor.processEvents(AbstractIOReactor.java:315) ~[org.apache.httpcomponents.httpcore-nio-4.4.5.jar:4.4.5]
   at org.apache.http.impl.nio.reactor.AbstractIOReactor.execute(AbstractIOReactor.java:276) ~[org.apache.httpcomponents.httpcore-nio-4.4.5.jar:4.4.5]
   at org.apache.http.impl.nio.reactor.BaseIOReactor.execute(BaseIOReactor.java:104) ~[org.apache.httpcomponents.httpcore-nio-4.4.5.jar:4.4.5]
   at org.apache.http.impl.nio.reactor.AbstractMultiworkerIOReactor$Worker.run(AbstractMultiworkerIOReactor.java:588) ~[org.apache.httpcomponents.httpcore-nio-4.4.5.jar:4.4.5]
   at java.lang.Thread.run(Thread.java:748) ~[?:1.8.0_151]
```