### PR TITLE
Small Bugfix on 5.6.X TCP Branch

### DIFF
--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/queries/MoreLikeThisQueryBuilderFn.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/queries/MoreLikeThisQueryBuilderFn.scala
@@ -17,9 +17,7 @@ object MoreLikeThisQueryBuilderFn {
 
       new MoreLikeThisQueryBuilder.Item(doc.index, doc.`type`, builder).routing(doc.routing.orNull)
     }
-
-    println(docs)
-
+    
     val builder = QueryBuilders.moreLikeThisQuery(
       q.fields.toArray,
       if (q.likeTexts.isEmpty) null else q.likeTexts.toArray,

--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/queries/geo/GeoDistanceQueryBuilder.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/queries/geo/GeoDistanceQueryBuilder.scala
@@ -12,6 +12,7 @@ object GeoDistanceQueryBuilder {
     q.geohash.foreach(builder.geohash)
     q.point.foreach { case (lat, long) => builder.point(lat, long) }
     q.distanceStr.foreach(builder.distance)
+    q.ignoreUnmapped.foreach(builder.ignoreUnmapped)
     q.distance.foreach { case (distance, unit) => builder.distance(distance, DistanceUnit.valueOf(unit.name)) }
     q.validationMethod.foreach(builder.setValidationMethod)
     builder


### PR DESCRIPTION
I am not sure your policy on pull requests, but this pull fixes two small issues that we had encountered in production. I know this is an older branch, but I wanted to submit it in case it would be useful to anyone else. 

The first removes a println statement that appears to leftover debugging info, and can't be disabled otherwise.

The second allows for the `ignoreUnmapped` parameter to be passed into the builder, currently - the parameter is ignored, and therefore generates a query with a value of `false` (since that is the default value in the java client). 