### PR TITLE
feat: add index_options for text fields

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/CommonFieldBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/CommonFieldBuilder.scala
@@ -116,6 +116,7 @@ object FieldBuilderFn {
         text.maxInputLength.foreach(builder.field("max_input_length", _))
         text.ignoreAbove.foreach(builder.field("ignore_above", _))
         text.similarity.foreach(builder.field("similarity", _))
+        text.indexOptions.foreach(builder.field("index_options", _))
 
       case keyword: KeywordFieldDefinition =>
         keyword.eagerGlobalOrdinals.foreach(builder.field("eager_global_ordinals", _))

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/TextFieldDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/TextFieldDefinition.scala
@@ -64,4 +64,6 @@ case class TextFieldDefinition(name: String,
   override def store(b: Boolean): T = copy(store = b.some)
 
   override def termVector(t: String): T = copy(termVector = t.some)
+
+  def indexOptions(indexOptions: String): T = copy(indexOptions = indexOptions.some)
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/mappings/TextFieldDefinitionTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/mappings/TextFieldDefinitionTest.scala
@@ -24,7 +24,8 @@ class TextFieldDefinitionTest extends FlatSpec with Matchers with ElasticApi {
       .similarity("classic")
       .nullable(false)
       .nullValue("nully")
+      .indexOptions("docs")
     FieldBuilderFn(field).string() shouldBe
-      """{"type":"text","analyzer":"armenian","boost":1.2,"copy_to":["copy1","copy2"],"doc_values":true,"index":true,"normalizer":"mynorm","norms":true,"null_value":"nully","search_analyzer":"english","store":true,"fielddata":true,"max_input_length":12,"ignore_above":30,"similarity":"classic"}"""
+      """{"type":"text","analyzer":"armenian","boost":1.2,"copy_to":["copy1","copy2"],"doc_values":true,"index":true,"normalizer":"mynorm","norms":true,"null_value":"nully","search_analyzer":"english","store":true,"fielddata":true,"max_input_length":12,"ignore_above":30,"similarity":"classic","index_options":"docs"}"""
   }
 }


### PR DESCRIPTION
Added support for the `index_options` mapping parameter for text fields:
https://www.elastic.co/guide/en/elasticsearch/reference/master/index-options.html