### PR TITLE
Add multifield match type support for query string search queries

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/queries/QueryStringQuery.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/queries/QueryStringQuery.scala
@@ -1,6 +1,7 @@
 package com.sksamuel.elastic4s.searches.queries
 
 import com.sksamuel.elastic4s.analyzers.Analyzer
+import com.sksamuel.elastic4s.searches.queries.matches.{MultiMatchQuery, MultiMatchQueryBuilderType}
 import com.sksamuel.exts.OptionImplicits._
 
 case class QueryStringQuery(query: String,
@@ -24,7 +25,8 @@ case class QueryStringQuery(query: String,
                             queryName: Option[String] = None,
                             rewrite: Option[String] = None,
                             splitOnWhitespace: Option[Boolean] = None,
-                            tieBreaker: Option[Double] = None)
+                            tieBreaker: Option[Double] = None,
+                            `type`: Option[MultiMatchQueryBuilderType] = None)
     extends Query {
 
   def rewrite(rewrite: String): QueryStringQuery = copy(rewrite = rewrite.some)
@@ -90,4 +92,7 @@ case class QueryStringQuery(query: String,
     copy(autoGeneratePhraseQueries = autoGeneratePhraseQueries.some)
 
   def phraseSlop(phraseSlop: Int): QueryStringQuery = copy(phraseSlop = phraseSlop.some)
+
+  def matchType(t: String): QueryStringQuery = matchType(MultiMatchQueryBuilderType.valueOf(t))
+  def matchType(t: MultiMatchQueryBuilderType): QueryStringQuery = copy(`type` = t.some)
 }

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/text/QueryStringBodyFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/queries/text/QueryStringBodyFn.scala
@@ -1,5 +1,6 @@
 package com.sksamuel.elastic4s.http.search.queries.text
 
+import com.sksamuel.elastic4s.http.EnumConversions
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 import com.sksamuel.elastic4s.searches.queries.QueryStringQuery
 
@@ -23,6 +24,7 @@ object QueryStringBodyFn {
     s.quoteFieldSuffix.map(_.toString).foreach(builder.field("quote_field_suffix", _))
     s.splitOnWhitespace.map(_.toString).foreach(builder.field("split_on_whitespace", _))
     s.tieBreaker.foreach(builder.field("tie_breaker", _))
+    s.`type`.map(EnumConversions.multiMatchQueryBuilderType).foreach(builder.field("type", _))
     s.rewrite.map(_.toString).foreach(builder.field("rewrite", _))
 
     if (s.fields.nonEmpty) {


### PR DESCRIPTION
https://github.com/sksamuel/elastic4s/issues/1565

The `type` parameter is only supported in ElasticSearch 6 ([docs](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/query-dsl-query-string-query.html#_multi_field)).