### PR TITLE
Fixed NullPointerException when accessing aggregationsAsMap 

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/responses.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/responses.scala
@@ -89,10 +89,11 @@ case class SearchResponse(took: Long,
                           private val suggest: Map[String, Seq[SuggestionResult]],
                           @JsonProperty("_shards") shards: Shards,
                           @JsonProperty("_scroll_id") scrollId: Option[String],
-                          @JsonProperty("aggregations") aggregationsAsMap: Map[String, Any],
+                          @JsonProperty("aggregations") private val _aggregationsAsMap: Map[String, Any],
                           hits: SearchHits
                          ) {
 
+  def aggregationsAsMap: Map[String, Any] = Option(_aggregationsAsMap).getOrElse(Map.empty)
   def totalHits: Long = hits.total
   def size: Long = hits.size
   def ids: Seq[String] = hits.hits.map(_.id)

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/aggs/AggregationAsStringTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/aggs/AggregationAsStringTest.scala
@@ -41,4 +41,18 @@ class AggregationAsStringTest extends FunSuite with DockerTests with Matchers {
     }.await.right.get.result.aggregationsAsString shouldBe
       """{"agg2":{"value":3869.0},"agg1":{"value":2456.0},"agg3":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"tower","doc_count":2},{"key":"burj","doc_count":1},{"key":"kalifa","doc_count":1},{"key":"london","doc_count":1},{"key":"of","doc_count":1},{"key":"willis","doc_count":1}]}}"""
   }
+
+  test("agg as string should return empty json when no aggregations are present") {
+    http.execute {
+      search("aggstring").matchAllQuery()
+    }.await.right.get.result.aggregationsAsString shouldBe "{}"
+  }
+
+
+  test("contains for not existent aggregation should return false") {
+    http.execute {
+      search("aggstring").matchAllQuery()
+    }.await.right.get.result.aggregations.contains("no_agg") shouldBe false
+  }
+
 }


### PR DESCRIPTION
This PR fixes NPE when accessing aggregationsAsMap in SearchResponse when no aggregation has been requested in search request. 