### PR TITLE
Add support for composite aggregations to 6.2.x #1376

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/aggs/CompositeAggregationDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/aggs/CompositeAggregationDefinition.scala
@@ -1,0 +1,49 @@
+package com.sksamuel.elastic4s.searches.aggs
+
+import com.sksamuel.elastic4s.script.ScriptDefinition
+import com.sksamuel.exts.OptionImplicits._
+
+sealed abstract class ValueSource(val valueSourceType: String, val name: String,
+                                  val field: Option[String],
+                                  val script: Option[ScriptDefinition],
+                                  val order: Option[String])
+
+case class TermsValueSource(override val name: String,
+                            override val field: Option[String] = None,
+                            override val script: Option[ScriptDefinition] = None,
+                            override val order: Option[String] = None)
+  extends ValueSource("terms", name, field, script, order)
+
+case class HistogramValueSource(override val name: String,
+                                interval: Int,
+                                override val field: Option[String] = None,
+                                override val script: Option[ScriptDefinition] = None,
+                                override val order: Option[String] = None)
+  extends ValueSource("histogram", name, field, script, order)
+
+case class DateHistogramValueSource(override val name: String,
+                                    interval: String,
+                                    override val field: Option[String] = None,
+                                    override val script: Option[ScriptDefinition] = None,
+                                    override val order: Option[String] = None,
+                                    timeZone: Option[String] = None)
+  extends ValueSource("date_histogram", name, field, script, order)
+
+
+case class CompositeAggregationDefinition(name: String,
+                                          sources: Seq[ValueSource] = Nil,
+                                          size: Option[Int] = None,
+                                          subaggs: Seq[AbstractAggregation] = Nil,
+                                          metadata: Map[String, AnyRef] = Map.empty)
+  extends AggregationDefinition {
+
+  type T = CompositeAggregationDefinition
+
+  def sources(sources: Seq[ValueSource]): CompositeAggregationDefinition = copy(sources = sources)
+
+  def size(size: Int): CompositeAggregationDefinition = copy(size = size.some)
+
+  override def subAggregations(aggs: Iterable[AbstractAggregation]): T = copy(subaggs = aggs.toSeq)
+
+  override def metadata(map: Map[String, AnyRef]): T = copy(metadata = map)
+}

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/AggregationBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/AggregationBuilderFn.scala
@@ -13,6 +13,7 @@ object AggregationBuilderFn {
       case agg: AvgAggregationDefinition           => AvgAggregationBuilder(agg)
       case agg: CardinalityAggregationDefinition   => CardinalityAggregationBuilder(agg)
       case agg: ChildrenAggregationDefinition      => ChildrenAggregationBuilder(agg)
+      case agg: CompositeAggregationDefinition     => CompositeAggregationBuilder(agg)
       case agg: DateHistogramAggregation           => DateHistogramAggregationBuilder(agg)
       case agg: ExtendedStatsAggregationDefinition => ExtendedStatsAggregationBuilder(agg)
       case agg: FilterAggregationDefinition        => FilterAggregationBuilder(agg)

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/CompositeAggregationBuilder.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/CompositeAggregationBuilder.scala
@@ -1,0 +1,41 @@
+package com.sksamuel.elastic4s.http.search.aggs
+
+import com.sksamuel.elastic4s.http.ScriptBuilderFn
+import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
+import com.sksamuel.elastic4s.searches.aggs._
+
+object CompositeAggregationBuilder {
+
+  def apply(agg: CompositeAggregationDefinition): XContentBuilder = {
+    val builder = XContentFactory.jsonBuilder().startObject("composite")
+
+    agg.size.foreach(builder.field("size", _))
+    builder.startArray("sources")
+    agg.sources.foreach(s => {
+      builder.startObject()
+      builder.startObject(s.name)
+      builder.startObject(s.valueSourceType)
+      s.field.foreach(builder.field("field", _))
+      s.script.foreach(s => builder.rawField("script", ScriptBuilderFn(s)))
+      s.order.foreach(builder.field("order", _))
+      s match {
+        case HistogramValueSource(_, interval, _, _, _) => builder.field("interval", interval)
+        case DateHistogramValueSource(_, interval, _, _, _, timeZone) => {
+          builder.field("interval", interval)
+          timeZone.foreach(builder.field("time_zone", _))
+        }
+        case _ =>
+      }
+      builder.endObject()
+      builder.endObject()
+      builder.endObject()
+    })
+    builder.endArray()
+    builder.endObject()
+
+    SubAggsBuilderFn(agg, builder)
+
+    builder
+  }
+
+}

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/aggs/CompositeAggregationBuilderTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/aggs/CompositeAggregationBuilderTest.scala
@@ -1,0 +1,61 @@
+package com.sksamuel.elastic4s.http.search.aggs
+
+import com.sksamuel.elastic4s.http.search.SearchBodyBuilderFn
+import com.sksamuel.elastic4s.script.ScriptDefinition
+import com.sksamuel.elastic4s.searches.SearchDefinition
+import com.sksamuel.elastic4s.searches.aggs.{CompositeAggregationDefinition, DateHistogramValueSource, HistogramValueSource, TermsValueSource}
+import org.scalatest.{FunSuite, Matchers}
+
+class CompositeAggregationBuilderTest extends FunSuite with Matchers {
+
+  import com.sksamuel.elastic4s.http.ElasticDsl._
+
+  test("CompositeAggregationBuilder should build simple terms-valued composites") {
+    val search = SearchDefinition("myindex" / "mytype").aggs(
+      CompositeAggregationDefinition("comp", sources = Seq(
+        TermsValueSource("s1", field = Some("f1")))
+      )
+    )
+
+    SearchBodyBuilderFn(search).string() shouldBe
+      """{"version":true,"aggs":{"comp":{"composite":{"sources":[{"s1":{"terms":{"field":"f1"}}}]}}}}"""
+  }
+
+  test("CompositeAggregationBuilder should terms-valued composites with multiple terms") {
+    val search = SearchDefinition("myindex" / "mytype").aggs(
+      CompositeAggregationDefinition("comp", sources = Seq(
+        TermsValueSource("s1", field = Some("f1")),
+        TermsValueSource("s2", field = Some("f2"))
+      ))
+    )
+
+    SearchBodyBuilderFn(search).string() shouldBe
+      """{"version":true,"aggs":{"comp":{"composite":{"sources":[{"s1":{"terms":{"field":"f1"}}},{"s2":{"terms":{"field":"f2"}}}]}}}}"""
+  }
+
+  test("CompositeAggregationBuilder should build script-valued composites") {
+    val search = SearchDefinition("myindex" / "mytype").aggs(
+      CompositeAggregationDefinition("comp", sources = Seq(
+        TermsValueSource("s1", script = Some(ScriptDefinition("doc['product'].value"))))
+      )
+    )
+
+    SearchBodyBuilderFn(search).string() shouldBe
+      """{"version":true,"aggs":{"comp":{"composite":{"sources":[{"s1":{"terms":{"script":{"source":"doc['product'].value"}}}}]}}}}"""
+  }
+
+  test("CompositeAggregationBuilder should respect all possible value types and attributes") {
+    val search = SearchDefinition("myindex" / "mytype").aggs(
+      CompositeAggregationDefinition("comp", sources = Seq(
+        TermsValueSource("s1", field = Some("f1"), order = Some("desc")),
+        HistogramValueSource("s2", 5, field = Some("f2"), order = Some("desc")),
+        DateHistogramValueSource("s3", "5d", field = Some("f3"), order = Some("desc"), timeZone = Some("+01:00"))
+      ))
+    )
+
+    SearchBodyBuilderFn(search).string() shouldBe
+      """{"version":true,"aggs":{"comp":{"composite":{"sources":[{"s1":{"terms":{"field":"f1","order":"desc"}}},{"s2":{"histogram":{"field":"f2","order":"desc","interval":5}}},{"s3":{"date_histogram":{"field":"f3","order":"desc","interval":"5d","time_zone":"+01:00"}}}]}}}}"""
+
+  }
+
+}


### PR DESCRIPTION
Composite aggregations are multi-bucket aggregations that create one
bucket for potentially every combination in the cross-product of values
from one or more fields. This commit introduces DSL elements to express
composite aggregations such as the following:

SearchDefinition("myindex" / "mytype").aggs(
  CompositeAggregationDefinition("comp", sources = Seq(
    TermsValueSource("s1", field = Some("f1"), order = Some("desc")),
    HistogramValueSource("s2", 5, field = Some("f2")),
    DateHistogramValueSource("s3", "5d", field = Some("f3"),
                             timeZone = Some("utc"))
  )))