### PR TITLE
Support HighlightOptions at the level of a nested query

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/queries/InnerHit.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/queries/InnerHit.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.elastic4s.searches.queries
 
 import com.sksamuel.elastic4s.FetchSourceContext
-import com.sksamuel.elastic4s.searches.HighlightField
+import com.sksamuel.elastic4s.searches.{Highlight, HighlightField, HighlightOptions}
 import com.sksamuel.elastic4s.searches.sort.Sort
 import com.sksamuel.exts.OptionImplicits._
 
@@ -15,14 +15,22 @@ case class InnerHit(name: String,
                     docValueFields: Seq[String] = Nil,
                     sorts: Seq[Sort] = Nil,
                     from: Option[Int] = None,
-                    highlights: Seq[HighlightField] = Nil) {
+                    highlight: Option[Highlight] = None) {
 
   def sortBy(sorts: Sort*): InnerHit          = sortBy(sorts)
   def sortBy(sorts: Iterable[Sort]): InnerHit = copy(sorts = sorts.toSeq)
 
-  def highlighting(highlights: HighlightField*): InnerHit = highlighting(highlights)
-  def highlighting(highlights: Iterable[HighlightField]): InnerHit =
-    copy(highlights = highlights.toSeq)
+  def highlighting(first: HighlightField, rest: HighlightField*): InnerHit =
+    highlighting(HighlightOptions(), first +: rest)
+
+  def highlighting(fields: Iterable[HighlightField]): InnerHit =
+    highlighting(HighlightOptions(), fields)
+
+  def highlighting(options: HighlightOptions, first: HighlightField, rest: HighlightField*): InnerHit =
+    highlighting(options, first +: rest)
+
+  def highlighting(options: HighlightOptions, fields: Iterable[HighlightField]): InnerHit =
+    copy(highlight = Highlight(options, fields).some)
 
   def trackScores(trackScores: Boolean): InnerHit            = copy(trackScores = trackScores.some)
   def version(version: Boolean): InnerHit                    = copy(version = version.some)

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/nested/InnerHitQueryBodyFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/nested/InnerHitQueryBodyFn.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.elastic4s.http.search.queries.nested
 
 import com.sksamuel.elastic4s.http.FetchSourceContextBuilderFn
-import com.sksamuel.elastic4s.http.search.HighlightFieldBuilderFn
+import com.sksamuel.elastic4s.http.search.HighlightBuilderFn
 import com.sksamuel.elastic4s.http.search.queries.SortBuilderFn
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 import com.sksamuel.elastic4s.searches.queries.InnerHit
@@ -32,14 +32,9 @@ object InnerHitQueryBodyFn {
     }
     if (d.storedFieldNames.nonEmpty)
       builder.array("stored_fields", d.storedFieldNames.toArray)
-    if (d.highlights.nonEmpty) {
-      builder.startObject("highlight")
-      builder.startObject("fields")
-      d.highlights.foreach { field =>
-        builder.rawField(field.field, HighlightFieldBuilderFn(field))
-      }
-      builder.endObject()
-      builder.endObject()
+
+    d.highlight.foreach { highlight =>
+      builder.rawField("highlight", HighlightBuilderFn(highlight))
     }
     builder.endObject()
   }

--- a/elastic4s-tests/src/test/resources/json/search/search_query_nested_inner_highlight.json
+++ b/elastic4s-tests/src/test/resources/json/search/search_query_nested_inner_highlight.json
@@ -18,6 +18,12 @@
                 "name": "obj1",
                 "size": 6,
                 "highlight": {
+                    "post_tags": [
+                        "</b>"
+                    ],
+                    "pre_tags": [
+                        "<b>"
+                    ],
                     "fields": {
                         "name": {
                             "fragment_size": 20

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
@@ -853,7 +853,10 @@ class SearchDslTest extends FlatSpec with MockitoSugar with JsonSugar with OneIn
           termQuery("name", "sammy")
         }
       } scoreMode "avg" inner
-        innerHits("obj1").size(6).highlighting(highlight("name").fragmentSize(20))
+        innerHits("obj1").size(6).highlighting(
+          highlightOptions().preTags("<b>").postTags("</b>"),
+          highlight("name").fragmentSize(20)
+        )
     }
     req.request.entity.get.get should matchJsonResource("/json/search/search_query_nested_inner_highlight.json")
   }


### PR DESCRIPTION
* Support using `HighlightOptions` at the level of a nested query.
* Unify how highlighting is defined on a `SearchRequest` and on an `InnerHit` respectively.