### PR TITLE
Generate `unit` field for geo distance sort

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/EnumConversions.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/EnumConversions.scala
@@ -1,6 +1,7 @@
 package com.sksamuel.elastic4s.http
 
-import com.sksamuel.elastic4s.VersionType
+import com.sksamuel.elastic4s.{VersionType, DistanceUnit}
+import com.sksamuel.elastic4s.DistanceUnit.{Inch, Yard, Feet, Kilometers, NauticalMiles, Millimeters, Centimeters, Miles, Meters}
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 import com.sksamuel.elastic4s.searches.QueryRescoreMode.{Avg, Max, Min, Multiply, Total}
 import com.sksamuel.elastic4s.searches.aggs.{HistogramOrder, SubAggCollectionMode, TermsOrder}
@@ -43,6 +44,18 @@ object EnumConversions {
   def geoDistance(distance: GeoDistance): String = distance match {
     case Arc   => "arc"
     case Plane => "plane"
+  }
+
+  def unit(distanceUnit: DistanceUnit): String = distanceUnit match {
+    case Inch          => "in"
+    case Yard          => "yd"
+    case Feet          => "ft"
+    case Kilometers    => "km"
+    case NauticalMiles => "nmi"
+    case Millimeters   => "mm"
+    case Centimeters   => "cm"
+    case Miles         => "mi"
+    case Meters        => "m"
   }
 
   def order(order: TermsOrder): XContentBuilder = {

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/GeoDistanceAggregationBuilder.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/aggs/GeoDistanceAggregationBuilder.scala
@@ -1,10 +1,9 @@
 package com.sksamuel.elastic4s.http.search.aggs
 
-import com.sksamuel.elastic4s.DistanceUnit._
+import com.sksamuel.elastic4s.http.EnumConversions
 import com.sksamuel.elastic4s.http.ScriptBuilderFn
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 import com.sksamuel.elastic4s.searches.aggs.GeoDistanceAggregation
-import com.sksamuel.elastic4s.searches.queries.geo.GeoDistance
 
 object GeoDistanceAggregationBuilder {
   def apply(agg: GeoDistanceAggregation): XContentBuilder = {
@@ -23,26 +22,8 @@ object GeoDistanceAggregationBuilder {
     agg.missing.foreach(builder.autofield("missing", _))
     agg.keyed.foreach(builder.field("keyed", _))
 
-    agg.distanceType
-      .map {
-        case GeoDistance.Arc   => "arc"
-        case GeoDistance.Plane => "plane"
-      }
-      .foreach(builder.field("distance_type", _))
-
-    agg.unit
-      .map {
-        case INCH          => "in"
-        case YARD          => "yd"
-        case FEET          => "ft"
-        case KILOMETERS    => "km"
-        case NAUTICALMILES => "nmi"
-        case MILLIMETERS   => "mm"
-        case CENTIMETERS   => "cm"
-        case MILES         => "mi"
-        case METERS        => "m"
-      }
-      .foreach(builder.field("unit", _))
+    agg.distanceType.map(EnumConversions.geoDistance).foreach(builder.field("distance_type", _))
+    agg.unit.map(EnumConversions.unit).foreach(builder.field("unit", _))
 
     agg.script.foreach { script =>
       builder.rawField("script", ScriptBuilderFn(script))

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/SortBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/SortBuilderFn.scala
@@ -59,6 +59,7 @@ object GeoDistanceSortBuilderFn {
     geo.geoDistance.map(EnumConversions.geoDistance).foreach(builder.field("distance_type", _))
     geo.sortMode.map(EnumConversions.sortMode).foreach(builder.field("mode", _))
     geo.order.map(o => builder.field("order", EnumConversions.order(o)))
+    geo.unit.map(EnumConversions.unit).foreach(builder.field("unit", _))
     geo.nestedPath.foreach(builder.field("nested_path", _))
     geo.nestedFilter.map(QueryBuilderFn.apply).map(_.string).foreach(builder.rawField("nested_filter", _))
 

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/SearchBodyBuilderFnTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/SearchBodyBuilderFnTest.scala
@@ -51,6 +51,6 @@ class SearchBodyBuilderFnTest extends FunSuite with Matchers {
     )
 
     SearchBodyBuilderFn(req).string shouldBe
-      """{"query":{"geo_distance":{"distance":"100km","location":[-79.38871,43.65435]}},"size":100,"sort":[{"_geo_distance":{"location":[[-79.38871,43.65435]],"order":"asc"}}]}"""
+      """{"query":{"geo_distance":{"distance":"100km","location":[-79.38871,43.65435]}},"size":100,"sort":[{"_geo_distance":{"location":[[-79.38871,43.65435]],"order":"asc","unit":"km"}}]}"""
   }
 }

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/SortBuilderFnTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/SortBuilderFnTest.scala
@@ -27,5 +27,26 @@ class SortBuilderFnTest extends FunSuite with Matchers {
     SortBuilderFn(request).string() shouldBe
       """{"_script":{"script":{"source":"dummy script","lang":"painless","params":{"nump":10.2,"stringp":"ciao","boolp":true}},"type":"number","order":"desc"}}"""
   }
+
+  test("geo distance sort does not generate unit field by default") {
+    val sort = GeoDistanceSort(
+      field = "location",
+      points = Seq(GeoPoint(43.65435, -79.38871))
+    )
+
+    SortBuilderFn(sort).string() shouldBe
+      """{"_geo_distance":{"location":[[-79.38871,43.65435]]}}"""
+  }
+
+  test("geo distance sort generates unit field when informed") {
+    val sort = GeoDistanceSort(
+      field = "location",
+      points = Seq(GeoPoint(43.65435, -79.38871)),
+      unit = Some(DistanceUnit.Kilometers)
+    )
+
+    SortBuilderFn(sort).string() shouldBe
+      """{"_geo_distance":{"location":[[-79.38871,43.65435]],"unit":"km"}}"""
+  }
 }
 


### PR DESCRIPTION
When the `DistanceUnit` is specified in the `GeoDistanceSort`, the `GeoDistanceSortBuilderFn` should use it to generate the `unit` field.

Ref:
https://www.elastic.co/guide/en/elasticsearch/reference/6.3/search-request-sort.html#geo-sorting
https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#distance-units
