### PR TITLE
Manage null value in top hits aggregation response

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/responses.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/responses.scala
@@ -55,14 +55,14 @@ case class SearchHit(@JsonProperty("_id") id: String,
       val v = hits("hits").asInstanceOf[Map[String, AnyRef]]
       InnerHits(
         total = v("total").toString.toLong,
-        maxScore = v("max_score").asInstanceOf[Double],
+        maxScore = Option(v("max_score")).map(_.toString.toDouble),
         hits = v("hits").asInstanceOf[Seq[Map[String, AnyRef]]].map { hits =>
           InnerHit(
             index = hits("_index").toString,
             `type` = hits("_type").toString,
             id = hits("_id").toString,
             nested = hits.get("_nested").map(_.asInstanceOf[Map[String, AnyRef]]).getOrElse(Map.empty),
-            score = hits("_score").asInstanceOf[Double],
+            score = Option(hits("_score")).map(_.toString.toDouble),
             routing = hits.get("_routing").map(_.toString).getOrElse(""),
             source = hits.get("_source").map(_.asInstanceOf[Map[String, AnyRef]]).getOrElse(Map.empty),
             innerHits = buildInnerHits(hits.getOrElse("inner_hits", null).asInstanceOf[Map[String, Map[String, Any]]]),
@@ -86,7 +86,7 @@ case class SearchHits(total: Long,
 }
 
 case class InnerHits(total: Long,
-                     @JsonProperty("max_score") maxScore: Double,
+                     @JsonProperty("max_score") maxScore: Option[Double],
                      hits: Seq[InnerHit]) {
   def size: Long = hits.length
   def isEmpty: Boolean = hits.isEmpty
@@ -97,7 +97,7 @@ case class InnerHit(index: String,
                     `type`: String,
                     id: String,
                     nested: Map[String, AnyRef],
-                    score: Double,
+                    score: Option[Double],
                     routing: String,
                     source: Map[String, AnyRef],
                     innerHits: Map[String, InnerHits],

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/InnerHitTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/InnerHitTest.scala
@@ -38,14 +38,14 @@ class InnerHitTest extends WordSpec with Matchers with DockerTests {
       result.hits.hits.head.innerHits shouldBe Map(
         "myinner" -> InnerHits(
           1,
-          1.0,
+          Some(1.0),
           List(
             com.sksamuel.elastic4s.http.search.InnerHit(
               indexName,
               "football",
               "2",
               Map.empty,
-              1.0,
+              Some(1.0),
               "1",
               Map("name" -> "traore", "affiliation" -> Map("name" -> "player", "parent" -> "1")),
               Map.empty,


### PR DESCRIPTION
Same as https://github.com/sksamuel/elastic4s/pull/1528
Doc for 6.4 still show that _score and max_score can be null: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-top-hits-aggregation.html

BTW, could you create a new release for branch 5.6.X please?