### PR TITLE
fix: nullable highlight in search hits

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/responses.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/responses.scala
@@ -22,11 +22,12 @@ case class SearchHit(@JsonProperty("_id") id: String,
                      @JsonProperty("sort") sort: Option[Seq[AnyRef]],
                      private val _source: Map[String, AnyRef],
                      fields: Map[String, AnyRef],
-                     highlight: Map[String, Seq[String]],
+                     @JsonProperty("highlight") private val _highlight: Option[Map[String, Seq[String]]],
                      private val inner_hits: Map[String, Map[String, Any]])
   extends Hit {
 
-  def highlightFragments(name: String): Seq[String] = Option(highlight).getOrElse(Map.empty).getOrElse(name, Nil)
+  def highlight: Map[String, Seq[String]] = _highlight.getOrElse(Map.empty)
+  def highlightFragments(name: String): Seq[String] = highlight.getOrElse(name, Nil)
 
   def innerHitsAsMap: Map[String, Map[String, Any]] = Option(inner_hits).getOrElse(Map.empty)
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/highlight/HighlightTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/highlight/HighlightTest.scala
@@ -32,6 +32,11 @@ class HighlightTest extends WordSpec with Matchers with DockerTests {
   }.await
 
   "highlighting" should {
+    "ignore missing highlight" in {
+      client.execute {
+        search("intros").matchAllQuery().limit(1)
+      }.await.result.hits.hits.map(_.highlight) shouldBe Array(Map.empty)
+    }
     "highlight selected words" in {
 
       val resp = client.execute {


### PR DESCRIPTION
I had encountered the nullable highlight issue as specified in #1444. I was thinking of fixing it like this. This would not break backward compatibility, though any existing client checking for nullity will now do it uselessly...