### PR TITLE
Added Elasticsearch common analyzers to elastic4s-embedded local node

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,12 +51,13 @@ lazy val embedded = Project("elastic4s-embedded", file("elastic4s-embedded"))
   .settings(
     name := "elastic4s-embedded",
     libraryDependencies ++= Seq(
-      "org.elasticsearch"                % "elasticsearch"            % ElasticsearchVersion,
-      "org.elasticsearch.client"         % "transport"                % ElasticsearchVersion,
-      "com.carrotsearch"                 % "hppc"                     % "0.7.1",
-      "joda-time"                        % "joda-time"                % "2.9.9",
-      "com.fasterxml.jackson.dataformat" % "jackson-dataformat-smile" % JacksonVersion,
-      "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor"  % JacksonVersion
+      "org.elasticsearch"                 % "elasticsearch"            % ElasticsearchVersion,
+      "org.elasticsearch.client"          % "transport"                % ElasticsearchVersion,
+      "org.codelibs.elasticsearch.module" % "analysis-common"          % ElasticsearchVersion,
+      "com.carrotsearch"                  % "hppc"                     % "0.7.1",
+      "joda-time"                         % "joda-time"                % "2.9.9",
+      "com.fasterxml.jackson.dataformat"  % "jackson-dataformat-smile" % JacksonVersion,
+      "com.fasterxml.jackson.dataformat"  % "jackson-dataformat-cbor"  % JacksonVersion
 //"org.locationtech.spatial4j" % "spatial4j"               % "0.6",
 //"com.vividsolutions"         % "jts"                     % "1.13",
 //"io.netty"                   % "netty-all"               % "4.1.10.Final",

--- a/elastic4s-embedded/src/main/scala/com/sksamuel/elastic4s/embedded/LocalNode.scala
+++ b/elastic4s-embedded/src/main/scala/com/sksamuel/elastic4s/embedded/LocalNode.scala
@@ -5,6 +5,7 @@ import java.nio.file.{Path, Paths}
 
 import com.sksamuel.elastic4s.http.{ElasticClient, HttpClient}
 import com.sksamuel.exts.Logging
+import org.elasticsearch.analysis.common.CommonAnalysisPlugin
 import org.elasticsearch.common.settings.Settings
 import org.elasticsearch.index.reindex.ReindexPlugin
 import org.elasticsearch.node.{InternalSettingsPreparer, Node}
@@ -14,7 +15,6 @@ import org.elasticsearch.script.mustache.MustachePlugin
 import org.elasticsearch.transport.Netty4Plugin
 
 import scala.collection.JavaConverters._
-import scala.concurrent.Future
 import scala.util.Try
 
 trait LocalNode {
@@ -143,7 +143,7 @@ object LocalNode {
     require(settings.get("path.repo") != null)
 
     val plugins =
-      List(classOf[Netty4Plugin], classOf[MustachePlugin], classOf[PercolatorPlugin], classOf[ReindexPlugin])
+      List(classOf[Netty4Plugin], classOf[MustachePlugin], classOf[PercolatorPlugin], classOf[ReindexPlugin], classOf[CommonAnalysisPlugin])
 
     val mergedSettings = Settings
       .builder()


### PR DESCRIPTION
Elasticsearch built-in analyzers were moved into an Elasticsearch plugin: analysis-common.
If this plugin is not registered by LocalNode testing indexes using built-in analyzers with elastic4s-embedded is not possible.