### PR TITLE
Support URIs with HTTPS in HTTP client

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticsearchClientUri.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticsearchClientUri.scala
@@ -6,7 +6,7 @@ import scala.language.implicitConversions
 
 object ElasticsearchClientUri {
 
-  private val Regex = "(?:elasticsearch|http)://(.*?)/?(\\?.*?)?".r
+  private val Regex = "(?:elasticsearch|http|https)://(.*?)/?(\\?.*?)?".r
 
   implicit def stringtoUri(str: String): ElasticsearchClientUri = ElasticsearchClientUri(str)
 
@@ -30,7 +30,7 @@ object ElasticsearchClientUri {
           case _ => sys.error(s"Invalid query $query")
         }
         ElasticsearchClientUri(str, hosts.toList, options.toMap)
-      case _ => sys.error(s"Invalid uri $str, must be in format elasticsearch://host:port,host:port?querystr or http://host:port,host:port?querystr")
+      case _ => sys.error(s"Invalid uri $str, must be in format elasticsearch://host:port,host:port?querystr, http://host:port,host:port?querystr or https://host:port,host:port?querystr")
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/ElasticsearchClientUriTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/ElasticsearchClientUriTest.scala
@@ -53,4 +53,8 @@ class ElasticsearchClientUriTest extends FlatSpec with Matchers {
   it should "support http protocol" in {
     testString("http://host1:1234,host2:2345", List("host1" -> 1234, "host2" -> 2345))
   }
+
+  it should "support https protocol" in {
+    testString("https://host1:1234,host2:2345", List("host1" -> 1234, "host2" -> 2345))
+  }
 }


### PR DESCRIPTION
Adds support for HTTPS URIs.

Like #1231 related to support for Bonsai on Heroku. In that case a `BONSAI_URL` environment variable is available including authentication credentials and the `https://` prefix. Adding support for HTTPS URIs as in this PR prevents the need to strip/replace the `https://` part.

See also https://devcenter.heroku.com/articles/bonsai#installing-the-add-on.