### PR TITLE
fix a warning when using RandomScoreFunction

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/queries/funcscorer/RandomScoreFunction.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/queries/funcscorer/RandomScoreFunction.scala
@@ -3,9 +3,10 @@ package com.sksamuel.elastic4s.searches.queries.funcscorer
 import com.sksamuel.elastic4s.searches.queries.Query
 import com.sksamuel.exts.OptionImplicits._
 
-case class RandomScoreFunction(seed: Long, weight: Option[Double] = None, override val filter: Option[Query] = None)
+case class RandomScoreFunction(seed: Long, fieldName: String = "_seq_no", weight: Option[Double] = None, override val filter: Option[Query] = None)
     extends ScoreFunction {
 
+  def fieldName(fieldName: String): RandomScoreFunction = copy(fieldName = fieldName)
   def weight(weight: Double): RandomScoreFunction = copy(weight = weight.some)
   def filter(filter: Query): RandomScoreFunction  = copy(filter = filter.some)
 }

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/specialized/GaussianDecayScoreBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/specialized/GaussianDecayScoreBuilderFn.scala
@@ -28,6 +28,7 @@ object RandomScoreFunctionBuilderFn {
     val builder = XContentFactory.jsonBuilder()
     builder.startObject("random_score")
     builder.field("seed", r.seed)
+    builder.field("field", r.fieldName)
     builder.endObject()
     r.filter.foreach(filter => builder.rawField("filter", QueryBuilderFn.apply(filter)))
     builder

--- a/elastic4s-http/src/test/resources/score_random.json
+++ b/elastic4s-http/src/test/resources/score_random.json
@@ -1,5 +1,6 @@
 {
     "random_score": {
-        "seed": 12345
+        "seed": 12345,
+        "field": "_seq_no"
     }
 }

--- a/elastic4s-tests/src/test/resources/json/search/search_function_score.json
+++ b/elastic4s-tests/src/test/resources/json/search/search_function_score.json
@@ -14,7 +14,8 @@
             "functions": [
                 {
                     "random_score": {
-                        "seed": 1234
+                        "seed": 1234,
+                        "field": "_seq_no"
                     }
                 },
                 {


### PR DESCRIPTION
fix the warning "As of version 7.0 Elasticsearch will require that a [field] parameter is provided when a [seed] is set"
when using RandomScoreFunction