### PR TITLE
Port [#1294] Respect IndexRequest.createOnly when used inside bulk through HTTP to 6.2.x branch

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/bulk/BulkBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/bulk/BulkBuilderFn.scala
@@ -15,7 +15,8 @@ object BulkBuilderFn {
     bulk.requests.foreach {
       case index: IndexDefinition =>
         val builder = XContentFactory.jsonBuilder()
-        builder.startObject("index")
+        val createOrIndex = if(index.createOnly.getOrElse(false)) "create" else "index"
+        builder.startObject(createOrIndex)
         builder.field("_index", index.indexAndType.index)
         builder.field("_type", index.indexAndType.`type`)
         index.id.foreach(id => builder.field("_id", id.toString))

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/bulk/domain.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/bulk/domain.scala
@@ -20,7 +20,8 @@ case class BulkError(`type`: String, reason: String, index_uuid: String, shard: 
 
 case class BulkResponseItems(index: Option[BulkResponseItem],
                              delete: Option[BulkResponseItem],
-                             update: Option[BulkResponseItem])
+                             update: Option[BulkResponseItem],
+                             create: Option[BulkResponseItem])
 
 case class BulkResponse(took: Long,
                         errors: Boolean,
@@ -29,7 +30,7 @@ case class BulkResponse(took: Long,
   def items: Seq[BulkResponseItem] =
     _items
       .flatMap { item =>
-        item.index.orElse(item.update).orElse(item.delete)
+        item.index.orElse(item.update).orElse(item.delete).orElse(item.create)
       }
       .zipWithIndex
       .map {

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/bulk/BulkBuilderFnTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/bulk/BulkBuilderFnTest.scala
@@ -25,4 +25,18 @@ class BulkBuilderFnTest extends FunSuite with Matchers {
         |{"delete":{"_index":"chemistry","_type":"elements","_id":"10"}}""".stripMargin
 
   }
+
+  test("bulk content builder should respect createOnly in IndexRequest") {
+    val req = bulk(
+      indexInto("chemistry/elements").fields("atomicweight" -> 8, "name" -> "oxygen").withId("8"),
+      indexInto("chemistry/elements").fields("atomicweight" -> 1, "name" -> "hydrogen").withId("1").createOnly(true)
+    ).refresh(RefreshPolicy.Immediate)
+
+    BulkBuilderFn(req).mkString("\n") shouldBe
+      """{"index":{"_index":"chemistry","_type":"elements","_id":"8"}}
+        |{"atomicweight":8,"name":"oxygen"}
+        |{"create":{"_index":"chemistry","_type":"elements","_id":"1"}}
+        |{"atomicweight":1,"name":"hydrogen"}""".stripMargin
+
+  }
 }

--- a/elastic4s-testkit/src/main/scala/com/sksamuel/elastic4s/testkit/ResponseConverter.scala
+++ b/elastic4s-testkit/src/main/scala/com/sksamuel/elastic4s/testkit/ResponseConverter.scala
@@ -96,6 +96,7 @@ object ResponseConverterImplicits {
             None
           ).some,
           None,
+          None,
           None
         )
       }


### PR DESCRIPTION
Looks like I missed `release/6.2.x` branch last time when doing https://github.com/sksamuel/elastic4s/pull/1294, now when trying to use 6.2.6 I got hit by that problem again.

Should I also create PR to 6.1.x ? Or is there any better way how to handle that?