### PR TITLE
Add `causedBy` field to `ElasticError` (master)

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/ElasticError.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/ElasticError.scala
@@ -1,19 +1,32 @@
 package com.sksamuel.elastic4s.http
 
-import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.{JsonAnySetter, JsonProperty}
 import com.sksamuel.elastic4s.json.JacksonSupport
+
+import scala.collection.mutable
 
 case class ElasticError(`type`: String,
                         reason: String,
                         @JsonProperty("index_uuid") indexUuid: Option[String],
                         index: Option[String],
                         shard: Option[String],
-                        @JsonProperty("root_cause") rootCause: Seq[ElasticError])
+                        @JsonProperty("root_cause") rootCause: Seq[ElasticError],
+                        @JsonProperty("caused_by") causedBy: Option[ElasticError.CausedBy])
 
 object ElasticError {
 
+  class CausedBy(`type`: String, reason: String){
+    private val _other = mutable.HashMap[String, String]()
+
+    @JsonAnySetter private def setOther(k: String, v: String): Unit = _other.put(k, v)
+
+    def other(key: String): Option[String] = _other.get(key)
+
+    override def toString: String = s"CausedBy(${`type`},$reason,${_other})"
+  }
+
   def fromThrowable(t: Throwable) =
-    ElasticError(t.getClass.getCanonicalName, t.getLocalizedMessage, None, None, None, Nil)
+    ElasticError(t.getClass.getCanonicalName, t.getLocalizedMessage, None, None, None, Nil, None)
 
   def parse(r: HttpResponse): ElasticError =
     r.entity match {
@@ -23,8 +36,8 @@ object ElasticError {
           val errorNode = node.get("error")
           JacksonSupport.mapper.readValue[ElasticError](JacksonSupport.mapper.writeValueAsBytes(errorNode))
         } else
-          ElasticError(r.statusCode.toString, r.statusCode.toString, None, None, None, Nil)
+          ElasticError(r.statusCode.toString, r.statusCode.toString, None, None, None, Nil, None)
       case _ =>
-        ElasticError(r.statusCode.toString, r.statusCode.toString, None, None, None, Nil)
+        ElasticError(r.statusCode.toString, r.statusCode.toString, None, None, None, Nil, None)
     }
 }

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/get/GetHandlers.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/get/GetHandlers.scala
@@ -53,7 +53,7 @@ trait GetHandlers {
           if (node.get("error").isObject)
             Left(ElasticError.parse(response))
           else
-            Left(ElasticError(response.entity.get.content, response.entity.get.content, None, None, None, Nil))
+            Left(ElasticError(response.entity.get.content, response.entity.get.content, None, None, None, Nil, None))
         }
 
         def good = Right(ResponseHandler.fromResponse[GetResponse](response))


### PR DESCRIPTION
Sometimes `type` and `rootCause` just not enough. In my case it's `TooManyBucketsException` which ES will return type `SearchPhaseExecutionException` and empty root cause.