### PR TITLE
Operations on /_cat/*  don’t work with elastic4s-akka client

### DIFF
--- a/elastic4s-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClient.scala
+++ b/elastic4s-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClient.scala
@@ -93,7 +93,7 @@ class AkkaHttpClient(settings: AkkaHttpClientSettings)(implicit system: ActorSys
   private def toRequest(request: ElasticRequest): HttpRequest = {
     HttpRequest(
       method = HttpMethod.custom(request.method),
-      uri = Uri(request.endpoint).withQuery(Query(request.params.mapValues(_.toString))),
+      uri = Uri(request.endpoint).withQuery(Query(request.params)),
       entity = request.entity.map(toEntity).getOrElse(HttpEntity.Empty)
     )
   }

--- a/elastic4s-akka/src/test/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientTest.scala
+++ b/elastic4s-akka/src/test/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientTest.scala
@@ -1,11 +1,13 @@
 package com.sksamuel.elastic4s.akka
 
-import scala.util.Try
-
 import akka.actor.ActorSystem
+import com.sksamuel.elastic4s.HealthStatus
 import com.sksamuel.elastic4s.http.ElasticClient
+import com.sksamuel.elastic4s.http.cat.CatAliasResponse
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+
+import scala.util.Try
 
 class AkkaHttpClientTest extends FlatSpec with Matchers with DockerTests with BeforeAndAfterAll {
 
@@ -39,5 +41,58 @@ class AkkaHttpClientTest extends FlatSpec with Matchers with DockerTests with Be
       indexInto("testindex" / "testindex").doc("""{ "text":"¡Hola! ¿Qué tal?" }""")
     }.await.result.result shouldBe "created"
   }
+
+  it should "work fine whith _cat endpoints " in {
+
+    client.execute {
+      catSegments()
+    }.await.result
+
+    client.execute {
+      catShards()
+    }.await.result
+
+    client.execute {
+      catNodes()
+    }.await.result
+
+    client.execute {
+      catPlugins()
+    }.await.result
+
+    client.execute {
+      catThreadPool()
+    }.await.result
+
+    client.execute {
+      catHealth()
+    }.await.result
+
+    client.execute {
+      catCount()
+    }.await.result
+
+    client.execute {
+      catMaster()
+    }.await.result
+
+    client.execute {
+      catAliases()
+    }.await.result
+
+    client.execute {
+      catIndices()
+    }.await.result
+
+    client.execute {
+      catIndices(HealthStatus.Green)
+    }.await.result
+
+    client.execute {
+      catAllocation()
+    }.await.result
+
+  }
+
 }
 

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/cat/CatHandlers.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/cat/CatHandlers.scala
@@ -8,18 +8,18 @@ trait CatHandlers {
   implicit object CatSegmentsHandler extends Handler[CatSegments, Seq[CatSegmentsResponse]] {
     override def build(request: CatSegments): ElasticRequest = {
       val endpoint = if (request.indices.isAll) "/_cat/segments" else "/_cat/segments/" + request.indices.string
-      ElasticRequest("GET", s"$endpoint?v&format=json&bytes=b")
+      ElasticRequest("GET", endpoint, Map("v" -> "", "format" -> "json", "bytes" -> "b"))
     }
   }
 
   implicit object CatShardsHandler extends Handler[CatShards, Seq[CatShardsResponse]] {
     override def build(request: CatShards): ElasticRequest =
-      ElasticRequest("GET", "/_cat/shards?v&format=json&bytes=b")
+      ElasticRequest("GET", "/_cat/shards", Map("v" -> "", "format" -> "json", "bytes" -> "b"))
   }
 
   implicit object CatNodesHandler extends Handler[CatNodes, Seq[CatNodesResponse]] {
     override def build(request: CatNodes): ElasticRequest = {
-      val headers = Seq(
+      val headers: String = Seq(
         "id",
         "pid",
         "ip",
@@ -56,20 +56,20 @@ trait CatHandlers {
         "request_cache.miss_count",
         "flush.total"
       ).mkString(",")
-      ElasticRequest("GET", s"/_cat/nodes?v&h=$headers&format=json")
+      ElasticRequest("GET", "/_cat/nodes", Map("v" -> "", "format" -> "json", "h" -> headers))
     }
   }
 
   implicit object CatPluginsHandler extends Handler[CatPlugins, Seq[CatPluginResponse]] {
     override def build(request: CatPlugins): ElasticRequest =
-      ElasticRequest("GET", "/_cat/plugins?v&format=json")
+      ElasticRequest("GET", "/_cat/plugins", Map("v" -> "", "format" -> "json"))
   }
 
   implicit object CatThreadPoolHandler extends Handler[CatThreadPool, Seq[CatThreadPoolResponse]] {
     override def build(request: CatThreadPool): ElasticRequest = {
-      val headers =
+      val headers: String =
         "id,name,active,rejected,completed,type,size,queue,queue_size,largest,min,max,keep_alive,node_id,ephemeral_id,pid,host,ip,port"
-      ElasticRequest("GET", s"/_cat/thread_pool?v&format=json&h=$headers")
+      ElasticRequest("GET", s"/_cat/thread_pool", Map("v" -> "", "format" -> "json", "h" -> headers))
     }
   }
 
@@ -81,7 +81,7 @@ trait CatHandlers {
     }
 
     override def build(request: CatHealth): ElasticRequest =
-      ElasticRequest("GET", "/_cat/health?v&format=json")
+      ElasticRequest("GET", "/_cat/health", Map("v" -> "", "format" -> "json"))
   }
 
   implicit object CatCountHandler extends Handler[CatCount, CatCountResponse] {
@@ -93,10 +93,10 @@ trait CatHandlers {
 
     override def build(request: CatCount): ElasticRequest = {
       val endpoint = request.indices match {
-        case Nil     => "/_cat/count?v&format=json"
-        case indexes => "/_cat/count/" + indexes.mkString(",") + "?v&format=json"
+        case Nil => "/_cat/count"
+        case indexes => "/_cat/count/" + indexes.mkString(",")
       }
-      ElasticRequest("GET", endpoint)
+      ElasticRequest("GET", endpoint, Map("v" -> "", "format" -> "json"))
     }
   }
 
@@ -108,30 +108,31 @@ trait CatHandlers {
     }
 
     override def build(request: CatMaster): ElasticRequest =
-      ElasticRequest("GET", "/_cat/master?v&format=json")
+      ElasticRequest("GET", "/_cat/master", Map("v" -> "", "format" -> "json"))
   }
 
   implicit object CatAliasesHandler extends Handler[CatAliases, Seq[CatAliasResponse]] {
     override def build(request: CatAliases): ElasticRequest =
-      ElasticRequest("GET", "/_cat/aliases?v&format=json")
+      ElasticRequest("GET", "/_cat/aliases", Map("v" -> "", "format" -> "json"))
   }
 
   implicit object CatIndexesHandler extends Handler[CatIndexes, Seq[CatIndicesResponse]] {
 
-    val BaseEndpoint = "/_cat/indices?v&format=json&bytes=b"
+    val BaseParams: Map[String, Any] = Map("v" -> "", "format" -> "json", "bytes" -> "b")
 
     override def build(request: CatIndexes): ElasticRequest = {
-      val endpoint = request.health match {
-        case Some(health) => BaseEndpoint + "&health=" + health.getClass.getSimpleName.toLowerCase.stripSuffix("$")
-        case _            => BaseEndpoint
+      val params = request.health match {
+        case Some(health) => BaseParams + ("health" -> health.getClass.getSimpleName.toLowerCase.stripSuffix("$"))
+        case _ => BaseParams
       }
-      ElasticRequest("GET", endpoint)
+      ElasticRequest("GET", "/_cat/indices", params)
     }
   }
 
   implicit object CatAllocationHandler extends Handler[CatAllocation, Seq[CatAllocationResponse]] {
 
     override def build(request: CatAllocation): ElasticRequest =
-      ElasticRequest("GET", "/_cat/aliases?v&format=json&bytes=b")
+      ElasticRequest("GET", "/_cat/aliases", Map("v" -> "", "format" -> "json", "bytes" -> "b"))
   }
+
 }


### PR DESCRIPTION
This is caused by `uri = Uri(request.endpoint).withQuery(Query(request.params)),` code in `AkkaHttpClient.toRequest` which always overrides all query string parameters passed as part of endpoint parameter with empty `request.params` map.