### PR TITLE
Change AvgAggResult, SumAggResult and ValueCountResult to have optional values

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggresponses.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggresponses.scala
@@ -265,11 +265,17 @@ object IpRangeAggResult {
     )
 }
 
-case class AvgAggResult(name: String, value: Double)         extends MetricAggregation
-case class SumAggResult(name: String, value: Double)         extends MetricAggregation
-case class MinAggResult(name: String, value: Option[Double]) extends MetricAggregation
-case class MaxAggResult(name: String, value: Option[Double]) extends MetricAggregation
-case class ValueCountResult(name: String, value: Double)     extends MetricAggregation
+case class AvgAggResult(name: String, valueOpt: Option[Double]) extends MetricAggregation {
+  def value: Double = valueOpt.get
+}
+case class SumAggResult(name: String, valueOpt: Option[Double]) extends MetricAggregation {
+  def value: Double = valueOpt.get
+}
+case class MinAggResult(name: String, value: Option[Double])        extends MetricAggregation
+case class MaxAggResult(name: String, value: Option[Double])        extends MetricAggregation
+case class ValueCountResult(name: String, valueOpt: Option[Double]) extends MetricAggregation {
+  def value: Double = valueOpt.get
+}
 
 case class GeoBoundsAggResult(name: String, topLeft: Option[GeoPoint], bottomRight: Option[GeoPoint])
     extends MetricAggregation
@@ -402,7 +408,7 @@ trait HasAggregations {
   def nested(name: String): NestedAggResult         = NestedAggResult(name, agg(name))
 
   // metric aggs
-  def avg(name: String): AvgAggResult = AvgAggResult(name, agg(name)("value").toString.toDouble)
+  def avg(name: String): AvgAggResult = AvgAggResult(name, Option(agg(name)("value")).map(_.toString.toDouble))
 
   def extendedStats(name: String): ExtendedStatsAggResult =
     ExtendedStatsAggResult(
@@ -418,7 +424,7 @@ trait HasAggregations {
     )
 
   def cardinality(name: String): CardinalityAggResult = CardinalityAggResult(name, agg(name)("value").toString.toDouble)
-  def sum(name: String): SumAggResult                 = SumAggResult(name, agg(name)("value").toString.toDouble)
+  def sum(name: String): SumAggResult                 = SumAggResult(name, Option(agg(name)("value")).map(_.toString.toDouble))
   def min(name: String): MinAggResult                 = MinAggResult(name, Option(agg(name)("value")).map(_.toString.toDouble))
   def max(name: String): MaxAggResult                 = MaxAggResult(name, Option(agg(name)("value")).map(_.toString.toDouble))
   def percentiles(name: String): PercentilesAggResult = {
@@ -448,7 +454,7 @@ trait HasAggregations {
   }
 
   def tophits(name: String): TopHitsResult       = TopHitsResult(name, agg(name))
-  def valueCount(name: String): ValueCountResult = ValueCountResult(name, agg(name)("value").toString.toDouble)
+  def valueCount(name: String): ValueCountResult = ValueCountResult(name, Option(agg(name)("value")).map(_.toString.toDouble))
 
   // pipeline aggs
   def avgBucket(name: String): AvgBucketAggResult = AvgBucketAggResult(name, agg(name)("value").toString.toDouble)


### PR DESCRIPTION
The new optional value is called `valueOpt` while `value` simply performs a `.get` on the option, possibly causing an exception to be raised

This is a proposed solution to issue #1244 