### PR TITLE
Add percolate query support to 5.4.x HTTP client

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/QueryBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/QueryBuilderFn.scala
@@ -5,7 +5,7 @@ import com.sksamuel.elastic4s.http.search.queries.compound.{BoolQueryBuilderFn, 
 import com.sksamuel.elastic4s.http.search.queries.geo.{GeoBoundingBoxQueryBodyFn, GeoDistanceQueryBodyFn, GeoPolyonQueryBodyFn}
 import com.sksamuel.elastic4s.http.search.queries.nested.{HasChildBodyFn, HasParentBodyFn, NestedQueryBodyFn, ParentIdQueryBodyFn}
 import com.sksamuel.elastic4s.http.search.queries.span._
-import com.sksamuel.elastic4s.http.search.queries.specialized.{FunctionScoreQueryBodyFn, MoreLikeThisBuilderFn, ScriptQueryBodyFn, ScriptScoreQueryBodyFn}
+import com.sksamuel.elastic4s.http.search.queries.specialized.{FunctionScoreQueryBodyFn, MoreLikeThisBuilderFn, PercolateQueryBodyFn, ScriptQueryBodyFn, ScriptScoreQueryBodyFn}
 import com.sksamuel.elastic4s.http.search.queries.term._
 import com.sksamuel.elastic4s.http.search.queries.text._
 import com.sksamuel.elastic4s.searches.queries.funcscorer.{FunctionScoreQueryDefinition, ScriptScoreDefinition}
@@ -40,6 +40,7 @@ object QueryBuilderFn {
     case q: MultiMatchQueryDefinition => MultiMatchBodyFn(q)
     case q: NestedQueryDefinition => NestedQueryBodyFn(q)
     case q: ParentIdQueryDefinition => ParentIdQueryBodyFn(q)
+    case q: PercolateQueryDefinition => PercolateQueryBodyFn(q)
     case q: PrefixQueryDefinition => PrefixQueryBodyFn(q)
     case q: QueryStringQueryDefinition => QueryStringBodyFn(q)
     case r: RangeQueryDefinition => RangeQueryBodyFn(r)

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/specialized/PercolateQueryBodyFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/specialized/PercolateQueryBodyFn.scala
@@ -1,0 +1,26 @@
+package com.sksamuel.elastic4s.http.search.queries.specialized
+
+import com.sksamuel.elastic4s.searches.queries.PercolateQueryDefinition
+import org.elasticsearch.common.bytes.BytesArray
+import org.elasticsearch.common.xcontent.{XContentBuilder, XContentFactory, XContentType}
+
+object PercolateQueryBodyFn {
+
+  def apply(q: PercolateQueryDefinition): XContentBuilder = {
+    val builder = XContentFactory.jsonBuilder()
+    builder.startObject()
+    builder.startObject("percolate")
+    builder.field("field", q.field)
+    builder.field("document_type", q.`type`)
+    q.ref.foreach { ref =>
+      builder.field("index", ref.index)
+      builder.field("type", ref.`type`)
+      builder.field("id", ref.id)
+    }
+    q.source.foreach { source =>
+      builder.rawField("document", new BytesArray(source), XContentType.JSON)
+    }
+    builder.endObject()
+    builder.endObject()
+  }
+}

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/specialized/PercolateQueryBodyFnTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/specialized/PercolateQueryBodyFnTest.scala
@@ -1,0 +1,22 @@
+package com.sksamuel.elastic4s.http.search.queries.specialized
+
+import com.sksamuel.elastic4s.DocumentRef
+import com.sksamuel.elastic4s.http.ElasticDsl._
+import org.scalatest.{FunSuite, Matchers}
+
+class PercolateQueryBodyFnTest extends FunSuite with Matchers {
+
+  test("percolateQuery should generate expected json using id") {
+    val q = percolateQuery("some_document_type", "some_field")
+      .usingId("some_index", "some_type", "some_id")
+    PercolateQueryBodyFn(q).string() shouldBe
+      """{"percolate":{"field":"some_field","document_type":"some_document_type","index":"some_index","type":"some_type","id":"some_id"}}"""
+  }
+
+  test("percolateQuery should generate expected json using source") {
+    val q = percolateQuery("some_document_type", "some_field")
+      .usingSource("""{"message":"A new bonsai tree in the office"}""")
+    PercolateQueryBodyFn(q).string() shouldBe
+      """{"percolate":{"field":"some_field","document_type":"some_document_type","document":{"message":"A new bonsai tree in the office"}}}"""
+  }
+}


### PR DESCRIPTION
[`percolateQuery` DSL is defined in the core module](https://github.com/sksamuel/elastic4s/blob/62a5cb2bf24c421f13366f3cdf2015068ad82b57/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/QueryApi.scala#L195) but a request body encoding for the query was missing in the HTTP client.

Note that I didn't add [`register` DSL defined in TCP version](https://github.com/sksamuel/elastic4s/blob/62a5cb2bf24c421f13366f3cdf2015068ad82b57/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/PercolateDsl.scala#L10) because registering a percolator is just inserting a query to the index.  It is possible by [index API](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html) as the following.

```scala
import com.sksamuel.elastic4s.http.ElasticDsl._
import com.sksamuel.elastic4s.searches.queries.QueryDefinition
import com.sksamuel.elastic4s.http.search.queries.QueryBuilderFn

val query: QueryDefinition = ...
val src = s"""{"query":${QueryBuilderFn(query).string()}}"""
indexInto("some-index" / "percolator-type")
  .source(src)
  .withId("percolator-id")
```

----

I would like to add the same support for other versions than 5.4.x as soon as we move our Elasticsearch clusters to newer versions.