### PR TITLE
Add failover to akka-http client

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -187,7 +187,8 @@ lazy val akka = Project("elastic4s-akka", file("elastic4s-akka"))
   .settings(
     name := "elastic4s-akka",
     libraryDependencies += "com.typesafe.akka" %% "akka-http" % "10.1.5",
-    libraryDependencies += "com.typesafe.akka" %% "akka-stream" % "2.5.17"
+    libraryDependencies += "com.typesafe.akka" %% "akka-stream" % "2.5.17",
+    libraryDependencies += "org.scalamock" %% "scalamock" % ScalamockVersion % "test"
   )
   .dependsOn(core, http, testkit % "test")
 

--- a/elastic4s-akka/src/main/resources/reference.conf
+++ b/elastic4s-akka/src/main/resources/reference.conf
@@ -2,6 +2,11 @@ com.sksamuel.elastic4s.akka {
   hosts: []
   https: false
   queue-size: 1000
+  blacklist {
+    min-duration = 1m
+    max-duration = 30m
+  }
+  max-retry-timeout = 30s
   akka.http {
     // akka-http settings specific for elastic4s
     // can be overwritten in this section

--- a/elastic4s-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClient.scala
+++ b/elastic4s-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClient.scala
@@ -1,11 +1,9 @@
 package com.sksamuel.elastic4s.akka
 
-import scala.concurrent.duration.Duration
 import scala.concurrent.{Future, Promise}
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.Uri.Query
 import akka.http.scaladsl.model._
 import akka.stream.scaladsl.{FileIO, Keep, Sink, Source, StreamConverters}
@@ -14,91 +12,216 @@ import akka.util.ByteString
 import com.sksamuel.elastic4s.http.HttpEntity.StringEntity
 import com.sksamuel.elastic4s.http.{ElasticRequest, HttpClient => ElasticHttpClient, HttpEntity => ElasticHttpEntity, HttpResponse => ElasticHttpResponse}
 
-class AkkaHttpClient(settings: AkkaHttpClientSettings)(implicit system: ActorSystem)
+class AkkaHttpClient private[akka](
+                                    settings: AkkaHttpClientSettings,
+                                    blacklist: Blacklist,
+                                    httpPoolFactory: HttpPoolFactory)(implicit system: ActorSystem)
   extends ElasticHttpClient {
 
+  import AkkaHttpClient._
   import system.dispatcher
 
   private implicit val materializer = ActorMaterializer()
 
-  private val http = Http()
-
-  private val poolSettings = settings.poolSettings
-    .withResponseEntitySubscriptionTimeout(Duration.Inf) // we guarantee to consume consume data from all responses
-
-  private val poolFlow = http.superPool[Promise[ElasticHttpResponse]](
-    settings = poolSettings
-  )
-
-  private val resolvedHosts: List[Uri] = {
-    val scheme = if (settings.https) "https" else "http"
-    settings.hosts.map(host => Uri.parseAbsolute(s"$scheme://$host")).toList
-  }
-
-  private val hostsFlow = Source.repeat(resolvedHosts).mapConcat(identity)
+  private val scheme = if (settings.https) "https" else "http"
 
   private val queue =
     Source
-      .queue[(ElasticRequest, Promise[ElasticHttpResponse])](settings.queueSize, OverflowStrategy.backpressure)
-      .map { case (r, p) => (toRequest(r), p) }
-      .zipWith(hostsFlow)((_, _))
-      .map { case ((r, p), host) => (r.withUri(r.uri.resolvedAgainst(host)), p) }
-      .via(poolFlow)
+      .queue[(ElasticRequest, RequestState)](settings.queueSize,
+      OverflowStrategy.backpressure)
+      .statefulMapConcat { () =>
+        val hosts = iterateHosts
+
+        in => {
+          (in, hosts.next()) match {
+            case ((r, s), Some(host)) =>
+              // if host is resolved - send request forward
+              s.host.success(host)
+              toRequest(r, host) match {
+                case Success(req) =>
+                  (req, s) :: Nil
+                case Failure(e) =>
+                  s.host.failure(e)
+                  s.response.failure(e)
+                  Nil
+              }
+            case ((_, s), None) =>
+              // if not - all hosts are blacklisted, return an error
+              val exception = AllHostsBlacklistedException
+              s.host.failure(exception)
+              s.response.failure(exception)
+              Nil
+          }
+        }
+      }
+      .via(httpPoolFactory.create[RequestState]())
       .flatMapMerge(
-        poolSettings.maxConnections, {
-          case (Success(r), p) =>
+        settings.poolSettings.maxConnections, {
+          case (Success(r), s) =>
             r.entity.dataBytes
               .fold(ByteString())(_ ++ _)
-              .map(data => (Success(toResponse(r, data)), p))
+              .map(data => (Success(toResponse(r, data)), s))
               .recoverWithRetries(1, { // in case of TCP timeout or response subscription timeout, etc.
                 case t: Throwable =>
-                  Source.single(Failure(t), p)
+                  Source.single(Failure(t), s)
               })
-          case (Failure(e), p) => Source.single(Failure(e), p)
+          case (Failure(e), s) => Source.single(Failure(e), s)
         }
       )
       .toMat(Sink.foreach({
-        case (Success(resp), p) => p.success(resp)
-        case (Failure(e), p) => p.failure(e)
+        case (Success(resp), s) => s.response.success(resp)
+        case (Failure(e), s) => s.response.failure(e)
       }))(Keep.left)
       .run()
 
-  private def queueRequest(request: ElasticRequest): Future[ElasticHttpResponse] = {
-    val responsePromise = Promise[ElasticHttpResponse]()
-    queue.offer(request -> responsePromise).flatMap {
-      case QueueOfferResult.Enqueued => responsePromise.future
-      case QueueOfferResult.Dropped => Future.failed(new RuntimeException("Queue overflowed. Try again later."))
+  /**
+    * Iterator of Some(host) or None if all hosts are blacklisted.
+    */
+  private def iterateHosts: Iterator[Option[String]] =
+    Iterator
+      .continually(settings.hosts)
+      .flatten
+      .flatMap { host =>
+        if (blacklist.contains(host)) {
+          logger.trace(s"[$host] is in blacklist")
+          if (blacklist.size < settings.hosts.size) Nil
+          else None :: Nil
+        } else Some(host) :: Nil
+      }
+
+  private def queueRequest(request: ElasticRequest,
+                           state: RequestState): Future[ElasticHttpResponse] = {
+    queue.offer(request -> state).flatMap {
+      case QueueOfferResult.Enqueued => state.response.future
+      case QueueOfferResult.Dropped =>
+        Future.failed(new Exception("Queue overflowed. Try again later."))
       case QueueOfferResult.Failure(ex) => Future.failed(ex)
       case QueueOfferResult.QueueClosed =>
-        Future.failed(
-          new RuntimeException("Queue was closed (pool shut down) while running the request. Try again later."))
+        Future.failed(new Exception(
+          "Queue was closed (pool shut down) while running the request. Try again later."))
     }
   }
 
-  override def send(request: ElasticRequest, callback: Either[Throwable, ElasticHttpResponse] => Unit): Unit = {
-    queueRequest(request).onComplete {
+  private def queueRequestWithRetry(
+                                     request: ElasticRequest,
+                                     startTimeNanos: Long = System.nanoTime): Future[ElasticHttpResponse] = {
+
+    val state = RequestState()
+
+    def retryIfPossible(notPossible: => Either[Throwable, ElasticHttpResponse])
+    : Future[ElasticHttpResponse] = {
+      val timePassed = System.nanoTime - startTimeNanos
+      if (timePassed < settings.maxRetryTimeout.toNanos) {
+        logger.trace(s"Retrying a request: ${request.endpoint}")
+        queueRequestWithRetry(request, startTimeNanos)
+      } else {
+        notPossible match {
+          case Left(exc) =>
+            Future.failed(new Exception(
+              s"Request retries exceeded max retry timeout [${settings.maxRetryTimeout}]",
+              exc))
+          case Right(resp) =>
+            Future.successful(resp)
+        }
+      }
+    }
+
+    def markDead(): Future[Unit] = {
+      state.host.future
+        .map { host =>
+          if (blacklist.add(host)) {
+            logger.debug(s"added [$host] to blacklist")
+          } else {
+            logger.trace(s"updated [$host] in a blacklist")
+          }
+        }
+    }
+
+    def markAlive(): Future[Unit] = {
+      state.host.future
+        .map { host =>
+          if (blacklist.remove(host)) {
+            logger.debug(s"removed [$host] from blacklist")
+          }
+        }
+    }
+
+    queueRequest(request, state)
+      .flatMap { response =>
+        val status = StatusCode.int2StatusCode(response.statusCode)
+        if (status.isSuccess()) {
+          markAlive().map(_ => response)
+        } else {
+          if (isRetryStatus(status)) {
+            markDead().flatMap(_ => retryIfPossible(Right(response)))
+          } else {
+            // mark host alive and don't retry, as the error should be a request problem
+            markAlive().map(_ => response)
+          }
+        }
+      }
+      .recoverWith {
+        case err: Throwable =>
+          if (isRetryException(err)) {
+            markDead().flatMap(_ => retryIfPossible(Left(err)))
+          } else {
+            markDead().flatMap(_ => Future.failed(err))
+          }
+      }
+  }
+
+  private def isRetryStatus(statusCode: StatusCode) = {
+    statusCode match {
+      case StatusCodes.BadGateway => true
+      case StatusCodes.ServiceUnavailable => true
+      case StatusCodes.GatewayTimeout => true
+      case _ => false
+    }
+  }
+
+  private def isRetryException(t: Throwable): Boolean = {
+    t match {
+      case AllHostsBlacklistedException => false
+      case _ => true
+    }
+  }
+
+  private[akka] def sendAsync(
+                               request: ElasticRequest): Future[ElasticHttpResponse] = {
+    queueRequestWithRetry(request)
+  }
+
+  override def send(
+                     request: ElasticRequest,
+                     callback: Either[Throwable, ElasticHttpResponse] => Unit): Unit = {
+    sendAsync(request).onComplete {
       case Success(r) => callback(Right(r))
       case Failure(e) => callback(Left(e))
     }
   }
 
   def shutdown(): Future[Unit] = {
-    http.shutdownAllConnectionPools()
+    httpPoolFactory.shutdown()
   }
 
   override def close(): Unit = {
     shutdown()
   }
 
-  private def toRequest(request: ElasticRequest): HttpRequest = {
+  private def toRequest(request: ElasticRequest,
+                        host: String): Try[HttpRequest] = Try {
     HttpRequest(
       method = HttpMethod.custom(request.method),
-      uri = Uri(request.endpoint).withQuery(Query(request.params)),
+      uri = Uri(request.endpoint)
+        .withQuery(Query(request.params))
+        .withAuthority(Uri.Authority.parse(host))
+        .withScheme(scheme),
       entity = request.entity.map(toEntity).getOrElse(HttpEntity.Empty)
     )
   }
 
-  private def toResponse(response: HttpResponse, data: ByteString): ElasticHttpResponse = {
+  private def toResponse(response: HttpResponse,
+                         data: ByteString): ElasticHttpResponse = {
     ElasticHttpResponse(
       response.status.intValue(),
       Some(StringEntity(data.utf8String, None)),
@@ -110,7 +233,9 @@ class AkkaHttpClient(settings: AkkaHttpClientSettings)(implicit system: ActorSys
     entity match {
       case ElasticHttpEntity.StringEntity(content, contentType) =>
         val ct =
-          contentType.flatMap(value => ContentType.parse(value).right.toOption).getOrElse(ContentTypes.`text/plain(UTF-8)`)
+          contentType
+            .flatMap(value => ContentType.parse(value).right.toOption)
+            .getOrElse(ContentTypes.`text/plain(UTF-8)`)
         HttpEntity(ct, ByteString(content))
       case ElasticHttpEntity.FileEntity(file, contentType) =>
         val ct = contentType
@@ -128,7 +253,22 @@ class AkkaHttpClient(settings: AkkaHttpClientSettings)(implicit system: ActorSys
 
 object AkkaHttpClient {
 
-  def apply(settings: AkkaHttpClientSettings)(implicit system: ActorSystem): AkkaHttpClient = {
-    new AkkaHttpClient(settings)
+  def apply(settings: AkkaHttpClientSettings)(
+    implicit system: ActorSystem): AkkaHttpClient = {
+
+    val blacklist = new DefaultBlacklist(settings.blacklistMinDuration,
+      settings.blacklistMaxDuration)
+
+    val httpPoolFactory = new DefaultHttpPoolFactory(settings.poolSettings)
+
+    new AkkaHttpClient(settings, blacklist, httpPoolFactory)
   }
+
+  private[akka] case class RequestState(response: Promise[ElasticHttpResponse] =
+                                        Promise(),
+                                        host: Promise[String] = Promise())
+
+  private[akka] case object AllHostsBlacklistedException
+    extends Exception("All hosts are blacklisted!")
+
 }

--- a/elastic4s-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientSettings.scala
+++ b/elastic4s-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientSettings.scala
@@ -1,30 +1,44 @@
 package com.sksamuel.elastic4s.akka
 
+import java.util.concurrent.TimeUnit
+
 import scala.collection.JavaConverters._
+import scala.concurrent.duration._
 
 import akka.http.scaladsl.settings.ConnectionPoolSettings
 import com.typesafe.config.{Config, ConfigFactory}
 
 object AkkaHttpClientSettings {
 
-  def apply(): AkkaHttpClientSettings = {
-    apply(ConfigFactory.load().getConfig("com.sksamuel.elastic4s.akka"))
-  }
+  private def defaultConfig: Config = ConfigFactory.load().getConfig("com.sksamuel.elastic4s.akka")
+
+  lazy val default: AkkaHttpClientSettings = apply(defaultConfig)
 
   def apply(config: Config): AkkaHttpClientSettings = {
-    val hosts = config.getStringList("hosts").asScala
-    val queueSize = config.getInt("queue-size")
-    val https = config.getBoolean("https")
-    val poolSettings = ConnectionPoolSettings(config.withFallback(ConfigFactory.load()))
-    AkkaHttpClientSettings(https, hosts, queueSize, poolSettings)
+    val cfg = config.withFallback(defaultConfig)
+    val hosts = cfg.getStringList("hosts").asScala.toVector
+    val queueSize = cfg.getInt("queue-size")
+    val https = cfg.getBoolean("https")
+    val blacklistMinDuration = Duration(cfg.getDuration("blacklist.min-duration", TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS)
+    val blacklistMaxDuration = Duration(cfg.getDuration("blacklist.max-duration", TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS)
+    val maxRetryTimeout = Duration(cfg.getDuration("max-retry-timeout", TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS)
+    val poolSettings = ConnectionPoolSettings(cfg.withFallback(ConfigFactory.load()))
+    AkkaHttpClientSettings(https, hosts, queueSize, poolSettings, blacklistMinDuration, blacklistMaxDuration, maxRetryTimeout)
+  }
+
+  def apply(): AkkaHttpClientSettings = {
+    default
   }
 
   def apply(hosts: Seq[String]): AkkaHttpClientSettings = {
-    apply().copy(hosts = hosts)
+    apply().copy(hosts = hosts.toVector)
   }
 }
 
 case class AkkaHttpClientSettings(https: Boolean,
-                                  hosts: Seq[String],
+                                  hosts: Vector[String],
                                   queueSize: Int,
-                                  poolSettings: ConnectionPoolSettings)
+                                  poolSettings: ConnectionPoolSettings,
+                                  blacklistMinDuration: FiniteDuration = AkkaHttpClientSettings.default.blacklistMinDuration,
+                                  blacklistMaxDuration: FiniteDuration = AkkaHttpClientSettings.default.blacklistMaxDuration,
+                                  maxRetryTimeout: FiniteDuration = AkkaHttpClientSettings.default.maxRetryTimeout)

--- a/elastic4s-akka/src/main/scala/com/sksamuel/elastic4s/akka/Blacklist.scala
+++ b/elastic4s-akka/src/main/scala/com/sksamuel/elastic4s/akka/Blacklist.scala
@@ -1,0 +1,45 @@
+package com.sksamuel.elastic4s.akka
+
+/**
+  * List of 'bad' hosts.
+  * Implementation must have expiration logic backed-in.
+  */
+private[akka] trait Blacklist {
+
+  /**
+    * Adds a host to the blacklist.
+    *
+    * @param host host
+    * @return true if record is blacklisted for the first time
+    */
+  def add(host: String): Boolean
+
+  /**
+    * Removes a host from the blacklist.
+    *
+    * @param host host
+    * @return true if host was blacklisted
+    */
+  def remove(host: String): Boolean
+
+  /**
+    * Checks if a host can be used.
+    *
+    * @param host host
+    * @return true if host is not in a blacklist or temporary removed from it
+    */
+  def contains(host: String): Boolean
+
+  /**
+    * Number of hosts in blacklist
+    */
+  def size: Int
+
+  /**
+    * List all hosts in the blacklist
+    *
+    * @return
+    */
+  def list: List[String]
+}
+

--- a/elastic4s-akka/src/main/scala/com/sksamuel/elastic4s/akka/DefaultBlacklist.scala
+++ b/elastic4s-akka/src/main/scala/com/sksamuel/elastic4s/akka/DefaultBlacklist.scala
@@ -1,0 +1,78 @@
+package com.sksamuel.elastic4s.akka
+
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration.FiniteDuration
+
+/**
+  * Thread-safe host blacklist.
+  * Blacklist duration starts with `min` and exponentially increased up to `max` on subsequent calls to `add`.
+  * When `remove` is called - blacklist record is permanently removed and next `add` will start with `min` again.
+  *
+  * @param min      minimum time to keep blacklist record
+  * @param max      maximum time to keep blacklist record
+  * @param nanoTime clock in nanoseconds
+  */
+private[akka] class DefaultBlacklist(min: FiniteDuration,
+                                     max: FiniteDuration,
+                                     nanoTime: => Long = System.nanoTime)
+  extends Blacklist {
+
+  import DefaultBlacklist._
+
+  private val hosts = new ConcurrentHashMap[String, BlacklistRecord]()
+
+  override def add(host: String): Boolean = {
+    val now = nanoTime
+    val record = hosts.getOrDefault(
+      host,
+      BlacklistRecord(enabled = true, startTime = now, untilTime = -1, -1))
+
+    if(now >= record.untilTime) {
+      val retries = record.retries + 1
+
+      val untilTime = now + Math
+        .min(min.toNanos * Math.pow(2, retries * 0.5), max.toNanos)
+        .toLong
+
+      val updatedRecord =
+        record.copy(
+          enabled = true,
+          untilTime = untilTime,
+          retries = retries)
+
+      hosts.put(host, updatedRecord) == null
+    } else false
+  }
+
+  override def remove(host: String): Boolean = {
+    hosts.remove(host) != null
+  }
+
+  override def contains(host: String): Boolean = {
+    hosts.get(host) match {
+      case null => false
+      case r =>
+        if (r.enabled) {
+          if (nanoTime - r.untilTime >= 0) {
+            hosts.put(host, r.copy(enabled = false))
+            false
+          } else true
+        } else false
+    }
+  }
+
+  override def size: Int = hosts.size()
+
+  override def list: List[String] = hosts.keys().asScala.toList
+}
+
+object DefaultBlacklist {
+
+  private case class BlacklistRecord(enabled: Boolean,
+                                     startTime: Long,
+                                     untilTime: Long,
+                                     retries: Int)
+
+}

--- a/elastic4s-akka/src/main/scala/com/sksamuel/elastic4s/akka/DefaultHttpPoolFactory.scala
+++ b/elastic4s-akka/src/main/scala/com/sksamuel/elastic4s/akka/DefaultHttpPoolFactory.scala
@@ -1,0 +1,31 @@
+package com.sksamuel.elastic4s.akka
+
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+import scala.util.Try
+
+import akka.NotUsed
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.http.scaladsl.settings.ConnectionPoolSettings
+import akka.stream.scaladsl.Flow
+
+private[akka] class DefaultHttpPoolFactory(settings: ConnectionPoolSettings)(
+  implicit system: ActorSystem)
+  extends HttpPoolFactory {
+
+  private val http = Http()
+
+  private val poolSettings = settings.withResponseEntitySubscriptionTimeout(
+    Duration.Inf) // we guarantee to consume consume data from all responses
+
+  override def create[T]()
+  : Flow[(HttpRequest, T), (Try[HttpResponse], T), NotUsed] = {
+    http.superPool[T](
+      settings = poolSettings
+    )
+  }
+
+  override def shutdown(): Future[Unit] = http.shutdownAllConnectionPools()
+}

--- a/elastic4s-akka/src/main/scala/com/sksamuel/elastic4s/akka/HttpPoolFactory.scala
+++ b/elastic4s-akka/src/main/scala/com/sksamuel/elastic4s/akka/HttpPoolFactory.scala
@@ -1,0 +1,18 @@
+package com.sksamuel.elastic4s.akka
+
+import scala.concurrent.Future
+import scala.util.Try
+
+import akka.NotUsed
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.stream.scaladsl.Flow
+
+/**
+  * Factory for Akka's http pool flow.
+  */
+private[akka] trait HttpPoolFactory {
+
+  def create[T](): Flow[(HttpRequest, T), (Try[HttpResponse], T), NotUsed]
+
+  def shutdown(): Future[Unit]
+}

--- a/elastic4s-akka/src/test/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientMockTest.scala
+++ b/elastic4s-akka/src/test/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientMockTest.scala
@@ -1,0 +1,238 @@
+package com.sksamuel.elastic4s.akka
+
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse, StatusCodes, Uri}
+import com.sksamuel.elastic4s.akka.AkkaHttpClient.AllHostsBlacklistedException
+import com.sksamuel.elastic4s.http.{ElasticRequest, HttpEntity => ElasticEntity, HttpResponse => ElasticResponse}
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+
+class AkkaHttpClientMockTest
+  extends WordSpec
+    with Matchers
+    with MockFactory
+    with ScalaFutures
+    with BeforeAndAfterAll {
+
+  private implicit lazy val system = ActorSystem()
+
+  override def afterAll: Unit = {
+    system.terminate()
+  }
+
+  def mockHttpPool() = {
+    val sendRequest = mockFunction[HttpRequest, Try[HttpResponse]]
+    val poolFactory = new TestHttpPoolFactory(sendRequest)
+
+    (sendRequest, poolFactory)
+  }
+
+  "AkkaHttpClient" should {
+
+    "retry on 502" in {
+
+      val hosts = List(
+        "host1",
+        "host2"
+      )
+
+      val blacklist = mock[Blacklist]
+
+      val (sendRequest, httpPool) = mockHttpPool()
+
+      val client =
+        new AkkaHttpClient(AkkaHttpClientSettings(hosts), blacklist, httpPool)
+
+      (blacklist.contains _).expects("host1").returns(false)
+      (blacklist.contains _).expects("host2").returns(false)
+      (blacklist.add _).expects("host1").returns(true)
+      (blacklist.remove _).expects("host2").returns(false)
+
+      sendRequest
+        .expects(argThat { r: HttpRequest =>
+          r.uri == Uri("http://host1/test")
+        })
+        .returns(Success(HttpResponse(StatusCodes.BadGateway)))
+
+      sendRequest
+        .expects(argThat { r: HttpRequest =>
+          r.uri == Uri("http://host2/test")
+        })
+        .returns(Success(HttpResponse().withEntity("ok")))
+
+      client
+        .sendAsync(ElasticRequest("GET", "/test"))
+        .futureValue shouldBe ElasticResponse(
+        200,
+        Some(ElasticEntity.StringEntity("ok", None)),
+        Map.empty)
+    }
+
+    "don't retry if no time left" in {
+
+      val hosts = List(
+        "host1",
+        "host2"
+      )
+
+      val blacklist = mock[Blacklist]
+
+      val (sendRequest, httpPool) = mockHttpPool()
+
+      val client =
+        new AkkaHttpClient(
+          AkkaHttpClientSettings(hosts).copy(maxRetryTimeout = 0.seconds),
+          blacklist,
+          httpPool)
+
+      (blacklist.contains _).expects("host1").returns(false)
+      (blacklist.add _).expects("host1").returns(true)
+
+      sendRequest
+        .expects(argThat { r: HttpRequest =>
+          r.uri == Uri("http://host1/test")
+        })
+        .returns(Success(HttpResponse(StatusCodes.BadGateway)))
+
+      client
+        .sendAsync(ElasticRequest("GET", "/test"))
+        .futureValue shouldBe ElasticResponse(
+        502,
+        Some(ElasticEntity.StringEntity("", None)),
+        Map.empty)
+    }
+
+    "blacklist on 502" in {
+
+      val hosts = List(
+        "host1",
+        "host2"
+      )
+
+      val blacklist = mock[Blacklist]
+
+      val (sendRequest, httpPool) = mockHttpPool()
+
+      val client =
+        new AkkaHttpClient(AkkaHttpClientSettings(hosts), blacklist, httpPool)
+
+      (blacklist.contains _).expects("host1").returns(false)
+      (blacklist.contains _).expects("host2").returns(false)
+      (blacklist.add _).expects("host1").returns(true)
+      (blacklist.remove _).expects("host2").returns(false)
+
+      sendRequest
+        .expects(argThat { r: HttpRequest =>
+          r.uri == Uri("http://host1/test")
+        })
+        .returns(Success(HttpResponse(StatusCodes.BadGateway)))
+
+      sendRequest
+        .expects(argThat { r: HttpRequest =>
+          r.uri == Uri("http://host2/test")
+        })
+        .returns(Success(HttpResponse().withEntity("host2")))
+
+      client
+        .sendAsync(ElasticRequest("GET", "/test"))
+        .futureValue
+    }
+
+    "blacklist on exception" in {
+
+      val hosts = List(
+        "host1",
+        "host2"
+      )
+
+      val blacklist = mock[Blacklist]
+
+      val (sendRequest, httpPool) = mockHttpPool()
+
+      val client =
+        new AkkaHttpClient(AkkaHttpClientSettings(hosts), blacklist, httpPool)
+
+      (blacklist.contains _).expects("host1").returns(false)
+      (blacklist.contains _).expects("host2").returns(false)
+      (blacklist.add _).expects("host1").returns(true)
+      (blacklist.remove _).expects("host2").returns(false)
+
+      sendRequest
+        .expects(argThat { r: HttpRequest =>
+          r.uri == Uri("http://host1/test")
+        })
+        .returns(Failure(new Exception("Some exception")))
+
+      sendRequest
+        .expects(argThat { r: HttpRequest =>
+          r.uri == Uri("http://host2/test")
+        })
+        .returns(Success(HttpResponse().withEntity("host2")))
+
+      client
+        .sendAsync(ElasticRequest("GET", "/test"))
+        .futureValue
+    }
+
+    "skip blacklisted hosts" in {
+
+      val hosts = List(
+        "host1",
+        "host2"
+      )
+
+      val blacklist = mock[Blacklist]
+
+      val (sendRequest, httpPool) = mockHttpPool()
+
+      val client =
+        new AkkaHttpClient(AkkaHttpClientSettings(hosts), blacklist, httpPool)
+
+      (blacklist.contains _).expects("host1").returns(true)
+      (blacklist.size _).expects().returns(1)
+      (blacklist.contains _).expects("host2").returns(false)
+      (blacklist.remove _).expects("host2").returns(false)
+
+      sendRequest
+        .expects(argThat { r: HttpRequest =>
+          r.uri == Uri("http://host2/test")
+        })
+        .returns(Success(HttpResponse().withEntity("host2")))
+
+      client
+        .sendAsync(ElasticRequest("GET", "/test"))
+        .futureValue shouldBe ElasticResponse(
+        200,
+        Some(ElasticEntity.StringEntity("host2", None)),
+        Map.empty)
+    }
+
+    "return error if all hosts are blacklisted" in {
+
+      val hosts = List(
+        "host1",
+        "host2"
+      )
+
+      val blacklist = mock[Blacklist]
+
+      val (_, httpPool) = mockHttpPool()
+
+      val client =
+        new AkkaHttpClient(AkkaHttpClientSettings(hosts), blacklist, httpPool)
+
+      (blacklist.contains _).expects("host1").returns(true)
+      (blacklist.size _).expects().returns(2)
+
+      client
+        .sendAsync(ElasticRequest("GET", "/test"))
+        .failed
+        .futureValue shouldBe AllHostsBlacklistedException
+    }
+
+  }
+}

--- a/elastic4s-akka/src/test/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientTest.scala
+++ b/elastic4s-akka/src/test/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientTest.scala
@@ -37,6 +37,7 @@ class AkkaHttpClientTest extends FlatSpec with Matchers with DockerTests with Be
   override val client = ElasticClient(akkaClient)
 
   "AkkaHttpClient" should "support utf-8" in {
+
     client.execute {
       indexInto("testindex" / "testindex").doc("""{ "text":"¡Hola! ¿Qué tal?" }""")
     }.await.result.result shouldBe "created"

--- a/elastic4s-akka/src/test/scala/com/sksamuel/elastic4s/akka/DefaultBlacklistTest.scala
+++ b/elastic4s-akka/src/test/scala/com/sksamuel/elastic4s/akka/DefaultBlacklistTest.scala
@@ -1,0 +1,83 @@
+package com.sksamuel.elastic4s.akka
+
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+import org.scalatest.{Matchers, WordSpec}
+
+class DefaultBlacklistTest extends WordSpec with Matchers {
+
+  val minDuration = 1 second
+  val maxDuration = 10 seconds
+  val host = "elastic.test"
+
+  "DefaultBlacklist" should {
+
+    "add host to blacklist" in {
+      val blacklist = new DefaultBlacklist(minDuration, maxDuration)
+      blacklist.add(host) shouldBe true
+      blacklist.contains(host) shouldBe true
+    }
+
+    "remove host from blacklist" in {
+      val blacklist = new DefaultBlacklist(minDuration, maxDuration)
+      blacklist.add(host)
+      blacklist.remove(host) shouldBe true
+      blacklist.contains(host) shouldBe false
+    }
+
+    "ensure host is in blacklist" in {
+      val blacklist = new DefaultBlacklist(minDuration, maxDuration)
+      blacklist.add(host) shouldBe true
+      blacklist.add(host) shouldBe false
+    }
+
+    "ensure host is not in blacklist" in {
+      val blacklist = new DefaultBlacklist(minDuration, maxDuration)
+      blacklist.remove(host) shouldBe false
+    }
+
+    "remove host from blacklist on timeout" in {
+      var now: Long = 0
+      val blacklist = new DefaultBlacklist(minDuration, maxDuration, now)
+
+      blacklist.add(host)
+      blacklist.contains(host) shouldBe true
+
+      now += minDuration.toNanos
+      blacklist.contains(host) shouldBe false
+    }
+
+    "increase blacklist timeout up to max" in {
+      var now: Long = 0
+      val blacklist = new DefaultBlacklist(minDuration, maxDuration, now)
+
+      blacklist.add(host)
+
+      now += minDuration.toNanos
+      blacklist.contains(host) shouldBe false
+
+      // after first blacklist timed out add it again
+      blacklist.add(host)
+
+      // check that the same time increase now doesn't result in invalidated blacklist record
+      now += minDuration.toNanos
+      blacklist.contains(host) shouldBe true
+
+      // now when more time elapses it should invalidate it again
+      now += maxDuration.toNanos
+      blacklist.contains(host) shouldBe false
+    }
+
+    "not increase blacklist timeout on early `add`" in {
+      var now: Long = 0
+      val blacklist = new DefaultBlacklist(minDuration, maxDuration, now)
+
+      blacklist.add(host)
+      now = minDuration.toNanos / 2
+      blacklist.add(host)
+      now = minDuration.toNanos
+      blacklist.contains(host) shouldBe false
+    }
+  }
+}

--- a/elastic4s-akka/src/test/scala/com/sksamuel/elastic4s/akka/TestHttpPoolFactory.scala
+++ b/elastic4s-akka/src/test/scala/com/sksamuel/elastic4s/akka/TestHttpPoolFactory.scala
@@ -1,0 +1,22 @@
+package com.sksamuel.elastic4s.akka
+
+import scala.concurrent.Future
+import scala.concurrent.duration.{FiniteDuration, _}
+import scala.util.Try
+
+import akka.NotUsed
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import akka.stream.scaladsl.Flow
+
+class TestHttpPoolFactory(sendRequest: HttpRequest => Try[HttpResponse],
+                          timeout: FiniteDuration = 2.seconds) extends HttpPoolFactory {
+
+  override def create[T](): Flow[(HttpRequest, T), (Try[HttpResponse], T), NotUsed] = {
+    Flow[(HttpRequest, T)]
+      .map {
+        case (r, s) => (Try(sendRequest(r)).flatten, s)
+      }
+  }
+
+  override def shutdown(): Future[Unit] = Future.successful(())
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -26,6 +26,7 @@ object Build extends AutoPlugin {
     val PlayJsonVersion        = "2.6.9"
     val ReactiveStreamsVersion = "1.0.2"
     val ScalatestVersion       = "3.0.5"
+    val ScalamockVersion       = "4.1.0"
     val Slf4jVersion           = "1.7.25"
   }
 


### PR DESCRIPTION
I've tried to implement here similar retry and host blacklisting logic as in the official REST client:
1. Exceptions and some HTTP status codes will trigger a retry until ```maxRetryTimeout``` is reached.
2. Exceptions and some HTTP status codes will mark a host dead and it will be excluded from round-robin for some time starting with ```blacklistMinDuration``` and up to ```blacklistMaxDuration```.

I've done some refactoring as well, primarily to make the client more unit-test friendly.