### PR TITLE
Fix support for path prefixing.

### DIFF
--- a/elastic4s-akka/src/test/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientMockTest.scala
+++ b/elastic4s-akka/src/test/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientMockTest.scala
@@ -8,7 +8,7 @@ import akka.http.scaladsl.model.{HttpRequest, HttpResponse, StatusCodes, Uri}
 import com.sksamuel.elastic4s.akka.AkkaHttpClient.AllHostsBlacklistedException
 import com.sksamuel.elastic4s.http.{ElasticRequest, HttpEntity => ElasticEntity, HttpResponse => ElasticResponse}
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.concurrent._
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
 
 class AkkaHttpClientMockTest
@@ -16,6 +16,7 @@ class AkkaHttpClientMockTest
     with Matchers
     with MockFactory
     with ScalaFutures
+    with IntegrationPatience
     with BeforeAndAfterAll {
 
   private implicit lazy val system = ActorSystem()

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/ElasticClient.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/ElasticClient.scala
@@ -81,13 +81,21 @@ object ElasticClient extends Logging {
   def apply[F[_] : Functor : Executor](props: ElasticProperties,
                                        requestConfigCallback: RequestConfigCallback,
                                        httpClientConfigCallback: HttpClientConfigCallback): ElasticClient = {
+
     val hosts = props.endpoints.map {
-      case ElasticNodeEndpoint(protocol, host, port, _) => new HttpHost(host, port, protocol)
+      case ElasticNodeEndpoint(protocol, host, port) => new HttpHost(host, port, protocol)
     }
+
     logger.info(s"Creating HTTP client on ${hosts.mkString(",")}")
 
-    val client = RestClient
-      .builder(hosts: _*)
+    val builder = RestClient.builder(hosts: _*)
+
+    props.prefix match {
+      case Some(prefix) => builder.setPathPrefix(prefix)
+      case _ =>
+    }
+
+    val client = builder
       .setRequestConfigCallback(requestConfigCallback)
       .setHttpClientConfigCallback(httpClientConfigCallback)
       .build()

--- a/elastic4s-testkit/src/main/scala/com/sksamuel/elastic4s/testkit/DockerTests.scala
+++ b/elastic4s-testkit/src/main/scala/com/sksamuel/elastic4s/testkit/DockerTests.scala
@@ -7,7 +7,9 @@ import scala.util.Try
 
 trait DockerTests extends com.sksamuel.elastic4s.http.ElasticDsl with ClientProvider {
 
-  val client = ElasticClient(ElasticProperties("http://localhost:9200"))
+  protected def elasticUri: String = "http://localhost:9200"
+
+  val client = ElasticClient(ElasticProperties(elasticUri))
 
   protected def deleteIdx(indexName: String): Unit = {
     Try {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/ElasticPropertiesTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/ElasticPropertiesTest.scala
@@ -7,19 +7,19 @@ class ElasticPropertiesTest extends FlatSpec with Matchers {
 
   "elasticsearch properties" should "parse multiple host/ports" in {
     ElasticProperties("http://host1:1234,host2:2345") shouldBe
-      http.ElasticProperties(Seq(ElasticNodeEndpoint("http", "host1", 1234, None), ElasticNodeEndpoint("http", "host2", 2345, None)))
+      http.ElasticProperties(Seq(ElasticNodeEndpoint("http", "host1", 1234), ElasticNodeEndpoint("http", "host2", 2345)))
   }
 
   it should "parse single host/ports" in {
-    ElasticProperties("http://host1:1234") shouldBe http.ElasticProperties(Seq(ElasticNodeEndpoint("http", "host1", 1234, None)))
+    ElasticProperties("http://host1:1234") shouldBe http.ElasticProperties(Seq(ElasticNodeEndpoint("http", "host1", 1234)))
   }
 
   it should "parse single host/ports with trailing slash" in {
-    ElasticProperties("http://host1:1234/") shouldBe http.ElasticProperties(Seq(ElasticNodeEndpoint("http", "host1", 1234, None)))
+    ElasticProperties("http://host1:1234/") shouldBe http.ElasticProperties(Seq(ElasticNodeEndpoint("http", "host1", 1234)))
   }
 
   it should "parse single host/ports with auth" in {
-    ElasticProperties("http://user:pass@host1:1234") shouldBe http.ElasticProperties(Seq(ElasticNodeEndpoint("http", "user:pass@host1", 1234, None)))
+    ElasticProperties("http://user:pass@host1:1234") shouldBe http.ElasticProperties(Seq(ElasticNodeEndpoint("http", "user:pass@host1", 1234)))
   }
 
   it should "errors on invalid host string" in {
@@ -30,12 +30,12 @@ class ElasticPropertiesTest extends FlatSpec with Matchers {
 
   it should "parse everything" in {
     ElasticProperties("http://user:pass@host1:1234?a=b&c=d") shouldBe
-      http.ElasticProperties(Seq(ElasticNodeEndpoint("http", "user:pass@host1", 1234, None)), Map("a" -> "b", "c" -> "d"))
+      http.ElasticProperties(Seq(ElasticNodeEndpoint("http", "user:pass@host1", 1234)), None, Map("a" -> "b", "c" -> "d"))
   }
 
   it should "parse everything with trailing slash" in {
     ElasticProperties("http://user:pass@host1:1234/?a=b&c=d") shouldBe
-      http.ElasticProperties(Seq(ElasticNodeEndpoint("http", "user:pass@host1", 1234, None)), Map("a" -> "b", "c" -> "d"))
+      http.ElasticProperties(Seq(ElasticNodeEndpoint("http", "user:pass@host1", 1234)), None, Map("a" -> "b", "c" -> "d"))
   }
 
   it should "error on missing values between commas" in {
@@ -46,30 +46,32 @@ class ElasticPropertiesTest extends FlatSpec with Matchers {
 
   it should "support https protocol" in {
     ElasticProperties("https://host1:1234,host2:2345") shouldBe
-      http.ElasticProperties(Seq(ElasticNodeEndpoint("https", "host1", 1234, None), ElasticNodeEndpoint("https", "host2", 2345, None)))
+      http.ElasticProperties(Seq(ElasticNodeEndpoint("https", "host1", 1234), ElasticNodeEndpoint("https", "host2", 2345)))
   }
 
   it should "support prefix path" in {
     ElasticProperties("https://host1:1234,host2:2345/prefix/path") shouldBe
-      http.ElasticProperties(Seq(ElasticNodeEndpoint("https", "host1", 1234, Some("/prefix/path")), ElasticNodeEndpoint("https", "host2", 2345, Some("/prefix/path"))))
+      http.ElasticProperties(Seq(ElasticNodeEndpoint("https", "host1", 1234), ElasticNodeEndpoint("https", "host2", 2345)), Some("/prefix/path"))
   }
 
   it should "support prefix path with trailing slash" in {
     ElasticProperties("https://host1:1234,host2:2345/prefix/path/") shouldBe
-      http.ElasticProperties(Seq(ElasticNodeEndpoint("https", "host1", 1234, Some("/prefix/path")), ElasticNodeEndpoint("https", "host2", 2345, Some("/prefix/path"))))
+      http.ElasticProperties(Seq(ElasticNodeEndpoint("https", "host1", 1234), ElasticNodeEndpoint("https", "host2", 2345)), Some("/prefix/path"))
   }
 
   it should "support prefix path with options" in {
     ElasticProperties("https://host1:1234,host2:2345/prefix/path?a=b&c=d") shouldBe
       http.ElasticProperties(
         Seq(
-          ElasticNodeEndpoint("https", "host1", 1234, Some("/prefix/path")),
-          ElasticNodeEndpoint("https", "host2", 2345, Some("/prefix/path"))
-        ), Map("a" -> "b", "c" -> "d"))
+          ElasticNodeEndpoint("https", "host1", 1234),
+          ElasticNodeEndpoint("https", "host2", 2345)
+        ),
+        Some("/prefix/path"),
+        Map("a" -> "b", "c" -> "d"))
   }
 
   it should "support prefix path with trailing slash and options" in {
     ElasticProperties("https://host1:1234,host2:2345/prefix/path/?a=b&c=d") shouldBe
-      http.ElasticProperties(Seq(ElasticNodeEndpoint("https", "host1", 1234, Some("/prefix/path")), ElasticNodeEndpoint("https", "host2", 2345, Some("/prefix/path"))), Map("a" -> "b", "c" -> "d"))
+      http.ElasticProperties(Seq(ElasticNodeEndpoint("https", "host1", 1234), ElasticNodeEndpoint("https", "host2", 2345)), Some("/prefix/path"), Map("a" -> "b", "c" -> "d"))
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/ElasticPropertiesTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/ElasticPropertiesTest.scala
@@ -54,6 +54,17 @@ class ElasticPropertiesTest extends FlatSpec with Matchers {
       http.ElasticProperties(Seq(ElasticNodeEndpoint("https", "host1", 1234), ElasticNodeEndpoint("https", "host2", 2345)), Some("/prefix/path"))
   }
 
+  it should "parse multiple hosts and a global prefix" in {
+    val expectedEndpoints = Seq(
+      ElasticNodeEndpoint("https", "host1", 11),
+      ElasticNodeEndpoint("https", "host2", 22),
+      ElasticNodeEndpoint("https", "host3", 33)
+    )
+
+    ElasticProperties("https://host1:11,host2:22,host3:33/prefixGlobal?fizz=buzz") shouldBe
+      http.ElasticProperties(expectedEndpoints, Some("/prefixGlobal"), Map("fizz" -> "buzz"))
+  }
+
   it should "support prefix path with trailing slash" in {
     ElasticProperties("https://host1:1234,host2:2345/prefix/path/") shouldBe
       http.ElasticProperties(Seq(ElasticNodeEndpoint("https", "host1", 1234), ElasticNodeEndpoint("https", "host2", 2345)), Some("/prefix/path"))

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/http/ElasticClientPrefixTests.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/http/ElasticClientPrefixTests.scala
@@ -1,0 +1,18 @@
+package com.sksamuel.elastic4s.http
+
+import com.sksamuel.elastic4s.testkit.DockerTests
+import org.scalatest.{FlatSpec, Matchers, OptionValues}
+
+class ElasticClientPrefixTests extends FlatSpec with Matchers with OptionValues with DockerTests {
+
+  override protected lazy val elasticUri: String = "http://localhost:9200/prefix"
+
+  "DefaultHttpClient" should "attempt and fail to read /prefix/testindex" in {
+    val response = client.execute {
+      count("textindex")
+    }.await
+
+    response.error.`type` shouldEqual "index_not_found_exception"
+    response.error.index.value shouldEqual "prefix"
+  }
+}


### PR DESCRIPTION
Addresses https://github.com/sksamuel/elastic4s/issues/1573.

Path prefixs are being read in and then immediately ignored.

I added a (janky) test in `ElasticClientPrefixTests` that goes about testing in a somewhat roundabout fashion. Let me know if you have suggestsions for improving this test.