### PR TITLE
Fix phrase suggestions

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/suggs/PhraseSuggestionBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/suggs/PhraseSuggestionBuilderFn.scala
@@ -9,16 +9,16 @@ object PhraseSuggestionBuilderFn {
 
     val builder = XContentFactory.obj()
 
+    phrase.text.foreach(builder.field("text", _))
     builder.startObject("phrase")
 
-    phrase.text.foreach(builder.field("text", _))
     builder.field("field", phrase.fieldname)
     phrase.analyzer.foreach(builder.field("analyzer", _))
 
     phrase.confidence.foreach(builder.field("confidence", _))
     phrase.forceUnigrams.foreach(builder.field("force_unigrams", _))
     phrase.gramSize.foreach(builder.field("gram_size", _))
-    phrase.maxErrors.foreach(builder.field("max_error", _))
+    phrase.maxErrors.foreach(builder.field("max_errors", _))
     phrase.realWordErrorLikelihood.foreach(builder.field("real_word_error_likelihood", _))
     phrase.separator.foreach(builder.field("separator", _))
     phrase.tokenLimit.foreach(builder.field("token_limit", _))

--- a/elastic4s-tests/src/test/resources/json/search/search_suggestions_multiple_suggesters.json
+++ b/elastic4s-tests/src/test/resources/json/search/search_suggestions_multiple_suggesters.json
@@ -16,9 +16,10 @@
             }
         },
         "suggestion-phrase": {
+            "text": "aqualuck by jethro toll",
             "phrase": {
-                "text": "aqualuck by jethro toll",
                 "field": "name",
+                "max_errors": 1.0,
                 "collate": {
                     "query": {},
                     "params": {}

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
@@ -818,7 +818,7 @@ class SearchDslTest extends FlatSpec with MockitoSugar with JsonSugar with OneIn
   it should "generate correct json for suggestions of multiple suggesters" in {
     val req = search("music") types "bands" query termQuery("name", "coldplay") suggestions(
       termSuggestion("suggestion-term") on "name" text "culdpaly" maxEdits 2,
-      phraseSuggestion("suggestion-phrase") on "name" text "aqualuck by jethro toll",
+      phraseSuggestion("suggestion-phrase") on "name" text "aqualuck by jethro toll" maxErrors 1.0f,
       completionSuggestion("suggestion-completion") on "ac" text "cold"
     )
     req.request.entity.get.get should matchJsonResource("/json/search/search_suggestions_multiple_suggesters.json")


### PR DESCRIPTION
The text field needs to be outside of the "phrase" object. Also there was a spelling error for "max_errors".
https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters-phrase.html