### PR TITLE
Add support for custom AWS auth chain

### DIFF
--- a/elastic4s-aws/src/main/scala/com/sksamuel/elastic4s/aws/Aws4ElasticClient.scala
+++ b/elastic4s-aws/src/main/scala/com/sksamuel/elastic4s/aws/Aws4ElasticClient.scala
@@ -1,13 +1,13 @@
 package com.sksamuel.elastic4s.aws
 
+import com.amazonaws.auth.{AWSCredentialsProvider, AWSStaticCredentialsProvider, BasicAWSCredentials, DefaultAWSCredentialsProviderChain}
+import com.amazonaws.regions.DefaultAwsRegionProviderChain
 import com.sksamuel.elastic4s.ElasticsearchClientUri
 import com.sksamuel.elastic4s.http.HttpClient
-import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials, DefaultAWSCredentialsProviderChain}
-
-import org.elasticsearch.client.RestClientBuilder.HttpClientConfigCallback
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder
 import org.apache.http.protocol.HttpContext
 import org.apache.http.{HttpRequest, HttpRequestInterceptor}
+import org.elasticsearch.client.RestClientBuilder.HttpClientConfigCallback
 
 case class Aws4ElasticConfig(endpoint: String, key: String, secret: String, region: String, service: String = "es") {
   require(key.length > 16 && key.length < 128 && key.matches("[\\w]+"), "Key id must be between 16 and 128 characters.")
@@ -20,7 +20,7 @@ object Aws4ElasticClient {
     */
   def apply(config: Aws4ElasticConfig): HttpClient = {
     val elasticUri = ElasticsearchClientUri(config.endpoint)
-    HttpClient(elasticUri, httpClientConfigCallback = new SignedClientConfig(config))
+    HttpClient(elasticUri, httpClientConfigCallback = new SignedClient(new AWSStaticCredentialsProvider(new BasicAWSCredentials(config.key, config.secret)), config.region))
   }
 
   /**
@@ -29,38 +29,26 @@ object Aws4ElasticClient {
     */
   def apply(endpoint: String): HttpClient = {
     val elasticUri = ElasticsearchClientUri(endpoint)
-    HttpClient(elasticUri, httpClientConfigCallback = new DefaultSignedClientConfig)
+    HttpClient(elasticUri, httpClientConfigCallback = new SignedClient(new DefaultAWSCredentialsProviderChain, (new DefaultAwsRegionProviderChain).getRegion))
+  }
+
+  /**
+    * Creates ES HttpClient with custom AWS credential and region providers.
+    */
+  def apply(endpoint: String, credentialProvider: AWSCredentialsProvider, region: String): HttpClient = {
+    val elasticUri = ElasticsearchClientUri(endpoint)
+    HttpClient(elasticUri, httpClientConfigCallback = new SignedClient(credentialProvider, region))
   }
 
 }
 
-private class SignedClientConfig(config: Aws4ElasticConfig) extends HttpClientConfigCallback {
+private class SignedClient(chainProvider: AWSCredentialsProvider, region: String) extends HttpClientConfigCallback {
   override def customizeHttpClient(httpClientBuilder: HttpAsyncClientBuilder): HttpAsyncClientBuilder =
-    httpClientBuilder.addInterceptorLast(new Aws4HttpRequestInterceptor(config))
+    httpClientBuilder.addInterceptorLast(new Aws4HttpRequestInterceptor(chainProvider, region))
 }
 
-private class DefaultSignedClientConfig extends HttpClientConfigCallback {
-  override def customizeHttpClient(httpClientBuilder: HttpAsyncClientBuilder): HttpAsyncClientBuilder =
-    httpClientBuilder.addInterceptorLast(new DefaultAws4HttpRequestInterceptor)
-}
-
-private class Aws4HttpRequestInterceptor(config: Aws4ElasticConfig) extends HttpRequestInterceptor {
-  private val chainProvider = new AWSStaticCredentialsProvider(new BasicAWSCredentials(config.key, config.secret))
-  private val signer        = new Aws4RequestSigner(chainProvider, config.region, config.service)
-
-  override def process(request: HttpRequest, context: HttpContext): Unit = signer.withAws4Headers(request)
-
-}
-
-/**
-  * Default Request Interceptor for convenience. Uses the default environment variable names.
-  * See <a href="http://docs.aws.amazon.com/cli/latest/userguide/cli-environment.html">amazon environment variable documentation</a>
-  *
-  */
-private class DefaultAws4HttpRequestInterceptor extends HttpRequestInterceptor {
-  private val defaultChainProvider = new DefaultAWSCredentialsProviderChain
-  private val region               = sys.env("AWS_DEFAULT_REGION")
-  private val signer               = new Aws4RequestSigner(defaultChainProvider, region)
+private class Aws4HttpRequestInterceptor(credentialProvider: AWSCredentialsProvider, region: String) extends HttpRequestInterceptor {
+  private val signer = new Aws4RequestSigner(credentialProvider, region)
 
   override def process(request: HttpRequest, context: HttpContext): Unit = signer.withAws4Headers(request)
 

--- a/elastic4s-aws/src/main/scala/com/sksamuel/elastic4s/aws/Aws4ElasticClient.scala
+++ b/elastic4s-aws/src/main/scala/com/sksamuel/elastic4s/aws/Aws4ElasticClient.scala
@@ -1,55 +1,23 @@
 package com.sksamuel.elastic4s.aws
 
-import com.amazonaws.auth.{AWSCredentialsProvider, AWSStaticCredentialsProvider, BasicAWSCredentials, DefaultAWSCredentialsProviderChain}
+import com.amazonaws.auth.{AWSCredentialsProvider, DefaultAWSCredentialsProviderChain}
 import com.amazonaws.regions.DefaultAwsRegionProviderChain
 import com.sksamuel.elastic4s.ElasticsearchClientUri
-import com.sksamuel.elastic4s.http.HttpClient
-import org.apache.http.impl.nio.client.HttpAsyncClientBuilder
-import org.apache.http.protocol.HttpContext
-import org.apache.http.{HttpRequest, HttpRequestInterceptor}
-import org.elasticsearch.client.RestClientBuilder.HttpClientConfigCallback
-
-case class Aws4ElasticConfig(endpoint: String, key: String, secret: String, region: String, service: String = "es") {
-  require(key.length > 16 && key.length < 128 && key.matches("[\\w]+"), "Key id must be between 16 and 128 characters.")
-}
+import com.sksamuel.elastic4s.http.{HttpClient, NoOpRequestConfigCallback}
+import org.elasticsearch.client.RestClientBuilder.RequestConfigCallback
 
 object Aws4ElasticClient {
 
   /**
-    * Creates ES HttpClient with aws4 request signer interceptor using custom config (key, secret, region and service).
-    */
-  def apply(config: Aws4ElasticConfig): HttpClient = {
-    val elasticUri = ElasticsearchClientUri(config.endpoint)
-    HttpClient(elasticUri, httpClientConfigCallback = new SignedClient(new AWSStaticCredentialsProvider(new BasicAWSCredentials(config.key, config.secret)), config.region))
-  }
-
-  /**
-    * Convenience method to create ES HttpClient with aws4 request signer interceptor using default aws environment variables.
-    * See <a href="http://docs.aws.amazon.com/cli/latest/userguide/cli-environment.html">amazon environment variables documentation</a>
-    */
-  def apply(endpoint: String): HttpClient = {
-    val elasticUri = ElasticsearchClientUri(endpoint)
-    HttpClient(elasticUri, httpClientConfigCallback = new SignedClient(new DefaultAWSCredentialsProviderChain, (new DefaultAwsRegionProviderChain).getRegion))
-  }
-
-  /**
     * Creates ES HttpClient with custom AWS credential and region providers.
     */
-  def apply(endpoint: String, credentialProvider: AWSCredentialsProvider, region: String): HttpClient = {
-    val elasticUri = ElasticsearchClientUri(endpoint)
-    HttpClient(elasticUri, httpClientConfigCallback = new SignedClient(credentialProvider, region))
+  def apply(uri: ElasticsearchClientUri, credentialProvider: AWSCredentialsProvider = new DefaultAWSCredentialsProviderChain, region: String = (new DefaultAwsRegionProviderChain).getRegion, requestConfigCallback: RequestConfigCallback = NoOpRequestConfigCallback): HttpClient = {
+    HttpClient(
+      uri,
+      requestConfigCallback = requestConfigCallback,
+      httpClientConfigCallback = new AwsHttpClientConfigCallback(credentialProvider, region)
+    )
   }
 
 }
 
-private class SignedClient(chainProvider: AWSCredentialsProvider, region: String) extends HttpClientConfigCallback {
-  override def customizeHttpClient(httpClientBuilder: HttpAsyncClientBuilder): HttpAsyncClientBuilder =
-    httpClientBuilder.addInterceptorLast(new Aws4HttpRequestInterceptor(chainProvider, region))
-}
-
-private class Aws4HttpRequestInterceptor(credentialProvider: AWSCredentialsProvider, region: String) extends HttpRequestInterceptor {
-  private val signer = new Aws4RequestSigner(credentialProvider, region)
-
-  override def process(request: HttpRequest, context: HttpContext): Unit = signer.withAws4Headers(request)
-
-}

--- a/elastic4s-aws/src/main/scala/com/sksamuel/elastic4s/aws/Aws4RequestSigner.scala
+++ b/elastic4s-aws/src/main/scala/com/sksamuel/elastic4s/aws/Aws4RequestSigner.scala
@@ -18,8 +18,8 @@ import org.apache.http.{Header, HttpRequest}
 class Aws4RequestSigner(provider: AWSCredentialsProvider, region: String, service: String = "es") {
   require(provider.getCredentials != null, "AWS Credentials are mandatory. AWSCredentialsProvider provided none.")
 
-  val dateHeader          = "X-Amz-Date"
-  val authHeader          = "Authorization"
+  val dateHeader = "X-Amz-Date"
+  val authHeader = "Authorization"
   val securityTokenHeader = "X-Amz-Security-Token"
 
   def withAws4Headers(request: HttpRequest): HttpRequest = {
@@ -34,7 +34,7 @@ class Aws4RequestSigner(provider: AWSCredentialsProvider, region: String, servic
     request.setHeader(dateHeader, dateTime)
 
     val canonicalRequest = CanonicalRequest(request)
-    val stringToSign     = StringToSign(service, region, canonicalRequest, date, dateTime)
+    val stringToSign = StringToSign(service, region, canonicalRequest, date, dateTime)
 
     val authHeaderValue = buildAuthenticationHeader(canonicalRequest, stringToSign, credentials)
     request.addHeader(authHeader, authHeaderValue)
@@ -42,7 +42,7 @@ class Aws4RequestSigner(provider: AWSCredentialsProvider, region: String, servic
     /* If the credentials are temporary (session credentials), add an additional security header */
     credentials match {
       case c: AWSSessionCredentials ⇒ request.addHeader(securityTokenHeader, c.getSessionToken)
-      case _                        ⇒
+      case _ ⇒
     }
 
     request
@@ -50,31 +50,31 @@ class Aws4RequestSigner(provider: AWSCredentialsProvider, region: String, servic
 
   /* Build date and dateTime in a protected method so it is possible to override it in tests */
   protected def buildDateAndDateTime(): (String, String) = {
-    val now      = ZonedDateTime.now(ZoneOffset.UTC)
+    val now = ZonedDateTime.now(ZoneOffset.UTC)
     val dateTime = now.format(DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'"))
-    val date     = now.format(DateTimeFormatter.ofPattern("yyyyMMdd"))
+    val date = now.format(DateTimeFormatter.ofPattern("yyyyMMdd"))
     (date, dateTime)
   }
 
   private def buildAuthenticationHeader(canonicalRequest: CanonicalRequest,
                                         stringToSign: StringToSign,
                                         credentials: AWSCredentials) = {
-    val credentialStr    = s"Credential=${credentials.getAWSAccessKeyId}/${stringToSign.credentialsScope}"
+    val credentialStr = s"Credential=${credentials.getAWSAccessKeyId}/${stringToSign.credentialsScope}"
     val signedHeadersStr = s"SignedHeaders=${canonicalRequest.signedHeaders}"
-    val signatureStr     = s"Signature=${buildSignature(stringToSign, credentials)}"
+    val signatureStr = s"Signature=${buildSignature(stringToSign, credentials)}"
     s"${Crypto.Algorithm} $credentialStr, $signedHeadersStr, $signatureStr"
   }
 
   private def buildSignature(stringToSign: StringToSign, credentials: AWSCredentials) = {
     val signatureKey = buildKeyToSign(stringToSign.date, credentials)
-    val signature    = sign(stringToSign.toString, signatureKey)
+    val signature = sign(stringToSign.toString, signatureKey)
     hexOf(signature).toLowerCase
   }
 
   private def buildKeyToSign(dateStr: String, credentials: AWSCredentials): Array[Byte] = {
-    val kSecret    = ("AWS4" + credentials.getAWSSecretKey).getBytes("utf-8")
-    val dateKey    = sign(dateStr, kSecret)
-    val regionKey  = sign(region, dateKey)
+    val kSecret = ("AWS4" + credentials.getAWSSecretKey).getBytes("utf-8")
+    val dateKey = sign(dateStr, kSecret)
+    val regionKey = sign(region, dateKey)
     val serviceKey = sign(service, regionKey)
     sign("aws4_request", serviceKey)
   }
@@ -88,7 +88,7 @@ class Aws4RequestSigner(provider: AWSCredentialsProvider, region: String, servic
   private def setHeader(h: String, f: Header => String)(request: HttpRequest): HttpRequest = {
     request.getAllHeaders.find(_.getName == h) match {
       case Some(header) ⇒ request.setHeader(h, f(header))
-      case _            ⇒
+      case _ ⇒
     }
     request
   }

--- a/elastic4s-aws/src/main/scala/com/sksamuel/elastic4s/aws/AwsHttpClientConfigCallback.scala
+++ b/elastic4s-aws/src/main/scala/com/sksamuel/elastic4s/aws/AwsHttpClientConfigCallback.scala
@@ -1,0 +1,19 @@
+package com.sksamuel.elastic4s.aws
+
+import com.amazonaws.auth.AWSCredentialsProvider
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder
+import org.apache.http.protocol.HttpContext
+import org.apache.http.{HttpRequest, HttpRequestInterceptor}
+import org.elasticsearch.client.RestClientBuilder.HttpClientConfigCallback
+
+class AwsHttpClientConfigCallback(chainProvider: AWSCredentialsProvider, region: String) extends HttpClientConfigCallback {
+  override def customizeHttpClient(httpClientBuilder: HttpAsyncClientBuilder): HttpAsyncClientBuilder =
+    httpClientBuilder.addInterceptorLast(new Aws4HttpRequestInterceptor(chainProvider, region))
+}
+
+private class Aws4HttpRequestInterceptor(credentialProvider: AWSCredentialsProvider, region: String) extends HttpRequestInterceptor {
+  private val signer = new Aws4RequestSigner(credentialProvider, region)
+
+  override def process(request: HttpRequest, context: HttpContext): Unit = signer.withAws4Headers(request)
+
+}


### PR DESCRIPTION
At the moment it's not possible to sign requests to ElasticSearch with a custom auth chain.
The only allowed ways are:
* with static access_key/secret_key
* with the default AWS auth chain

In some cases it could be usefull set the auth chain: for example if I need to assume a role to access ElasticSearch (`new STSAssumeRoleSessionCredentialsProvider.Builder(myrole,mysessionanme).build` instead of using the user permission). 
This scenario is common when someone need to access a cluster that is in a different AWS account of the user/role that wants to access it.

