### PR TITLE
Only generate collate if needed

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/suggs/PhraseSuggestionBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/suggs/PhraseSuggestionBuilderFn.scala
@@ -45,18 +45,23 @@ object PhraseSuggestionBuilderFn {
     builder.endArray()
     // END DIRECT GENERATOR
 
-    //COLLATE
-    builder.startObject("collate")
+    phrase.collateQuery match {
+      case None =>
+      case Some(query) => {
+        //COLLATE
+        builder.startObject("collate")
 
-    builder.startObject("query")
-    phrase.collateQuery.foreach(t => builder.rawField(t.scriptType.toString.toLowerCase, t.script))
-    builder.endObject()
+        builder.startObject("query")
+        phrase.collateQuery.foreach(t => builder.rawField(t.scriptType.toString.toLowerCase, t.script))
+        builder.endObject()
 
-    phrase.collatePrune.foreach(builder.field("prune", _))
-    builder.rawField("params", SourceAsContentBuilder(phrase.collateParams))
+        phrase.collatePrune.foreach(builder.field("prune", _))
+        builder.rawField("params", SourceAsContentBuilder(phrase.collateParams))
 
-    builder.endObject()
-    //END COLLATE
+        builder.endObject()
+        //END COLLATE
+      }
+    }
 
     //highlight
     builder.startObject("highlight")

--- a/elastic4s-tests/src/test/resources/json/search/search_suggestions_multiple_suggesters.json
+++ b/elastic4s-tests/src/test/resources/json/search/search_suggestions_multiple_suggesters.json
@@ -22,14 +22,10 @@
                 "direct_generator": [
                     {
                         "field": "fieldName",
-                        "min_word_length": 3,
-                        "prefix_length": 0
+                        "prefix_length": 0,
+                        "min_word_length": 3
                     }
                 ],
-                "collate": {
-                    "query": {},
-                    "params": {}
-                },
                 "highlight": {}
             }
         },


### PR DESCRIPTION
When not providing values for the collate function an empty block gets created like this:
"collate": {
  "query":{}
}
Which results in deprecation errors: _must specify either [source] for an inline script or [id] for a stored script_
This pr omits the collate block if not explicitly needed.