### PR TITLE
Prevents NullPointerException when suggestion is not found

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/responses.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/responses.scala
@@ -105,7 +105,7 @@ case class SearchResponse(took: Long,
   def aggs: Aggregations = aggregations
   def aggregations: Aggregations = Aggregations(aggregationsAsMap)
 
-  private def suggestion(name: String): Map[String, SuggestionResult] = suggest(name).map { result => result.text -> result }.toMap
+  private def suggestion(name: String): Map[String, SuggestionResult] = suggest.getOrElse(name, Nil).map { result => result.text -> result }.toMap
 
   def termSuggestion(name: String): Map[String, TermSuggestionResult] = suggestion(name).mapValues(_.toTerm)
   def completionSuggestion(name: String): Map[String, CompletionSuggestionResult] = suggestion(name).mapValues(_.toCompletion)


### PR DESCRIPTION
This change fixes NullPointerException when suggestion is not found and instead returns an empty list.