### PR TITLE
ENTELLECT-411 Fix preference bug in 6.2.x

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/SearchBodyBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/SearchBodyBuilderFn.scala
@@ -24,7 +24,6 @@ object SearchBodyBuilderFn {
     val builder = XContentFactory.jsonBuilder()
 
     builder.field("version", true)
-    request.control.pref.foreach(builder.field("preference", _))
     request.control.timeout.map(_.toMillis + "ms").foreach(builder.field("timeout", _))
     request.control.terminateAfter.map(_.toString).foreach(builder.field("terminate_after", _))
     request.version.map(_.toString).foreach(builder.field("version", _))

--- a/elastic4s-tests/src/test/resources/json/search/search_preference_primary_first.json
+++ b/elastic4s-tests/src/test/resources/json/search/search_preference_primary_first.json
@@ -1,6 +1,5 @@
 {
     "version": true,
-    "preference": "_primary_first",
     "query": {
         "query_string": {
             "query": "coldplay"

--- a/elastic4s-tests/src/test/resources/json/search/search_sort_script.json
+++ b/elastic4s-tests/src/test/resources/json/search/search_sort_script.json
@@ -1,6 +1,5 @@
 {
     "version": true,
-    "preference": "custom-node",
     "sort": [
         {
             "_script": {

--- a/elastic4s-tests/src/test/resources/json/search/search_sort_script_params.json
+++ b/elastic4s-tests/src/test/resources/json/search/search_sort_script_params.json
@@ -1,6 +1,5 @@
 {
     "version": true,
-    "preference": "custom-node",
     "sort": [
         {
             "_script": {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
@@ -9,7 +9,7 @@ import com.sksamuel.elastic4s.searches.queries.matches.{MultiMatchQueryBuilderTy
 import com.sksamuel.elastic4s.searches.queries.{RegexpFlag, SimpleQueryStringFlag}
 import com.sksamuel.elastic4s.searches.sort.{SortMode, SortOrder}
 import com.sksamuel.elastic4s.searches.suggestion.SuggestMode
-import com.sksamuel.elastic4s.searches.{DateHistogramInterval, GeoPoint, QueryRescoreMode, ScoreMode, SearchType}
+import com.sksamuel.elastic4s.searches._
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FlatSpec, OneInstancePerTest}
 
@@ -56,6 +56,7 @@ class SearchDslTest extends FlatSpec with MockitoSugar with JsonSugar with OneIn
   it should "use preference when specified" in {
     val req = search("*") types("users", "tweets") query "coldplay" preference Preference.PrimaryFirst
     req.show should matchJsonResource("/json/search/search_preference_primary_first.json")
+    req.parameters shouldBe Map("preference" -> "_primary_first")
   }
 
   it should "generate wrapped query for a raw query" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/CommonQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/CommonQueryTest.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.elastic4s.search.queries
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import com.sksamuel.elastic4s.{ElasticDsl, Indexable}
+import com.sksamuel.elastic4s.{ElasticDsl, Indexable, Preference}
 import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
@@ -44,6 +44,16 @@ class CommonQueryTest extends WordSpec with Matchers with DockerTests with Elast
       }.await.right.get.result
       resp.totalHits shouldBe 1
     }
+
+    "use preference" in {
+      val resp = http.execute {
+        search("condiments") query {
+          commonTermsQuery("desc") text "catsup"
+        } preference Preference.PrimaryFirst
+      }.await.right.get.result
+      resp.totalHits shouldBe 1
+    }
+
     "use operators" in {
       val resp = http.execute {
         search("condiments") query {


### PR DESCRIPTION
#1398 

I extracted a RichSearchDefinition class to enable unit testing. The integration test I added in CommonQueryTest doesn't really test the preference functionality, but it does at least fail without the fix. To really test the preference functionality I think you'd need a multi node cluster