### PR TITLE
Use `index_patterns` instead of `template` in index templates

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/IndexTemplateImplicits.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/IndexTemplateImplicits.scala
@@ -83,7 +83,7 @@ object CreateIndexTemplateBodyFn {
   def apply(create: CreateIndexTemplateDefinition): XContentBuilder = {
 
     val builder = XContentFactory.jsonBuilder()
-    builder.field("template", create.pattern)
+    builder.array("index_patterns", Array(create.pattern))
     create.order.foreach(builder.field("order", _))
     create.version.foreach(builder.field("version", _))
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/indexes/CreateIndexTemplateDefinitionShowTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/indexes/CreateIndexTemplateDefinitionShowTest.scala
@@ -10,7 +10,7 @@ class CreateIndexTemplateDefinitionShowTest extends WordSpec with Matchers with 
   "CreateIndexTemplateDefinition" should {
     "have a show typeclass implementation" in {
       val req =
-        createTemplate("matchme.*").pattern("matchme.*").mappings(
+        createIndexTemplate("matchme.*", "matchme.*").mappings(
           mapping("characters").fields(
             textField("name"),
             textField("location")
@@ -25,7 +25,7 @@ class CreateIndexTemplateDefinitionShowTest extends WordSpec with Matchers with 
         .order(1)
         .settings(Map("number_of_shards" -> 4))
 
-      CreateIndexTemplateShow.show(req) should matchJson("""{"template":"matchme.*","order":1,"settings":{"number_of_shards":4,"analysis":{"analyzer":{"default":{"type":"custom","tokenizer":"keyword","filter":["lowercase"]}}}},"mappings":{"characters":{"properties":{"name":{"type":"text"},"location":{"type":"text"}}}}}""")
+      CreateIndexTemplateShow.show(req) should matchJson("""{"index_patterns":["matchme.*"],"order":1,"settings":{"number_of_shards":4,"analysis":{"analyzer":{"default":{"type":"custom","tokenizer":"keyword","filter":["lowercase"]}}}},"mappings":{"characters":{"properties":{"name":{"type":"text"},"location":{"type":"text"}}}}}""")
     }
   }
 }


### PR DESCRIPTION
This PR modifies the way index templates are created to use `index_patterns` instead of `template`, since `template` is now a [deprecated field](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_60_indices_changes.html#_index_templates_use_literal_index_patterns_literal_instead_of_literal_template_literal).