### PR TITLE
Fix missing suggestions response

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/responses.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/responses.scala
@@ -105,8 +105,9 @@ case class SearchResponse(took: Long,
   def aggregations: Aggregations        = Aggregations(aggregationsAsMap)
 
   private def suggestion(name: String): Map[String, SuggestionResult] =
-    Option(suggest(name))
-      .getOrElse(Nil)
+    Option(suggest)
+      .getOrElse(Map.empty)
+      .getOrElse(name, Nil)
       .map { result =>
         result.text -> result
       }

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/responses.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/responses.scala
@@ -105,8 +105,8 @@ case class SearchResponse(took: Long,
   def aggregations: Aggregations        = Aggregations(aggregationsAsMap)
 
   private def suggestion(name: String): Map[String, SuggestionResult] =
-    suggest
-      .getOrElse(name, Nil)
+    Option(suggest(name))
+      .getOrElse(Nil)
       .map { result =>
         result.text -> result
       }


### PR DESCRIPTION
When using the suggester API and no results are returned, the "suggest" field is missing from the response. This results in a NullPointerException at the moment, ex:
```
java.lang.NullPointerException: null
at com.sksamuel.elastic4s.http.search.SearchResponse.suggestion(responses.scala:109) ~[com.sksamuel.elastic4s.elastic4s-http_2.12-6.2.9.jar:6.2.9]
at com.sksamuel.elastic4s.http.search.SearchResponse.completionSuggestion(responses.scala:117) ~[com.sksamuel.elastic4s.elastic4s-http_2.12-6.2.9.jar:6.2.9]
```
