### PR TITLE
Add missing fields to DirectGenerator

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/suggestion/PhraseSuggestion.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/suggestion/PhraseSuggestion.scala
@@ -4,7 +4,17 @@ import com.sksamuel.elastic4s.json.XContentFactory
 import com.sksamuel.elastic4s.script.Script
 import com.sksamuel.exts.OptionImplicits._
 
-case class DirectGenerator(field: String, minWordLength: Int, prefixLength: Int)
+case class DirectGenerator(field: String,
+                           size: Option[Int] = None,
+                           suggestMode: Option[String] = None,
+                           maxEdits: Option[Integer] = None,
+                           prefixLength: Option[Int] = None,
+                           minWordLength: Option[Int] = None,
+                           maxInspections: Option[Int] = None,
+                           minDocFreq: Option[Float] = None,
+                           maxTermFreq: Option[Float] = None,
+                           preFilter: Option[String] = None,
+                           postFilter: Option[String] = None)
 
 case class PhraseSuggestion(name: String,
                             fieldname: String,

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/suggs/PhraseSuggestionBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/suggs/PhraseSuggestionBuilderFn.scala
@@ -30,8 +30,16 @@ object PhraseSuggestionBuilderFn {
     phrase.directGenerators.foreach { generator =>
       builder.startObject()
       builder.field("field", generator.field)
-      builder.field("min_word_length", generator.minWordLength)
-      builder.field("prefix_length", generator.prefixLength)
+      generator.size.foreach(builder.field("size", _))
+      generator.suggestMode.foreach(builder.field("suggest_mode", _))
+      generator.maxEdits.foreach(builder.field("max_edits", _))
+      generator.prefixLength.foreach(builder.field("prefix_length", _))
+      generator.minWordLength.foreach(builder.field("min_word_length", _))
+      generator.maxInspections.foreach(builder.field("max_inspections", _))
+      generator.minDocFreq.foreach(builder.field("min_doc_freq", _))
+      generator.maxTermFreq.foreach(builder.field("max_term_freq", _))
+      generator.preFilter.foreach(builder.field("pre_filter", _))
+      generator.postFilter.foreach(builder.field("post_filter", _))
       builder.endObject()
     }
     builder.endArray()

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
@@ -818,7 +818,7 @@ class SearchDslTest extends FlatSpec with MockitoSugar with JsonSugar with OneIn
   it should "generate correct json for suggestions of multiple suggesters" in {
     val req = search("music") types "bands" query termQuery("name", "coldplay") suggestions(
       termSuggestion("suggestion-term") on "name" text "culdpaly" maxEdits 2,
-      phraseSuggestion("suggestion-phrase") on "name" text "aqualuck by jethro toll" maxErrors 1.0f addDirectGenerator DirectGenerator("fieldName", 3, 0),
+      phraseSuggestion("suggestion-phrase") on "name" text "aqualuck by jethro toll" maxErrors 1.0f addDirectGenerator DirectGenerator(field = "fieldName", minWordLength = Some(3), prefixLength = Some(0)),
       completionSuggestion("suggestion-completion") on "ac" text "cold"
     )
     req.request.entity.get.get should matchJsonResource("/json/search/search_suggestions_multiple_suggesters.json")


### PR DESCRIPTION
We need to be able to set the suggest_mode for a phrase suggestor. And since there were more fields missing I took the liberty to add them all.