### PR TITLE
Optimized http bulk api by lazy logging and eliminating unnecessary memory allocations abd GC cycles

### DIFF
--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/bulk/BulkImplicitsTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/bulk/BulkImplicitsTest.scala
@@ -1,0 +1,28 @@
+package com.sksamuel.elastic4s.http.bulk
+
+import com.sksamuel.elastic4s.IndexAndType
+import com.sksamuel.elastic4s.bulk.{BulkCompatibleDefinition, BulkDefinition}
+import com.sksamuel.elastic4s.http.testutils.StringExtensions.StringOps
+import com.sksamuel.elastic4s.indexes.IndexDefinition
+import org.scalatest.Matchers.convertToAnyShouldWrapper
+import org.scalatest.{FlatSpec, FunSuite}
+
+class BulkImplicitsTest extends FlatSpec with BulkImplicits {
+
+  it should "build bulk definition http body" in {
+    val bulkDefinition: BulkDefinition = BulkDefinition(Seq(
+      IndexDefinition(IndexAndType("my_index1", "my_type1"), source = Some("""{"field1":"value1"}""")),
+      IndexDefinition(IndexAndType("my_index2", "my_type2"), source = Some("""{"field2":"value2"}"""))
+    ))
+
+    val expected =
+      """{"index":{"_index":"my_index1","_type":"my_type1"}}
+        |{"field1":"value1"}
+        |{"index":{"_index":"my_index2","_type":"my_type2"}}
+        |{"field2":"value2"}
+        |""".stripMargin.withUnixLineEndings
+
+    BulkExecutable.buildBulkHttpBody(bulkDefinition) shouldBe expected
+  }
+
+}

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/testutils/StringExtensions.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/testutils/StringExtensions.scala
@@ -1,0 +1,17 @@
+package com.sksamuel.elastic4s.http.testutils
+
+object StringExtensions {
+  private val LineEndingRegex = s"""(\r\n|\n)"""
+
+  private val WindowsLE = "\r\n"
+  private val UnixLE = "\n"
+
+  implicit class StringOps(val target: String) extends AnyVal {
+    def withWindowsLineEndings: String = target.replaceAll(LineEndingRegex, WindowsLE)
+
+    def withUnixLineEndings: String = target.replaceAll(LineEndingRegex, UnixLE)
+
+    def withoutSpaces: String = target.replaceAll("\\s+", "")
+  }
+
+}

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/testutils/StringExtensionsTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/testutils/StringExtensionsTest.scala
@@ -1,0 +1,17 @@
+package com.sksamuel.elastic4s.http.testutils
+
+import com.sksamuel.elastic4s.http.testutils.StringExtensions.StringOps
+import org.scalatest.Matchers.convertToAnyShouldWrapper
+import org.scalatest.{FlatSpec, FunSuite}
+
+class StringExtensionsTest extends FlatSpec {
+
+  it should "convert line endings to Windows style" in {
+    "one\r\ntwo\nthree\n".withWindowsLineEndings shouldBe  "one\r\ntwo\r\nthree\r\n"
+  }
+
+  it should "convert line endings to Unix style" in {
+    "one\r\ntwo\nthree\r\n".withUnixLineEndings shouldBe "one\ntwo\nthree\n"
+  }
+
+}


### PR DESCRIPTION
In the current implementation of HTTP bulk API ther is quite a havy and unoptimized place in class
```com.sksamuel.elastic4s.http.bulk.BulkImplicits.BulkExecutable```:
```scala
val rows = BulkContentBuilder(bulk)
logger.debug(s"Bulk entity: ${rows.mkString("\n")}")
// es seems to require a trailing new line as well
val entity = new StringEntity(rows.mkString("\n") + "\n", ContentType.APPLICATION_JSON)
```
I would like to point out that bulk API should be considered with a certain care since we talk about `O(N)` memory usage.

Let's say that we have a bulk of N elements and the total size of JSONs is ~100Mb.
(The question of what bulk size  in elements/bytes is out of scope).
```BulkDefinition.requests``` will contain those ~100Mb bulk (eg. in ```IndexDefinition.source``` fields)
```val rows = BulkContentBuilder(bulk)``` will also contain ~100Mb rows
first ```rows.mkString("\n")``` (during logging) will allocate another ~100Mb.
When it is interpolated inside the string (during logging) it will allocate another ~100Mb
line ```new StringEntity(rows.mkString("\n") + "\n"``` will require extra 3 * 100Mb = 300mb (including mem copy inside StringEntity)

more of that when logging huge body inside:
```client.async("POST", endpoint, params.toMap, entity, ResponseHandler.default)```
```logger.debug(Source.fromInputStream(entity.getContent)(Codec.UTF8).getLines().mkString("\n"))```
it allocates another ~200Mb for `getLines` and `mkString`

So when indexing a single bulk just this simple place of code uses ~800Mb (**x8**) extra memory out of nowhere even if we do not use debug level for elastic.

I understand that most of the memory is ready for garbage collection quite fast but it is a really unnecessary load for GC that we could avoid.

This PR reduces extra memory usage to **x3** extra memory in non-debug mode **x4** in debug mode.

also relates to:  https://github.com/sksamuel/elastic4s/issues/1547