### PR TITLE
Support URIs with authentication (i.e. more than one colon) in HTTP client

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticsearchClientUri.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticsearchClientUri.scala
@@ -19,7 +19,10 @@ object ElasticsearchClientUri {
     str match {
       case Regex(hoststr, query) =>
         val hosts = hoststr.split(',').map(_.split(':')).map {
-          case Array(host, port) => (host, port.toInt)
+          case hostAndPort if hostAndPort.length >= 2 =>
+            val host = hostAndPort.dropRight(1).mkString(":")
+            val port = hostAndPort.last.toInt
+            (host, port)
           case _ => sys.error(s"Invalid hosts/ports $hoststr")
         }
         val options = StringOption(query)

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/ElasticsearchClientUriTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/ElasticsearchClientUriTest.scala
@@ -24,6 +24,10 @@ class ElasticsearchClientUriTest extends FlatSpec with Matchers {
     testString("elasticsearch://host1:1234/", List("host1" -> 1234))
   }
 
+  it should "parse single host/ports with auth" in {
+    testString("elasticsearch://user:pass@host1:1234", List("user:pass@host1" -> 1234))
+  }
+
   it should "errors on trailing commas" in {
     testString("elasticsearch://host1:1234,", List("host1" -> 1234))
   }


### PR DESCRIPTION
Adds support for HTTP URIs containing more than one colon. This is e.g. used in URIs with authentication (formatted like `user:pass@host:port`) and is required for Bonsai on Heroku.