### PR TITLE
use DefaultAwsRegionProviderChain to select default aws region

### DIFF
--- a/elastic4s-aws/src/main/scala/com/sksamuel/elastic4s/aws/Aws4ElasticClient.scala
+++ b/elastic4s-aws/src/main/scala/com/sksamuel/elastic4s/aws/Aws4ElasticClient.scala
@@ -3,7 +3,7 @@ package com.sksamuel.elastic4s.aws
 import com.sksamuel.elastic4s.ElasticsearchClientUri
 import com.sksamuel.elastic4s.http.ElasticClient
 import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials, DefaultAWSCredentialsProviderChain}
-
+import com.amazonaws.regions.DefaultAwsRegionProviderChain
 import org.elasticsearch.client.RestClientBuilder.HttpClientConfigCallback
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder
 import org.apache.http.protocol.HttpContext
@@ -55,12 +55,12 @@ private class Aws4HttpRequestInterceptor(config: Aws4ElasticConfig) extends Http
 /**
   * Default Request Interceptor for convenience. Uses the default environment variable names.
   * See <a href="http://docs.aws.amazon.com/cli/latest/userguide/cli-environment.html">amazon environment variable documentation</a>
-  *
+  * See <a href="https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/java-dg-region-selection.html"> default region selection</a>
   */
 private class DefaultAws4HttpRequestInterceptor extends HttpRequestInterceptor {
   private val defaultChainProvider = new DefaultAWSCredentialsProviderChain
-  private val region               = sys.env("AWS_DEFAULT_REGION")
-  private val signer               = new Aws4RequestSigner(defaultChainProvider, region)
+  private val regionProvider       = new DefaultAwsRegionProviderChain
+  private val signer               = new Aws4RequestSigner(defaultChainProvider, regionProvider.getRegion)
 
   override def process(request: HttpRequest, context: HttpContext): Unit = signer.withAws4Headers(request)
 


### PR DESCRIPTION
Right now, the `elastic4s-aws` code checks the `AWS_DEFAULT_REGION` environment variable to find the default AWS region. This is only one of the techniques which the AWS SDK uses to determine the default region, and thus this code fails in scenarios where the AWS SDK can succeed (e.g. I have some code which uses the EC2 metadata service to find the region)

Use the `DefaultAwsRegionProviderChain` class from the AWS SDK to find the default region. This encapsulates the various default region-finding rules as described in the documentation: https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/java-dg-region-selection.html