### PR TITLE
Use rawSource to build mapping if provided

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/MappingBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/MappingBuilderFn.scala
@@ -6,18 +6,31 @@ import com.sksamuel.elastic4s.mappings.dynamictemplate.{DynamicMapping, DynamicT
 object MappingBuilderFn {
 
   def build(d: MappingDefinitionLike): XContentBuilder = {
-    val builder = XContentFactory.jsonBuilder()
-    build(d, builder)
-    builder.endObject()
+    d.rawSource match {
+      //user raw source if provided, ignore other mapping settings
+      case Some(rs) => XContentFactory.parse(rs)
+      case None     =>
+        val builder = XContentFactory.jsonBuilder()
+        build(d, builder)
+        builder.endObject()
+    }
   }
 
   // returns the mapping json wrapped in the mapping type name, eg "mytype" : { mapping }
   def buildWithName(d: MappingDefinitionLike, tpe: String): XContentBuilder = {
-    val builder = XContentFactory.jsonBuilder
-    builder.startObject(tpe)
-    build(d, builder)
-    builder.endObject()
-    builder.endObject()
+    d.rawSource match {
+      //user raw source if provided, ignore other mapping settings
+      case Some(rs) =>
+        val builder = XContentFactory.jsonBuilder
+        builder.rawField(tpe, XContentFactory.parse(rs))
+        builder
+      case None     =>
+        val builder = XContentFactory.jsonBuilder
+        builder.startObject(tpe)
+        build(d, builder)
+        builder.endObject()
+        builder.endObject()
+    }
   }
 
   def build(d: MappingDefinitionLike, builder: XContentBuilder): Unit = {

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/MappingDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/MappingDefinition.scala
@@ -21,6 +21,7 @@ trait MappingDefinitionLike {
   def meta: Map[String, Any]
   def routing: Option[RoutingDefinition]
   def templates: Seq[DynamicTemplateDefinition]
+  def rawSource: Option[String]
 }
 
 case class PutMappingDefinition(indexesAndType: IndexesAndType,

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/CreateIndexContentBuilder.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/CreateIndexContentBuilder.scala
@@ -35,9 +35,7 @@ object CreateIndexContentBuilder {
       if (d.mappings.nonEmpty) {
         builder.startObject("mappings")
         for (mapping <- d.mappings) {
-          builder.startObject(mapping.`type`)
-          MappingBuilderFn.build(mapping, builder)
-          builder.endObject()
+          builder.rawField(mapping.`type`, MappingBuilderFn.build(mapping))
         }
         builder.endObject()
       }

--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/index/CreateIndexContentBuilder.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/index/CreateIndexContentBuilder.scala
@@ -34,9 +34,7 @@ object CreateIndexContentBuilder {
       if (d.mappings.nonEmpty) {
         builder.startObject("mappings")
         for (mapping <- d.mappings) {
-          builder.startObject(mapping.`type`)
-          MappingBuilderFn.build(mapping, builder)
-          builder.endObject()
+          builder.rawField(mapping.`type`, MappingBuilderFn.build(mapping))
         }
         builder.endObject()
       }

--- a/elastic4s-tests/src/test/resources/json/createindextemplate/createindextemplate_body.json
+++ b/elastic4s-tests/src/test/resources/json/createindextemplate/createindextemplate_body.json
@@ -1,0 +1,67 @@
+{
+    "index_patterns": [
+        "users"
+    ],
+    "mappings": {
+        "tweets": {
+            "_all": {
+                "enabled": false
+            },
+            "numeric_detection": true,
+            "_boost": {
+                "name": "myboost",
+                "null_value": 1.2
+            },
+            "_size": {
+                "enabled": true
+            },
+            "properties": {
+                "name": {
+                    "type": "geo_point"
+                },
+                "content": {
+                    "type": "date",
+                    "null_value": "no content"
+                }
+            },
+            "_meta": {
+                "class": "com.sksamuel.User"
+            }
+        },
+        "users": {
+            "_all": {
+                "enabled": true
+            },
+            "dynamic_date_formats": [
+                "mm/yyyy",
+                "dd-MM-yyyy"
+            ],
+            "date_detection": true,
+            "_analyzer": {
+                "path": "somefield"
+            },
+            "properties": {
+                "name": {
+                    "type": "ip",
+                    "boost": 1.0,
+                    "null_value": "127.0.0.1"
+                },
+                "location": {
+                    "type": "integer",
+                    "null_value": 0
+                },
+                "email": {
+                    "type": "binary"
+                },
+                "age": {
+                    "type": "float"
+                },
+                "area": {
+                    "type": "geo_shape",
+                    "tree": "quadtree",
+                    "precision": "1m"
+                }
+            }
+        }
+    }
+}

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/indexes/CreateIndexApiTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/indexes/CreateIndexApiTest.scala
@@ -31,6 +31,22 @@ class CreateIndexApiTest extends FlatSpec with MockitoSugar with JsonSugar with 
     CreateIndexContentBuilder(req).string() should matchJsonResource("/json/createindex/createindex_mappings.json")
   }
 
+
+  "the index dsl" should "allow provide mapping properties using rawSource" in {
+    val tweetRawSource = """{"_all": {"enabled": false},"numeric_detection": true,"_boost": {"name": "myboost","null_value": 1.2},"_size": {"enabled": true},"properties": {"name": {"type": "geo_point"},"content": {"type": "date","null_value": "no content"}},"_meta": {"class": "com.sksamuel.User"}}"""
+    val req = createIndex("users").mappings(
+      mapping("tweets").rawSource(tweetRawSource),
+      mapping("users").as(
+        ipField("name") nullValue "127.0.0.1" boost 1.0,
+        intField("location") nullValue 0,
+        binaryField("email"),
+        floatField("age"),
+        geoshapeField("area") tree PrefixTree.Quadtree precision "1m"
+      ) all true analyzer "somefield" dateDetection true dynamicDateFormats("mm/yyyy", "dd-MM-yyyy")
+    )
+    CreateIndexContentBuilder(req).string() should matchJsonResource("/json/createindex/createindex_mappings.json")
+  }
+
   it should "support override built in analyzers" in {
     val req = createIndex("users").analysis(
       StandardAnalyzerDefinition("standard", stopwords = Seq("stop1", "stop2")),

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/indexes/CreateIndexTemplateApiTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/indexes/CreateIndexTemplateApiTest.scala
@@ -1,0 +1,29 @@
+package com.sksamuel.elastic4s.indexes
+
+import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.JsonSugar
+import com.sksamuel.elastic4s.http.index.CreateIndexTemplateBodyFn
+import com.sksamuel.elastic4s.mappings.PrefixTree
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{FlatSpec, Matchers, OneInstancePerTest}
+
+class CreateIndexTemplateApiTest extends FlatSpec with MockitoSugar with JsonSugar with Matchers with OneInstancePerTest {
+
+
+  "the index template dsl" should "allow provide mapping properties using rawSource" in {
+    val tweetRawSource = """{"_all": {"enabled": false},"numeric_detection": true,"_boost": {"name": "myboost","null_value": 1.2},"_size": {"enabled": true},"properties": {"name": {"type": "geo_point"},"content": {"type": "date","null_value": "no content"}},"_meta": {"class": "com.sksamuel.User"}}"""
+    val req = createIndexTemplate("usersTemplate", "users").mappings(
+      mapping("tweets").rawSource(tweetRawSource),
+      mapping("users").as(
+        ipField("name") nullValue "127.0.0.1" boost 1.0,
+        intField("location") nullValue 0,
+        binaryField("email"),
+        floatField("age"),
+        geoshapeField("area") tree PrefixTree.Quadtree precision "1m"
+      ) all true analyzer "somefield" dateDetection true dynamicDateFormats("mm/yyyy", "dd-MM-yyyy")
+    )
+
+    CreateIndexTemplateBodyFn(req).string() should matchJsonResource("/json/createindextemplate/createindextemplate_body.json")
+  }
+
+}


### PR DESCRIPTION
This PR adds support for rawSource in MappingDefinitionLike. It is related to issue   #1112 and #1071