### PR TITLE
Support for typed_keys in Search and MultiSearch

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/MultiSearchRequest.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/MultiSearchRequest.scala
@@ -2,6 +2,8 @@ package com.sksamuel.elastic4s.searches
 
 import com.sksamuel.exts.OptionImplicits._
 
-case class MultiSearchRequest(searches: Iterable[SearchRequest], maxConcurrentSearches: Option[Int] = None) {
+case class MultiSearchRequest(searches: Iterable[SearchRequest], maxConcurrentSearches: Option[Int] = None, typedKeys: Option[Boolean] = None) {
   def maxConcurrentSearches(max: Int): MultiSearchRequest = copy(maxConcurrentSearches = max.some)
+
+  def typedKeys(enabled: Boolean): MultiSearchRequest = copy(typedKeys = enabled.some)
 }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/SearchRequest.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/SearchRequest.scala
@@ -54,7 +54,8 @@ case class SearchRequest(indexesTypes: IndexesAndTypes,
                          version: Option[Boolean] = None,
                          profile: Option[Boolean] = None,
                          source: Option[String] = None,
-                         trackHits: Option[Boolean] = None) {
+                         trackHits: Option[Boolean] = None,
+                         typedKeys: Option[Boolean] = None) {
 
   /** Adds a single string query to this search
     *
@@ -297,4 +298,6 @@ case class SearchRequest(indexesTypes: IndexesAndTypes,
     copy(fetchContext = FetchSourceContext(true, includes.toArray, excludes.toArray).some)
 
   def collapse(collapse: CollapseRequest): SearchRequest = copy(collapse = collapse.some)
+
+  def typedKeys(enabled: Boolean): SearchRequest = copy(typedKeys = enabled.some)
 }

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/SearchHandlers.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/SearchHandlers.scala
@@ -45,6 +45,7 @@ trait SearchHandlers {
 
       val params = scala.collection.mutable.Map.empty[String, String]
       request.maxConcurrentSearches.map(_.toString).foreach(params.put("max_concurrent_searches", _))
+      request.typedKeys.map(_.toString).foreach(params.put("typed_keys", _))
 
       val body = MultiSearchBuilderFn(request)
       logger.debug("Executing msearch: " + body)
@@ -84,6 +85,8 @@ trait SearchHandlers {
       request.indicesOptions.foreach { opts =>
         IndicesOptionsParams(opts).foreach { case (key, value) => params.put(key, value) }
       }
+
+      request.typedKeys.map(_.toString).foreach(params.put("typed_keys", _))
 
       val body = request.source.getOrElse(SearchBodyBuilderFn(request).string())
       ElasticRequest("POST", endpoint, params.toMap, HttpEntity(body, ContentType.APPLICATION_JSON.getMimeType))


### PR DESCRIPTION
This PR includes the changes to provide an option to include`typed_keys` query parameter to the search request to elasticsearch cluster. Enabling the `typed_keys` will let the elasticsearch to prefix aggregation type to the aggregation name in the response. 


```
search(indices).source(jsonQuery).typedKeys(true)
```

This addresses the issue discussed in #1436 