### PR TITLE
Correct phrase suggestion 'max_errors' field name

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/SearchBodyBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/SearchBodyBuilderFn.scala
@@ -135,7 +135,7 @@ object SearchBodyBuilderFn {
           phrase.confidence.foreach(builder.field("confidence", _))
           phrase.forceUnigrams.foreach(builder.field("force_unigrams", _))
           phrase.gramSize.foreach(builder.field("gram_size", _))
-          phrase.maxErrors.foreach(builder.field("max_error", _))
+          phrase.maxErrors.foreach(builder.field("max_errors", _))
           phrase.realWordErrorLikelihood.foreach(builder.field("real_word_error_likelihood", _))
           phrase.separator.foreach(builder.field("separator", _))
           phrase.tokenLimit.foreach(builder.field("token_limit", _))


### PR DESCRIPTION
This PR updates the building of a phrase suggestion query string to use the correct field name "max_errors" instead of "max_error", as specified in the Elasticsearch v5.6 documentation: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-suggesters-phrase.html

I'm aware that this was corrected in a 6.x release, but this allows the issue to be fixed for integration with 5.x Elasticsearch clusters.