### PR TITLE
Fix-1238 Add wait_for_no_relocating_shards param to cluster health and add timeout to request

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/cluster/ClusterApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/cluster/ClusterApi.scala
@@ -42,7 +42,8 @@ case class ClusterHealthDefinition(indices: Seq[String],
                                    waitForActiveShards: Option[Int] = None,
                                    waitForEvents: Option[Priority] = None,
                                    waitForStatus: Option[HealthStatus] = None,
-                                   waitForNodes: Option[String] = None) {
+                                   waitForNodes: Option[String] = None,
+                                   waitForNoRelocatingShards: Option[Boolean] = None) {
 
   def timeout(value: String): ClusterHealthDefinition = copy(timeout = value.some)
 
@@ -55,4 +56,6 @@ case class ClusterHealthDefinition(indices: Seq[String],
     copy(waitForStatus = waitForStatus.some)
 
   def waitForNodes(waitForNodes: String): ClusterHealthDefinition = copy(waitForNodes = waitForNodes.some)
+
+  def waitForNoRelocatingShards(waitForNoRelocatingShards: Boolean): ClusterHealthDefinition = copy(waitForNoRelocatingShards = waitForNoRelocatingShards.some)
 }

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/cluster/ClusterImplicits.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/cluster/ClusterImplicits.scala
@@ -41,6 +41,8 @@ trait ClusterImplicits {
       request.waitForStatus.map(_.toString).foreach(params.put("wait_for_status", _))
       request.waitForActiveShards.map(_.toString).foreach(params.put("wait_for_active_shards", _))
       request.waitForNodes.map(_.toString).foreach(params.put("wait_for_nodes", _))
+      request.waitForNoRelocatingShards.map(_.toString).foreach(params.put("wait_for_no_relocating_shards", _))
+      request.timeout.map(_.toString).foreach(params.put("timeout", _))
 
       client.async("GET", endpoint, params.toMap)
     }

--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/admin/ClusterExecutables.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/admin/ClusterExecutables.scala
@@ -31,6 +31,7 @@ trait ClusterExecutables {
       }.foreach(builder.setWaitForStatus)
       definition.waitForNodes.foreach(builder.setWaitForNodes)
       definition.waitForActiveShards.foreach(builder.setWaitForActiveShards)
+      definition.waitForNoRelocatingShards.foreach(builder.setWaitForNoRelocatingShards)
       definition.waitForEvents.map {
         case Priority.High => org.elasticsearch.common.Priority.HIGH
         case Priority.Immediate => org.elasticsearch.common.Priority.IMMEDIATE


### PR DESCRIPTION
Initially was just adding the `wait_for_no_relocating_shards` param and noticed `timeout` was not being included in the request params for cluster health requests, so I fixed that as well.