### PR TITLE
Fixed NoSuchElementException when getting mapping without properties

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/mappings/MappingExecutables.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/mappings/MappingExecutables.scala
@@ -21,7 +21,7 @@ trait MappingExecutables {
           case (index, types) =>
             val mappings = types("mappings").map {
               case (tpe, properties) =>
-                tpe -> properties("properties").asInstanceOf[Map[String, Any]]
+                tpe -> properties.get("properties").map(_.asInstanceOf[Map[String, Any]]).getOrElse(Map.empty)
             }
             IndexMappings(index, mappings)
         }.toSeq


### PR DESCRIPTION
Sometimes mapping doesn't have "properties". This PR fixes NoSuchElementException thrown when getting mapping without properties.