### PR TITLE
Support Multi termvectors API on master branch

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/termvectors/MultiTermVectorsRequest.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/termvectors/MultiTermVectorsRequest.scala
@@ -1,0 +1,7 @@
+package com.sksamuel.elastic4s.termvectors
+
+case class MultiTermVectorsRequest(termVectorsRequests: Seq[TermVectorsRequest],
+                                   realtime: Option[Boolean] = None) {
+
+  def realtime(boolean: Boolean): MultiTermVectorsRequest = copy(realtime = Option(boolean))
+}

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/termvectors/TermVectorApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/termvectors/TermVectorApi.scala
@@ -5,4 +5,7 @@ import com.sksamuel.elastic4s.{Index, IndexAndType}
 trait TermVectorApi {
   def termVectors(index: Index, `type`: String, id: String): TermVectorsRequest =
     TermVectorsRequest(IndexAndType(index.name, `type`), id.toString)
+
+  def multiTermVectors(first: TermVectorsRequest, rest: TermVectorsRequest*): MultiTermVectorsRequest = MultiTermVectorsRequest(first +: rest)
+  def multiTermVectors(defs: Iterable[TermVectorsRequest]): MultiTermVectorsRequest = MultiTermVectorsRequest(defs.toSeq)
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/termvectors/TermVectorsTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/termvectors/TermVectorsTest.scala
@@ -34,4 +34,28 @@ class TermVectorsTest extends FlatSpec with Matchers with DockerTests {
     response.found shouldBe true
     response.termVectors shouldBe Map("name" -> TermVectors(FieldStatistics(1, 1, 1), Map("interstellar" -> Terms(0, 0, 1.0, 1, List(Token(0, 0, 12))))))
   }
+
+  "multi term vectors" should "return full stats in multiple docs" in {
+    val response = client.execute {
+      multiTermVectors(
+        termVectors("hansz", "albums", "1"),
+        termVectors("hansz", "albums", "2")
+      )
+    }.await.result
+
+    val docs = response.docs.sortBy(_.id)
+    docs.size shouldBe 2
+
+    docs(0).index shouldBe "hansz"
+    docs(0).`type` shouldBe "albums"
+    docs(0).id shouldBe "1"
+    docs(0).found shouldBe true
+    docs(0).termVectors shouldBe Map("name" -> TermVectors(FieldStatistics(1, 1, 1), Map("interstellar" -> Terms(0, 0, 1.0, 1, List(Token(0, 0, 12))))))
+
+    docs(1).index shouldBe "hansz"
+    docs(1).`type` shouldBe "albums"
+    docs(1).id shouldBe "2"
+    docs(1).found shouldBe true
+    docs(1).termVectors shouldBe Map("name" -> TermVectors(FieldStatistics(2, 1, 2), Map("lion" -> Terms(0, 0, 1.0, 1, List(Token(0, 0, 4))), "king" -> Terms(0, 0, 1.0, 1, List(Token(1, 5, 9))))))
+  }
 }


### PR DESCRIPTION
cf. [Multi termvectors API](https://www.elastic.co/guide/en/elasticsearch/reference/5.4/docs-multi-termvectors.html)

> This would be awesome to have in master. 
>
> https://github.com/sksamuel/elastic4s/pull/1484#issuecomment-411571457
