### PR TITLE
Fix join mapping type

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/CommonFieldBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/CommonFieldBuilder.scala
@@ -99,7 +99,7 @@ object FieldBuilderFn {
         builder.startObject("relations")
         join.relations.foreach {
           case (parent, child) =>
-            builder.field(parent, child)
+            builder.autofield(parent, child)
         }
         builder.endObject()
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/JoinField.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/JoinField.scala
@@ -28,6 +28,8 @@ case class JoinField(name: String,
   def dynamic(dynamic: String): T               = copy(dynamic = dynamic.some)
   def dynamic(dynamic: Boolean): T              = copy(dynamic = dynamic.toString.some)
 
+  def relation(parent: String, child: String): T = copy(relations = relations + (parent -> child))
+  def relation(parent: String, children: Seq[String]): T = copy(relations = relations + (parent -> children))
   def relations(map: Map[String, Any]): T = copy(relations = map)
 
   override def analyzer(analyzer: String): T       = copy(analysis = analysis.copy(analyzer = analyzer.some))

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/JoinField.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/JoinField.scala
@@ -21,7 +21,7 @@ case class JoinField(name: String,
     extends FieldDefinition {
 
   type T = JoinField
-  override def `type` = "object"
+  override def `type` = "join"
 
   override def boost(boost: Double): T          = copy(boost = boost.some)
   override def docValues(docValues: Boolean): T = copy(docValues = docValues.some)

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/JoinField.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/JoinField.scala
@@ -17,7 +17,7 @@ case class JoinField(name: String,
                      nulls: Nulls = Nulls(),
                      store: Option[Boolean] = None,
                      termVector: Option[String] = None,
-                     relations: Map[String, String] = Map.empty)
+                     relations: Map[String, Any] = Map.empty)
     extends FieldDefinition {
 
   type T = JoinField
@@ -28,7 +28,7 @@ case class JoinField(name: String,
   def dynamic(dynamic: String): T               = copy(dynamic = dynamic.some)
   def dynamic(dynamic: Boolean): T              = copy(dynamic = dynamic.toString.some)
 
-  def relations(map: Map[String, String]): T = copy(relations = map)
+  def relations(map: Map[String, Any]): T = copy(relations = map)
 
   override def analyzer(analyzer: String): T       = copy(analysis = analysis.copy(analyzer = analyzer.some))
   override def normalizer(normalizer: String): T   = copy(analysis = analysis.copy(normalizer = normalizer.some))

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/mappings/MappingHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/mappings/MappingHttpTest.scala
@@ -23,7 +23,9 @@ class MappingHttpTest extends WordSpec with DockerTests with Matchers {
     createIndex("index").mappings(
       mapping("mapping1") as Seq(
         textField("a") stored true analyzer WhitespaceAnalyzer,
-        keywordField("b") normalizer "my_normalizer"
+        keywordField("b") normalizer "my_normalizer",
+        joinField("c") relation ("parent", Seq("bar", "foo"))
+
       )
     ) analysis {
       CustomAnalyzerDefinition("my_analyzer", WhitespaceTokenizer, LowercaseTokenFilter)
@@ -55,6 +57,10 @@ class MappingHttpTest extends WordSpec with DockerTests with Matchers {
       val b = properties("b").asInstanceOf[Map[String, Any]]
       b("type") shouldBe "keyword"
       b("normalizer") shouldBe "my_normalizer"
+
+      val c = properties("c").asInstanceOf[Map[String, Any]]
+      c("type") shouldBe "join"
+      c("relations") shouldEqual Map("parent" -> Seq("bar", "foo"))
     }
 
     "handle properly mapping without properties" in {


### PR DESCRIPTION
This PR includes a fix for https://github.com/sksamuel/elastic4s/pull/1191, and adds support for more than one child per parent.

According to [the docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/parent-join.html), the mapping type should be `join` rather than `object`, and although a mapping may have only one type, the docs say:

> An element can have multiple children but only one parent.

For example:

```
~ $ curl -X PUT http://localhost:9200/my_index -H 'Content-Type: application/json' \
    -d '{"mappings":{"_doc":{"properties":{"type":{"type":"join","relations":{"parent":["child1","child2"]}}}}}}'
{"acknowledged":true,"shards_acknowledged":true,"index":"my_index"}
```

```
~ $ curl -s http://localhost:9200/my_index | jq                                                                                                                                                 
{
  "my_index": {
    "aliases": {},
    "mappings": {
      "_doc": {
        "properties": {
          "type": {
            "type": "join",
            "eager_global_ordinals": true,
            "relations": {
              "parent": [
                "child2",
                "child1"
              ]
            }
          }
        }
      }
    },
    "settings": {
      "index": {
        "creation_date": "1523059422053",
        "number_of_shards": "5",
        "number_of_replicas": "1",
        "uuid": "WgZ4-v2uRk687w6RY4lGTQ",
        "version": {
          "created": "6020399"
        },
        "provided_name": "my_index"
      }
    }
  }
}
```