### PR TITLE
Add instances for cats-effect IO, Monix Task and Scalaz Task

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,8 @@ To get started you will need to add a dependency to either
 depending on which client you intend you use (or both).
 
 The basic usage is that you create an instance of a client and then invoke the `execute` method with the requests you
-want to perform. The execute method is asynchronous and will return a standard Scala `Future[T]` where T is the response
+want to perform. The execute method is asynchronous and will return a standard Scala `Future[T]`
+(or use one of the [Alternative executors](#alternative-executors)) where T is the response
 type appropriate for your request type. For example a _search_ request will return a response of type `SearchResponse`
 which contains the results of the search.
 
@@ -102,6 +103,20 @@ The DSL methods are located in the `ElasticDsl` trait which needs to be imported
 identical whether you use the HTTP or TCP client, you must import the appropriate trait
 (`com.sksamuel.elastic4s.ElasticDsl` for TCP or `com.sksamuel.elastic4s.http.ElasticDsl` for HTTP) depending on which
 client you are using.
+
+### Alternative Executors
+The default `Executor` uses scala `Future`s to execute requests, but there are alternate Executors that can be used by
+adding appropriate imports. The imports will create an implicit `Executor[F]` and a `Functor[F]`,
+where `F` is some effect type.
+
+#### Cats-Effect IO
+`import com.sksamuel.elastic4s.cats.effect.instances._` will provide implicit instances for `cats.effect.IO`
+
+#### Monix Task
+`import com.sksamuel.elastic4s.monix.instances._` will provide implicit instances for `monix.eval.Task`
+
+#### Scalaz Task
+`import com.sksamuel.elastic4s.scalaz.instances._` will provide implicit instances for `scalaz.concurrent.Task` 
 
 ### Example SBT Setup
 

--- a/elastic4s-cats-effect/src/main/scala/com/sksamuel/elastic4s/cats/effect/instances/IOInstances.scala
+++ b/elastic4s-cats-effect/src/main/scala/com/sksamuel/elastic4s/cats/effect/instances/IOInstances.scala
@@ -1,0 +1,13 @@
+package com.sksamuel.elastic4s.cats.effect.instances
+
+import cats.effect.IO
+import com.sksamuel.elastic4s.cats.effect.IOExecutor
+import com.sksamuel.elastic4s.http.Functor
+
+trait IOInstances {
+  implicit val ioFunctor: Functor[IO] = new Functor[IO] {
+    override def map[A, B](fa: IO[A])(f: A => B): IO[B] = fa.map(f)
+  }
+
+  implicit val ioExecutor: IOExecutor = new IOExecutor
+}

--- a/elastic4s-cats-effect/src/main/scala/com/sksamuel/elastic4s/cats/effect/instances/package.scala
+++ b/elastic4s-cats-effect/src/main/scala/com/sksamuel/elastic4s/cats/effect/instances/package.scala
@@ -1,0 +1,3 @@
+package com.sksamuel.elastic4s.cats.effect
+
+package object instances extends IOInstances

--- a/elastic4s-monix/src/main/scala/com/sksamuel/elastic4s/monix/instances/TaskInstances.scala
+++ b/elastic4s-monix/src/main/scala/com/sksamuel/elastic4s/monix/instances/TaskInstances.scala
@@ -1,0 +1,13 @@
+package com.sksamuel.elastic4s.monix.instances
+
+import com.sksamuel.elastic4s.http.Functor
+import com.sksamuel.elastic4s.monix.TaskExecutor
+import monix.eval.Task
+
+trait TaskInstances {
+  implicit val taskFunctor: Functor[Task] = new Functor[Task] {
+    override def map[A, B](fa: Task[A])(f: A => B): Task[B] = fa.map(f)
+  }
+
+  implicit val taskExecutor: TaskExecutor = new TaskExecutor
+}

--- a/elastic4s-monix/src/main/scala/com/sksamuel/elastic4s/monix/instances/package.scala
+++ b/elastic4s-monix/src/main/scala/com/sksamuel/elastic4s/monix/instances/package.scala
@@ -1,0 +1,3 @@
+package com.sksamuel.elastic4s.monix
+
+package object instances extends TaskInstances

--- a/elastic4s-scalaz/src/main/scala/com/sksamuel/elastic4s/scalaz/instances/TaskInstances.scala
+++ b/elastic4s-scalaz/src/main/scala/com/sksamuel/elastic4s/scalaz/instances/TaskInstances.scala
@@ -1,0 +1,13 @@
+package com.sksamuel.elastic4s.scalaz.instances
+
+import com.sksamuel.elastic4s.http.Functor
+import com.sksamuel.elastic4s.scalaz.TaskExecutor
+import scalaz.concurrent.Task
+
+trait TaskInstances {
+  implicit val taskFunctor: Functor[Task] = new Functor[Task] {
+    override def map[A, B](fa: Task[A])(f: A => B): Task[B] = fa.map(f)
+  }
+
+  implicit val taskExecutor: TaskExecutor = new TaskExecutor
+}

--- a/elastic4s-scalaz/src/main/scala/com/sksamuel/elastic4s/scalaz/instances/package.scala
+++ b/elastic4s-scalaz/src/main/scala/com/sksamuel/elastic4s/scalaz/instances/package.scala
@@ -1,0 +1,3 @@
+package com.sksamuel.elastic4s.scalaz
+
+package object instances extends TaskInstances


### PR DESCRIPTION
There's some good work that has been done to create modules and executors for a cats-effect `IO`, Monix `Task` and scalaz `Task, but there are a couple of things which are missing thus far, namely an instance of `Functor[F]` and the lack of a single import which can provide implicit instances of the `Functor` and `Executor`.

I've included simple `instances` imports and updated the readme.

Happy to change the import names or structure if you'd prefer.