### PR TITLE
Add matched_queries support to 5.4.x HTTP client

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/responses.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/responses.scala
@@ -16,7 +16,8 @@ case class SearchHit(@JsonProperty("_id") id: String,
                      fields: Map[String, AnyRef],
                      highlight: Map[String, Seq[String]],
                      private val inner_hits: Map[String, Map[String, Any]],
-                     @JsonProperty("_version") version: Long) extends Hit {
+                     @JsonProperty("_version") version: Long,
+                     @JsonProperty("matched_queries") private val _matchedQueries: Option[Seq[String]]) extends Hit {
 
   def highlightFragments(name: String): Seq[String] = Option(highlight).getOrElse(Map.empty).getOrElse(name, Nil)
 
@@ -53,6 +54,8 @@ case class SearchHit(@JsonProperty("_id") id: String,
         }
       )
   }
+
+  def matchedQueries: Seq[String] = _matchedQueries.getOrElse(Nil)
 }
 
 case class SearchHits(total: Int,

--- a/elastic4s-testkit/src/main/scala/com/sksamuel/elastic4s/testkit/ResponseConverter.scala
+++ b/elastic4s-testkit/src/main/scala/com/sksamuel/elastic4s/testkit/ResponseConverter.scala
@@ -128,7 +128,9 @@ object ResponseConverterImplicits {
             x.fields.mapValues(_.value),
             x.highlightFields.mapValues(_.fragments.map(_.string)),
             inner_hits = Map.empty,// TODO: Set properly
-            x.version
+            x.version,
+            if (Option(x.java.getMatchedQueries).isDefined) Some(x.matchedQueries)
+            else None
           )
         }
       )


### PR DESCRIPTION
Accept `matched_queries` (a response field for [named queries](https://www.elastic.co/guide/en/elasticsearch/reference/5.4/search-request-named-queries-and-filters.html)) as a field of search hits.

----

I would like to add the same support for other versions than 5.4.x as soon as we move our Elasticsearch clusters to newer versions.