### PR TITLE
Fix travis build for scala 2.12 on 1.5.x branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: scala
 scala:
-- 2.11.6
+- 2.11.12
+- 2.12.7
 script:
 - sbt clean test
 jdk:
-- oraclejdk7
-- openjdk7
+- oraclejdk8
+- openjdk8
 env:
   secure: N6nYcHF+gT+zMkSImnLzGADt3UfKHS2ihfClDLrwLbEqswS+MaOWUpIxgg/THeWlGMZ94oV0zK9OTOlZXcG7c4Af4BRzm8ydQqCCm4C+kCzvfDFpnSB4601VewHAD41Fx7GSxxANSs5IIE0Y6L0pns9zhGpfupkh9kXNySnT/uQ=

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -25,7 +25,7 @@ object Build extends AutoPlugin {
   override val projectSettings = Seq(
     organization := org,
     scalaVersion := ScalaVersion,
-    crossScalaVersions := Seq("2.12.6", "2.11.12"),
+    crossScalaVersions := Seq("2.12.7", "2.11.12"),
     resolvers += Resolver.mavenLocal,
     resolvers += Resolver.url("https://artifacts.elastic.co/maven"),
     publishMavenStyle := true,


### PR DESCRIPTION
Heya, I'm a colleague of @sebastiaansamyn-tc and this is a follow-up on #1381 - it seems that building the 1.5 branch for scala 2.12 on travis is failing. There was no config for cross-compiling in .travis.yml and it should build with JDK8, not 7. I've also bumped scalaversion to 2.12.7 from 2.12.6