### PR TITLE
Fixed `StemmerTokenFilter` incorrectly set `language` field to `name` when creating TokenFilter to index

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/analyzers/TokenFilter.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/analyzers/TokenFilter.scala
@@ -331,7 +331,7 @@ case class StemmerTokenFilter(name: String, lang: String) extends TokenFilterDef
   val filterType = "stemmer"
 
   override def build(source: XContentBuilder): Unit =
-    source.field("name", lang)
+    source.field("language", lang)
 
   def lang(l: String): StemmerTokenFilter = copy(lang = l)
 }


### PR DESCRIPTION
The following code:

`StemmerTokenFilter("english_possessive_stemmer", "possessive_english")`

Should create a new filter in the following structure:
```
           "english_possessive_stemmer": {
              "language": "possessive_english",
              "type": "stemmer"
            }
```
However, the actual structure was:
```
           "english_possessive_stemmer": {
              "name": "possessive_english",
              "type": "stemmer"
            }
```
