### PR TITLE
Fix boundary_chars property in HighlightOptions

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/HighlightBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/HighlightBuilderFn.scala
@@ -10,7 +10,6 @@ object HighlightBuilderFn {
 
     val builder = XContentFactory.obj()
 
-    highlight.options.encoder.foreach(builder.field("boundary_chars", _))
     highlight.options.boundaryScanner.foreach(builder.field("boundary_scanner", _))
     highlight.options.boundaryScannerLocale.foreach(builder.field("boundary_scanner_locale", _))
     highlight.options.boundaryChars.foreach(chars => builder.field("boundary_chars", String.valueOf(chars)))


### PR DESCRIPTION
In https://github.com/sksamuel/elastic4s/pull/1450 I already removed two lines that incorrectly use the value of the `encoder` field to set the `boundary_chars` property in the highlight options... However I missed that this exact same line was used a third time in the same file...

This remaining incorrect line only affected cases were `encoder` is specified in the `HighlightOptions` but `boundaryChars` is not specified. That's why it was not caught by the unit test.