### PR TITLE
Fix synonymTokenFilter method

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/analyzers/TokenFilterApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/analyzers/TokenFilterApi.scala
@@ -34,7 +34,7 @@ trait TokenFilterApi {
   def synonymTokenFilter(name: String): SynonymTokenFilter = SynonymTokenFilter(name)
 
   def synonymTokenFilter(name: String, synonyms: Iterable[String]): SynonymTokenFilter =
-    SynonymTokenFilter(name).synonyms(synonyms)
+    SynonymTokenFilter(name, synonyms = synonyms.toSet)
 
   def truncateTokenFilter(name: String): TruncateTokenFilter = TruncateTokenFilter(name)
 


### PR DESCRIPTION
SynonymTokenFilter contains require which fails when constructor is called with empty path & synonyms.