### PR TITLE
Accessor to SubAggregation Data

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggresponses.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggresponses.scala
@@ -380,6 +380,8 @@ trait HasAggregations extends Transformable {
   override private[elastic4s] def data: Map[String, Any]
   private def agg(name: String): Map[String, Any] = data(name).asInstanceOf[Map[String, Any]]
 
+  def dataAsMap: Map[String, Any] = if(data != null) data else Map.empty
+
   def contains(name: String): Boolean = data.contains(name)
   def names: Iterable[String] = data.keys
 


### PR DESCRIPTION
This PR contains the change to provide an accessor function to aggregation data with a null check. (Addressing the issue mentioned in #1452 )