### PR TITLE
Fixed bug with extra zero bytes

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/span/SpanNearQueryBodyFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/span/SpanNearQueryBodyFn.scala
@@ -11,9 +11,7 @@ object SpanNearQueryBodyFn {
 
     builder.startObject()
     builder.startObject("span_near")
-    builder.startArray("clauses")
-    builder.rawArrayValue(q.clauses.map(QueryBuilderFn.apply))
-    builder.endArray()
+    builder.addArray("clauses", q.clauses.map(QueryBuilderFn.apply))
 
     builder.field("slop", q.slop)
     q.inOrder.foreach(builder.field("in_order", _))

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/span/SpanOrQueryBodyFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/span/SpanOrQueryBodyFn.scala
@@ -11,9 +11,7 @@ object SpanOrQueryBodyFn {
 
     builder.startObject()
     builder.startObject("span_or")
-    builder.startArray("clauses")
-    builder.rawArrayValue(q.clauses.map(QueryBuilderFn.apply))
-    builder.endArray()
+    builder.addArray("clauses", q.clauses.map(QueryBuilderFn.apply))
 
     q.boost.foreach(builder.field("boost", _))
     q.queryName.foreach(builder.field("_name", _))

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/span/XContentBuilderExtensions.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/span/XContentBuilderExtensions.scala
@@ -1,51 +1,18 @@
 package com.sksamuel.elastic4s.http.search.queries.span
 
 import org.elasticsearch.common.bytes.BytesArray
-import org.elasticsearch.common.xcontent.XContentBuilder
+import org.elasticsearch.common.xcontent.{XContentBuilder, XContentType}
 
 object XContentBuilderExtensions {
-  private val CommaByte: Byte = ','
 
   implicit class RichXContentBuilder(builder: XContentBuilder) {
-    /**
-      * Default XContentFactory.rawValue method does not add comma symbol between array elements.
-      * This is low level workaround method to insert comma byte between array elements bytes.
-      *
-      * NOTE: we can't do builder.rawValue(SINGLE_COMMA_BYTE) so we first need to build entire array object in memory.
-      * NOTE: intentionally using low level methods to obtain max speed.
-      *
-      * @return original builder
-      */
-    def rawArrayValue(arrayObjects: Seq[XContentBuilder]): XContentBuilder = {
-      val elementsBytes: List[Array[Byte]] = arrayObjects.map(_.bytes.toBytesRef.bytes).toList
-
-      elementsBytes match {
-        case Nil =>
-        case head :: tail =>
-          val resultBytes = allocateResultByteArray(elementsBytes)
-          var currentDistPos = copyInternal(head, resultBytes, 0)
-          tail.foreach(bytes => {
-            resultBytes(currentDistPos) = CommaByte
-            currentDistPos += 1
-            currentDistPos += copyInternal(bytes, resultBytes, currentDistPos)
-          })
-          builder.rawValue(new BytesArray(resultBytes))
-      }
-
-      builder
+    def addArray(arrayField: String, elements: Seq[XContentBuilder]): XContentBuilder = {
+      builder.startArray(arrayField)
+      val elementsRawString = elements.map(_.string).mkString(",")
+      builder.rawValue(new BytesArray(elementsRawString), XContentType.JSON)
+      builder.endArray()
     }
   }
 
-  private def copyInternal(src: Array[Byte], dist: Array[Byte], distPos: Int): Int = {
-    val srcLength = src.length
-    System.arraycopy(src, 0, dist, distPos, srcLength)
-    srcLength
-  }
-
-  private def allocateResultByteArray(elementsBytes: Seq[Array[Byte]]) = {
-    val commasCount = elementsBytes.size - 1
-    val totalBufferSize = elementsBytes.map(_.length).sum + commasCount
-    new Array[Byte](totalBufferSize)
-  }
 }
 

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/span/XContentBuilderExtensionsTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/span/XContentBuilderExtensionsTest.scala
@@ -3,54 +3,72 @@ package com.sksamuel.elastic4s.http.search.queries.span
 import com.sksamuel.elastic4s.http.search.queries.span.XContentBuilderExtensions._
 import org.elasticsearch.common.xcontent.{XContentBuilder, XContentFactory}
 import org.scalatest.FunSuite
+import org.scalatest.Matchers._
 
 import scala.util.parsing.json.JSON
 
 class XContentBuilderExtensionsTest extends FunSuite {
 
-  test("RichXContentBuilder.rawArrayValue should write not write bytes for empty array") {
+  test("RichXContentBuilder.addArray should not write bytes for empty array") {
     val builder = XContentFactory.jsonBuilder()
-    builder.startArray()
-    builder.rawArrayValue(Seq())
-    builder.endArray()
+    builder.startObject()
+    builder.addArray("arrayField", Seq())
+    builder.endObject()
 
     val actual = JSON.parseRaw(builder.string())
-    val expected = JSON.parseRaw("""[]""")
+    val expected = JSON.parseRaw("""{"arrayField": []}""")
     assert(actual === expected)
   }
 
-  test("RichXContentBuilder.rawArrayValue should write bytes array with one element") {
+  test("RichXContentBuilder.addArray should write bytes array with one element") {
     val builder = XContentFactory.jsonBuilder()
-    builder.startArray()
-    builder.rawArrayValue(Seq(getSimpleObject("f1", "v1")))
-    builder.endArray()
+    builder.startObject()
+    builder.addArray("arrayField", Seq(buildSimpleObject("f1", "v1")))
+    builder.endObject()
 
     val actual = JSON.parseRaw(builder.string())
-    val expected = JSON.parseRaw("""[{"f1": "v1"}]""")
+    val expected = JSON.parseRaw("""{"arrayField": [{"f1": "v1"}]}""")
     assert(actual === expected)
   }
 
-  test("RichXContentBuilder.rawArrayValue should write bytes array many elements") {
+  test("RichXContentBuilder.addArray should write bytes array with many elements") {
     val builder = XContentFactory.jsonBuilder()
-    builder.startArray()
-    builder.rawArrayValue(Seq(
-      getSimpleObject("f1", "v1"),
-      getSimpleObject("f2", "v2"),
-      getSimpleObject("f3", "v3")
+    builder.startObject()
+    builder.addArray("arrayField", Seq(
+      buildSimpleObject("f1", "v1"),
+      buildSimpleObject("f2", "v2"),
+      buildSimpleObject("f3", "v3")
     ))
-    builder.endArray()
+    builder.endObject()
 
     val actual = JSON.parseRaw(builder.string())
     val expected = JSON.parseRaw(
-      """[
-        |   {"f1": "v1"},
-        |   {"f2": "v2"},
-        |   {"f3": "v3"}
-        |]""".stripMargin)
+      """{
+        |  "arrayField": [
+        |    {"f1": "v1"},
+        |    {"f2": "v2"},
+        |    {"f3": "v3"}
+        |  ]
+        |}""".stripMargin)
     assert(actual === expected)
   }
 
-  private def getSimpleObject(field: String, value: String): XContentBuilder = {
+  test("RichXContentBuilder.addArray should not write extra zero bytes between/after comma character, because ES fails to handle them") {
+    val builder = XContentFactory.jsonBuilder()
+    builder.startObject()
+    builder.addArray("arrayField", Seq(
+      buildSimpleObject("f1", "v1"),
+      buildSimpleObject("f2", "v2"),
+      buildSimpleObject("f3", "v3")
+    ))
+    builder.endObject()
+
+    val result = builder.string()
+    result should not contain '\u0000'
+    result shouldBe """{"arrayField":[{"f1":"v1"},{"f2":"v2"},{"f3":"v3"}]}"""
+  }
+
+  private def buildSimpleObject(field: String, value: String): XContentBuilder = {
     XContentFactory.jsonBuilder().startObject().field(field, value).endObject()
   }
 }


### PR DESCRIPTION
Fixed bug with extra zero bytes, simplified logic of building array fields (for near queries), removed low level code, added critical tests for XContentBuilderExtensions

refers to https://github.com/sksamuel/elastic4s/issues/1535