### PR TITLE
Add multi termvectors API support to 5.4.x HTTP client

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/termvectors/MultiTermVectorsDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/termvectors/MultiTermVectorsDefinition.scala
@@ -1,0 +1,7 @@
+package com.sksamuel.elastic4s.termvectors
+
+case class MultiTermVectorsDefinition(termVectorsDefinitions: Seq[TermVectorsDefinition],
+                                      realtime: Option[Boolean] = None) {
+
+  def realtime(boolean: Boolean): MultiTermVectorsDefinition = copy(realtime = Option(boolean))
+}

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/termvectors/TermVectorApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/termvectors/TermVectorApi.scala
@@ -5,4 +5,7 @@ import com.sksamuel.elastic4s.IndexAndType
 trait TermVectorApi {
   def termVectors(index: String, `type`: String, id: Any): TermVectorsDefinition =
     TermVectorsDefinition(IndexAndType(index, `type`), id.toString)
+
+  def multiTermVectors(first: TermVectorsDefinition, rest: TermVectorsDefinition*): MultiTermVectorsDefinition = MultiTermVectorsDefinition(first +: rest)
+  def multiTermVectors(defs: Iterable[TermVectorsDefinition]): MultiTermVectorsDefinition = MultiTermVectorsDefinition(defs.toSeq)
 }


### PR DESCRIPTION
cf. [Multi termvectors API](https://www.elastic.co/guide/en/elasticsearch/reference/5.4/docs-multi-termvectors.html)

----

I would like to add the same support for other versions than 5.4.x as soon as we move our Elasticsearch clusters to newer versions.