### PR TITLE
Fix deprecated "_version" & "_version_type" in bulk

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/bulk/BulkBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/bulk/BulkBuilderFn.scala
@@ -22,8 +22,8 @@ object BulkBuilderFn {
         index.id.foreach(id => builder.field("_id", id.toString))
         index.parent.foreach(builder.field("_parent", _))
         index.routing.foreach(builder.field("_routing", _))
-        index.version.foreach(builder.field("_version", _))
-        index.versionType.foreach(versionType ⇒ builder.field("_version_type", VersionTypeHttpString(versionType)))
+        index.version.foreach(builder.field("version", _))
+        index.versionType.foreach(versionType ⇒ builder.field("version_type", VersionTypeHttpString(versionType)))
         builder.endObject()
         builder.endObject()
 
@@ -51,8 +51,8 @@ object BulkBuilderFn {
         builder.field("_id", update.id)
         update.parent.foreach(builder.field("_parent", _))
         update.routing.foreach(builder.field("_routing", _))
-        update.version.foreach(builder.field("_version", _))
-        update.versionType.foreach(builder.field("_version_type", _))
+        update.version.foreach(builder.field("version", _))
+        update.versionType.foreach(builder.field("version_type", _))
         builder.endObject()
         builder.endObject()
 


### PR DESCRIPTION
Use "version" & "version_type" instead
Doc: https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html#bulk-versioning
Fix following warning:
```
WARNING: request [POST http://localhost:9200/_bulk?refresh=true] returned 2 warnings: [299 Elasticsearch-6.2.2-10b1edd "Deprecated field [_version] used, expected [version] instead" "Fri, 09 Mar 2018 09:02:05 GMT"],[299 Elasticsearch-6.2.2-10b1edd "Deprecated field [_version_type] used, expected [version_type] instead" "Fri, 09 Mar 2018 09:02:05 GMT"]
```