### PR TITLE
Change shrink index settings copy builder to use param

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/admin/ShrinkIndexRequest.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/admin/ShrinkIndexRequest.scala
@@ -5,5 +5,5 @@ case class ShrinkIndexRequest(source: String,
                               waitForActiveShards: Option[Int] = None,
                               settings: Map[String, String] = Map.empty) {
 
-  def settings(map: Map[String, String]): ShrinkIndexRequest = copy(settings = settings)
+  def settings(map: Map[String, String]): ShrinkIndexRequest = copy(settings = map)
 }


### PR DESCRIPTION
`ShrinkIndexRequest` was doing a no-op on the `settings` builder (`settings = settings`)