### PR TITLE
Fix AWS sign with unordered query param

### DIFF
--- a/elastic4s-aws/src/main/scala/com/sksamuel/elastic4s/aws/CanonicalRequest.scala
+++ b/elastic4s-aws/src/main/scala/com/sksamuel/elastic4s/aws/CanonicalRequest.scala
@@ -57,7 +57,7 @@ object CanonicalRequest {
   private def canonicalQueryString(httpRequest: HttpRequest): String = {
     val uri        = new URI(httpRequest.getRequestLine.getUri)
     val parameters = URLEncodedUtils.parse(uri, "utf-8")
-    parameters.asScala.map(h ⇒ s"${h.getName}=${h.getValue}").mkString("&")
+    parameters.asScala.sortBy(_.getName).map(h ⇒ s"${h.getName}=${h.getValue}").mkString("&")
   }
 
   private def canonicalHeaders(httpRequest: HttpRequest): String =

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/aws/CanonicalRequestTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/aws/CanonicalRequestTest.scala
@@ -44,6 +44,11 @@ class CanonicalRequestTest extends WordSpec with Matchers with SharedTestData{
       canonicalRequest.toString shouldBe(resultWithoutPayload)
     }
 
+    "be able to build a canonical request string from request with unordered query params" in {
+      val canonicalRequest = CanonicalRequest(httpGetRequestWithUnorderedQueryParams)
+      canonicalRequest.toString shouldBe(resultWithoutPayload)
+    }
+
     "be able to build a canonical request string from request with payload" in {
       val canonicalRequest = CanonicalRequest(httpPostRequest)
       canonicalRequest.toString shouldBe(resultWithPayload)

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/aws/SharedTestData.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/aws/SharedTestData.scala
@@ -36,6 +36,14 @@ trait SharedTestData {
     request
   }
 
+  def httpGetRequestWithUnorderedQueryParams = {
+    val request = new HttpGet("https://es.amazonaws.com/path/to/resource?Version=2010-05-08&Action=ListUsers")
+    request.addHeader("x-amz-date", dateTime)
+    request.addHeader("Host", host)
+    request.addHeader("content-type", "application/x-www-form-urlencoded; charset=utf-8")
+    request
+  }
+
   def httpPostRequest = {
     val entity = new BasicHttpEntity()
     entity.setContent(new ByteArrayInputStream("This is the content".getBytes(StandardCharsets.UTF_8.name())))


### PR DESCRIPTION
If the URL to sign hasn't the query params already ordered the AWS sign is not correct.
If I specify indices options the resulting URL hasn't the query param ordered.
The fix is to build the canonicalQueryString with ordered query params.

https://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html 
To construct the canonical query string, complete the following steps:
a) Sort the parameter names by character code point in ascending order. For example, a parameter name that begins with the uppercase letter F precedes a parameter name that begins with a lowercase letter b.

Related to #1326