### PR TITLE
Support Refresh of index on delete by query

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/delete/DeleteImplicits.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/delete/DeleteImplicits.scala
@@ -42,6 +42,7 @@ trait DeleteImplicits {
       request.requestsPerSecond.map(_.toString).foreach(params.put("requests_per_second", _))
       request.timeout.map(_.toMillis + "ms").foreach(params.put("timeout", _))
       request.scrollSize.map(_.toString).foreach(params.put("scroll_size", _))
+      request.refresh.map(RefreshPolicyHttpValue.apply).foreach(params.put("refresh", _))
       request.waitForActiveShards.map(_.toString).foreach(params.put("wait_for_active_shards", _))
 
       val body = DeleteByQueryBodyFn(request)

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/delete/DeleteByQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/delete/DeleteByQueryTest.scala
@@ -36,8 +36,6 @@ class DeleteByQueryTest extends WordSpec with Matchers with ElasticDsl with Dual
         deleteIn("charlesd").by(matchQuery("name", "bumbles")).refresh(RefreshPolicy.IMMEDIATE)
       }.await.deleted shouldBe 2
 
-      Thread.sleep(5000)
-
       execute {
         search("charlesd" / "characters").matchAllQuery()
       }.await.totalHits shouldBe 2


### PR DESCRIPTION
Thanks for this fantastic library!

A while back this issue was raised: https://github.com/sksamuel/elastic4s/issues/984. It was closed as the delete-by-ID executable already has it, but I think the delete-by-query should have it as well.

The test for delete-by-query was using a 5 second sleep to wait until the elastic index had refreshed but this is no longer necessary when forcing it to refresh on the delete request.