### PR TITLE
Fix SearchError content

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/SearchHandlers.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/SearchHandlers.scala
@@ -31,7 +31,7 @@ trait SearchHandlers {
               val status = element.get("status").intValue()
               val either =
                 if (element.has("error"))
-                  Left(JacksonSupport.mapper.treeToValue[SearchError](element))
+                  Left(JacksonSupport.mapper.treeToValue[SearchError](element.get("error")))
                 else
                   Right(JacksonSupport.mapper.treeToValue[SearchResponse](element))
               MultisearchResponseItem(index, status, either)


### PR DESCRIPTION
Fixes issue #1447 
The mapper failed because there was an "error" element wrapping the SearchError