### PR TITLE
Fixed a bug with sort script parameters

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/SortBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/SortBuilderFn.scala
@@ -76,11 +76,8 @@ object ScriptSortBuilderFn {
     builder.startObject("script")
     builder.field(scriptSort.script.scriptType.toString.toLowerCase, scriptSort.script.script)
     builder.field("lang", scriptSort.script.lang.getOrElse("painless"))
-    if (scriptSort.script.params.nonEmpty) {
-      builder.startObject("params")
-      scriptSort.script.params.foreach(a => builder.field(a._1, a._2.toString))
-      builder.endObject()
-    }
+    if (scriptSort.script.params.nonEmpty)
+      builder.autofield("params", scriptSort.script.params)
     builder.endObject()
 
     builder.field("type", scriptSort.scriptSortType.toString.toLowerCase)

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/SortBuilderFnTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/SortBuilderFnTest.scala
@@ -1,0 +1,31 @@
+package com.sksamuel.elastic4s.http.search.queries
+
+import com.sksamuel.elastic4s.DistanceUnit
+import com.sksamuel.elastic4s.http.ElasticDsl._
+import com.sksamuel.elastic4s.http.search.SearchBodyBuilderFn
+import com.sksamuel.elastic4s.script.ScriptType
+import com.sksamuel.elastic4s.searches.GeoPoint
+import com.sksamuel.elastic4s.searches.queries.geo.GeoDistanceQueryDefinition
+import com.sksamuel.elastic4s.searches.sort.{GeoDistanceSortDefinition, SortOrder, ScriptSortType}
+import org.scalatest.{FunSuite, Matchers}
+import com.sksamuel.exts.OptionImplicits._
+
+class SortBuilderFnTest extends FunSuite with Matchers {
+
+  test("sort script parameters are encoded with the correct type") {
+    val scr = script("dummy script")
+      .lang("painless")
+      .scriptType(ScriptType.Source)
+      .params(Map(
+        "nump" -> 10.2,
+        "stringp" -> "ciao",
+        "boolp" -> true
+      ))
+    val request = scriptSort(scr)
+      .typed(ScriptSortType.Number)
+      .order(SortOrder.Desc)
+    SortBuilderFn(request).string() shouldBe
+      """{"_script":{"script":{"source":"dummy script","lang":"painless","params":{"nump":10.2,"stringp":"ciao","boolp":true}},"type":"number","order":"desc"}}"""
+  }
+}
+


### PR DESCRIPTION
The problem was that all parameters were converted to string, losing their type. This, in turn, required a cast for parameters to the correct type inside scripts. I also added a simple test.