### PR TITLE
remove requires check for / for date math indexing

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/indexes/CreateIndexDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/indexes/CreateIndexDefinition.scala
@@ -16,7 +16,6 @@ case class CreateIndexDefinition(name: String,
                                  waitForActiveShards: Option[Int] = None,
                                  aliases: Set[IndexAliasDefinition] = Set.empty,
                                  settings: IndexSettings = new IndexSettings) {
-  require(!name.contains("/"), "Index should not contain / when creating mappings. Specify the type as the mapping")
 
   def alias(name: String): CreateIndexDefinition = alias(IndexAliasDefinition(name, None))
   def alias(name: String, filter: QueryDefinition): CreateIndexDefinition = alias(IndexAliasDefinition(name, Option(filter)))


### PR DESCRIPTION
This fixes #1230, since types are going to be going away in the next ES release.