### PR TITLE
GetMapping to handle error in 6.2.x

### DIFF
--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/mappings/MappingHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/mappings/MappingHttpTest.scala
@@ -67,5 +67,14 @@ class MappingHttpTest extends WordSpec with DockerTests with Matchers {
 
       properties shouldBe Map.empty
     }
+
+    "handle error response" in {
+      val result = http.execute {
+        getMapping("nonexistent" / "mapping2")
+      }.await
+
+      result.isLeft shouldBe true
+      result.left.get.error.`type` shouldBe "index_not_found_exception"
+    }
   }
 }


### PR DESCRIPTION
This is a backport of #1422 to 6.2.x. Fixes #1513 