### PR TITLE
Don’t use hardcoded and deprecated value

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/suggs/PhraseSuggestionBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/suggs/PhraseSuggestionBuilderFn.scala
@@ -41,7 +41,7 @@ object PhraseSuggestionBuilderFn {
     builder.startObject("collate")
 
     builder.startObject("query")
-    phrase.collateQuery.foreach(t => builder.rawField("inline", t.script))
+    phrase.collateQuery.foreach(t => builder.rawField(t.scriptType.toString.toLowerCase, t.script))
     builder.endObject()
 
     phrase.collatePrune.foreach(builder.field("prune", _))


### PR DESCRIPTION
This fix will get rid of the log entry on each request:
```
"Deprecated field [inline] used, expected [source] instead" "Fri, 06 Jul 2018 06:58:21 GMT"
```