### PR TITLE
https://github.com/elastic/elasticsearch/issues/6299

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/aggs/TopHitsAggregationDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/aggs/TopHitsAggregationDefinition.scala
@@ -9,6 +9,7 @@ case class TopHitsAggregationDefinition(name: String,
                                         explain: Option[Boolean] = None,
                                         fetchSource: Option[FetchSourceContext] = None,
                                         size: Option[Int] = None,
+                                        from: Option[Int] = None,
                                         sorts: Seq[SortDefinition] = Nil,
                                         trackScores: Option[Boolean] = None,
                                         version: Option[Boolean] = None,
@@ -29,6 +30,8 @@ case class TopHitsAggregationDefinition(name: String,
     copy(fetchSource = FetchSourceContext(fetchSource).some)
 
   def size(size: Int): TopHitsAggregationDefinition = copy(size = size.some)
+
+  def from(from: Int): TopHitsAggregationDefinition = copy(from = from.some)
 
   def sortBy(first: SortDefinition, rest: SortDefinition*): TopHitsAggregationDefinition = sortBy(first +: rest)
   def sortBy(sorts: Iterable[SortDefinition]): TopHitsAggregationDefinition              = copy(sorts = sorts.toSeq)

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/TopHitsAggregationBuilder.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/TopHitsAggregationBuilder.scala
@@ -12,6 +12,7 @@ object TopHitsAggregationBuilder {
     val builder = XContentFactory.jsonBuilder().startObject("top_hits")
 
     agg.size.foreach(builder.field("size", _))
+    agg.from.foreach(builder.field("from", _))
     if (agg.sorts.nonEmpty) {
       builder.startArray("sort")
       agg.sorts.foreach { sort =>

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/aggs/TopHitsAggregationBuilderTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/aggs/TopHitsAggregationBuilderTest.scala
@@ -8,10 +8,11 @@ class TopHitsAggregationBuilderTest extends FunSuite with Matchers {
   test("top hits aggregation should generate expected json") {
     val q = TopHitsAggregationDefinition("top_items")
       .size(5)
+      .from(10)
       .version(true)
       .explain(false)
       .sortBy(List(FieldSortDefinition("price").sortMode(SortMode.Median)))
     TopHitsAggregationBuilder(q).string() shouldBe
-      """{"top_hits":{"size":5,"sort":[{"price":{"mode":"median","order":"asc"}}],"explain":false,"version":true}}"""
+      """{"top_hits":{"size":5,"from":10,"sort":[{"price":{"mode":"median","order":"asc"}}],"explain":false,"version":true}}"""
   }
 }

--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/aggs/TopHitsAggregationBuilder.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/aggs/TopHitsAggregationBuilder.scala
@@ -18,6 +18,7 @@ object TopHitsAggregationBuilder {
     agg.trackScores.foreach(builder.trackScores)
     agg.version.foreach(builder.version)
     agg.size.foreach(builder.size)
+    agg.from.foreach(builder.from)
     agg.storedFields.foreach(builder.storedField)
 
     agg.scripts.foreach {


### PR DESCRIPTION
was added pagination to top_hits aggregation.
it's very small changes. just added the possibility of pagination.
i'd rather to see the changes and in previous version.