### PR TITLE
Fix encoder property in highlighting options

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/HighlightBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/HighlightBuilderFn.scala
@@ -18,8 +18,7 @@ object HighlightBuilderFn {
     highlight.options.fragmenter.foreach(builder.field("fragmenter", _))
     highlight.options.fragmentSize.foreach(builder.field("fragment_size", _))
     highlight.options.numOfFragments.foreach(builder.field("number_of_fragments", _))
-    highlight.options.encoder.foreach(builder.field("boundary_chars", _))
-    highlight.options.encoder.foreach(builder.field("boundary_chars", _))
+    highlight.options.encoder.foreach(builder.field("encoder", _))
     highlight.options.forceSource.foreach(builder.field("force_source", _))
     highlight.options.highlighterType.foreach(builder.field("type", _))
     highlight.options.highlightQuery.map(QueryBuilderFn.apply).foreach { highlight =>

--- a/elastic4s-tests/src/test/resources/json/search/search_highlighting.json
+++ b/elastic4s-tests/src/test/resources/json/search/search_highlighting.json
@@ -1,8 +1,9 @@
 {
     "version": true,
     "highlight": {
-        "boundary_chars": "html",
+        "boundary_chars": "\\b",
         "boundary_max_scan": 4,
+        "encoder": "html",
         "order": "score",
         "post_tags": [
             "</b>"


### PR DESCRIPTION
The `encoder` and `boundary_chars` options for search highlighting were mixed up because of an apparent copy-paste mistake.