### PR TITLE
Debug ScoreMode.scala

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/ScoreMode.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/ScoreMode.scala
@@ -14,7 +14,9 @@ object ScoreMode {
 
   case object Avg   extends ScoreMode
   case object Max   extends ScoreMode
-  case object Total extends ScoreMode
+  case object Total extends ScoreMode {
+    override def toString: String = "sum"
+  }
   case object Min   extends ScoreMode
   case object None  extends ScoreMode
   case object Sum   extends ScoreMode


### PR DESCRIPTION
ScoreMode.Total is a Lucene constant, it corresponds to sum score mode in Elasticsearch documentation and HTTP API.

https://github.com/elastic/elasticsearch/blob/20e1b5e2fe3e7319e2c908657e484bb49bbf11d7/server/src/main/java/org/elasticsearch/index/query/NestedQueryBuilder.java#L229