### PR TITLE
fix: correctly add bounding box options

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/geo/GeoBoundingBoxQueryBodyFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/geo/GeoBoundingBoxQueryBodyFn.scala
@@ -8,6 +8,12 @@ object GeoBoundingBoxQueryBodyFn {
 
   def apply(q: GeoBoundingBoxQuery): XContentBuilder = {
     val builder = XContentFactory.jsonBuilder().startObject("geo_bounding_box")
+
+    q.geoExecType.map(EnumConversions.geoExecType).foreach(builder.field("type", _))
+    q.ignoreUnmapped.foreach(builder.field("ignore_unmapped", _))
+    q.validationMethod.map(EnumConversions.geoValidationMethod).foreach(builder.field("validation_method", _))
+    q.queryName.foreach(builder.field("_name", _))
+
     builder.startObject(q.field)
 
     q.corners.foreach { corners =>
@@ -27,11 +33,6 @@ object GeoBoundingBoxQueryBodyFn {
         builder.field("bottom_right", bottomright)
         builder.endObject()
     }
-
-    q.geoExecType.map(EnumConversions.geoExecType).foreach(builder.field("type", _))
-    q.ignoreUnmapped.foreach(builder.field("ignore_unmapped", _))
-    q.validationMethod.map(EnumConversions.geoValidationMethod).foreach(builder.field("validation_method", _))
-    q.queryName.foreach(builder.field("_name", _))
 
     builder.endObject().endObject().endObject()
   }

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/geo/GeoBoundingBoxQueryBodyFnTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/geo/GeoBoundingBoxQueryBodyFnTest.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.elastic4s.http.search.queries.geo
 
 import com.sksamuel.elastic4s.searches.GeoPoint
-import com.sksamuel.elastic4s.searches.queries.geo.{Corners, GeoBoundingBoxQuery}
+import com.sksamuel.elastic4s.searches.queries.geo.{Corners, GeoBoundingBoxQuery, GeoExecType}
 import org.scalatest.{FunSuite, GivenWhenThen, Matchers}
 
 class GeoBoundingBoxQueryBodyFnTest extends FunSuite with Matchers with GivenWhenThen {
@@ -54,6 +54,39 @@ class GeoBoundingBoxQueryBodyFnTest extends FunSuite with Matchers with GivenWhe
 
     Then("Should have right field and all corners specified")
     queryBody.string() shouldEqual buildBasicGeoBoxQuery()
+  }
+
+  test("Should correctly handle `type`") {
+    Given("some geo bouding box query with type specified")
+    val geoQuery = GeoBoundingBoxQuery("locationField")
+      .withCorners(
+        top = 1.1,
+        bottom = 3.3,
+        left = 2.2,
+        right = 4.4
+      ).withType(GeoExecType.Memory)
+
+    When("Geo bounding box query is built")
+    val queryBody = GeoBoundingBoxQueryBodyFn(geoQuery)
+
+    Then("Should have right field and all corners specified")
+    queryBody.string() shouldEqual """
+                                     |{
+                                     |  "geo_bounding_box": {
+                                     |    "type": "memory",
+                                     |    "locationField": {
+                                     |      "top_left": {
+                                     |        "lat": 1.1,
+                                     |        "lon": 2.2
+                                     |      },
+                                     |      "bottom_right": {
+                                     |        "lat": 3.3,
+                                     |        "lon": 4.4
+                                     |      }
+                                     |    }
+                                     |  }
+                                     |}
+                                   """.stripMargin.replaceAllLiterally(" ", "").replace("\n", "")
   }
 
   def buildBasicGeoBoxQuery() =

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/HitReaderTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/HitReaderTest.scala
@@ -8,7 +8,7 @@ import com.sksamuel.exts.OptionImplicits._
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FlatSpec, Matchers}
 
-import scala.util.Try
+import scala.util.{Success, Try}
 
 class HitReaderTest extends FlatSpec with MockitoSugar with DockerTests with Matchers {
 
@@ -72,8 +72,8 @@ class HitReaderTest extends FlatSpec with MockitoSugar with DockerTests with Mat
     }.await.result.safeTo[Team]
 
     teams.toSet shouldBe Set(
-      Right(Team("Arsenal", "The Library", 1886)),
-      Right(Team("Middlesbrough", "Fortress Riverside", 1876))
+      Success(Team("Arsenal", "The Library", 1886)),
+      Success(Team("Middlesbrough", "Fortress Riverside", 1876))
     )
   }
 
@@ -82,7 +82,7 @@ class HitReaderTest extends FlatSpec with MockitoSugar with DockerTests with Mat
       get("1").from(IndexName)
     }.await.result.safeTo[Team]
 
-    team shouldBe Right(Team("Middlesbrough", "Fortress Riverside", 1876))
+    team shouldBe Success(Team("Middlesbrough", "Fortress Riverside", 1876))
   }
 
   it should "unmarshall a get response" in {
@@ -102,8 +102,8 @@ class HitReaderTest extends FlatSpec with MockitoSugar with DockerTests with Mat
     }.await.result.safeTo[Team]
 
     teams.toSet shouldBe Set(
-      Right(Team("Arsenal", "The Library", 1886)),
-      Right(Team("Middlesbrough", "Fortress Riverside", 1876))
+      Success(Team("Arsenal", "The Library", 1886)),
+      Success(Team("Middlesbrough", "Fortress Riverside", 1876))
     )
   }
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/jackson/ElasticJacksonIndexableTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/jackson/ElasticJacksonIndexableTest.scala
@@ -8,6 +8,8 @@ import com.sksamuel.elastic4s.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.{Matchers, WordSpec}
 
+import scala.util.Success
+
 class ElasticJacksonIndexableTest extends WordSpec with Matchers with DockerTests {
 
   import ElasticJackson.Implicits._
@@ -39,7 +41,7 @@ class ElasticJacksonIndexableTest extends WordSpec with Matchers with DockerTest
 
       // should populate _id, _index and _type for us from the search result
       resp.safeTo[CharacterWithIdTypeAndIndex] shouldBe
-        List(Right(CharacterWithIdTypeAndIndex("2", "jacksontest", "characters", "hank", "breaking bad")))
+        List(Success(CharacterWithIdTypeAndIndex("2", "jacksontest", "characters", "hank", "breaking bad")))
     }
     "support custom mapper" in {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchHitReaderTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchHitReaderTest.scala
@@ -4,6 +4,8 @@ import com.sksamuel.elastic4s.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.{FlatSpec, Matchers}
 
+import scala.util.Success
+
 class SearchHitReaderTest extends FlatSpec with Matchers with DockerTests {
 
   import com.sksamuel.elastic4s.jackson.ElasticJackson.Implicits._
@@ -30,7 +32,7 @@ class SearchHitReaderTest extends FlatSpec with Matchers with DockerTests {
 
     client.execute {
       search("cars").matchAllQuery().limit(1)
-    }.await.result.safeTo[Car] shouldBe Seq(Right(focus))
+    }.await.result.safeTo[Car] shouldBe Seq(Success(focus))
   }
 }
 


### PR DESCRIPTION
Bounding box options were added within `locationField` node instead of within` geo_bounding_box`