### PR TITLE
Fix broken termsQuery when empty seq is passed

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/term/TermsQueryBodyFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/term/TermsQueryBodyFn.scala
@@ -8,11 +8,7 @@ object TermsQueryBodyFn {
 
     val builder = XContentFactory.jsonBuilder().startObject("terms")
 
-    if (t.values.nonEmpty) {
-      builder.startArray(t.field)
-      t.values.foreach(builder.autovalue)
-      builder.endArray()
-    } else {
+    if (t.ref.nonEmpty) {
       builder.startObject(t.field)
       t.ref.foreach { ref =>
         builder.field("index", ref.index)
@@ -22,6 +18,10 @@ object TermsQueryBodyFn {
       t.path.foreach(builder.field("path", _))
       t.routing.foreach(builder.field("routing", _))
       builder.endObject()
+    } else {
+      builder.startArray(t.field)
+      t.values.foreach(builder.autovalue)
+      builder.endArray()
     }
 
     t.boost.foreach(builder.field("boost", _))

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/TermsQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/TermsQueryTest.scala
@@ -54,5 +54,12 @@ class TermsQueryTest
     resp.hits.hits.map(_.sourceAsString).toSet shouldBe Set("""{"name":"nelson"}""", """{"name":"edmure"}""")
   }
 
+  it should "return no results when an empty array is passed" in {
+    val resp = client.execute {
+      search("lords") query termsQuery("name", Seq.empty[String])
+    }.await.result
+
+    resp.hits.hits.map(_.sourceAsString).toSet shouldBe Set.empty[String]
+  }
 
 }


### PR DESCRIPTION
Hi, termsQuery currently fails with an empty Seq. I have a dynamic termsQuery in my code, and sometimes it filters by "Seq()", that's how I found out.  This should fix it: it uses the ref lookup if specified otherwise fallbacks to normal terms instead of viceversa.

cheers