### PR TITLE
Mirror HitReader typeclass instances with AggReader.

### DIFF
--- a/elastic4s-json4s/src/main/scala/com/sksamuel/elastic4s/json4s/ElasticJson4s.scala
+++ b/elastic4s-json4s/src/main/scala/com/sksamuel/elastic4s/json4s/ElasticJson4s.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.elastic4s.json4s
 
-import com.sksamuel.elastic4s.{Hit, HitReader, Indexable}
+import com.sksamuel.elastic4s.{AggReader, Hit, HitReader, Indexable}
 import org.json4s._
 
 import scala.reflect.Manifest
@@ -13,6 +13,13 @@ object ElasticJson4s {
       new HitReader[T] {
         override def read(hit: Hit): Try[T] = Try {
           json4s.read[T](hit.sourceAsString)
+        }
+      }
+
+    implicit def Json4sAggReader[T](implicit json4s: Serialization, formats: Formats, mf: Manifest[T]): AggReader[T] =
+      new AggReader[T] {
+        override def read(json: String): Try[T] = Try {
+          json4s.read[T](json)
         }
       }
 

--- a/elastic4s-play-json/src/main/scala/com/sksamuel/elastic4s/playjson/package.scala
+++ b/elastic4s-play-json/src/main/scala/com/sksamuel/elastic4s/playjson/package.scala
@@ -18,4 +18,11 @@ package object playjson {
       Json.parse(hit.sourceAsString).as[T]
     }
   }
+
+  @implicitNotFound("No Reads for type ${T} found. Bring an implicit Reads[T] instance in scope")
+  implicit def playJsonAggReader[T](implicit r: Reads[T]): AggReader[T] = new AggReader[T] {
+    override def read(json: String): Try[T] = Try {
+      Json.parse(json).as[T]
+    }
+  }
 }

--- a/elastic4s-spray-json/src/main/scala/com/sksamuel/elastic4s/sprayjson/package.scala
+++ b/elastic4s-spray-json/src/main/scala/com/sksamuel/elastic4s/sprayjson/package.scala
@@ -18,4 +18,11 @@ package object sprayjson {
       r.read(hit.sourceAsString.parseJson)
     }
   }
+
+  @implicitNotFound("No RootJsonReader for type ${T} found. Bring an implicit RootJsonReader[T] instance in scope")
+  implicit def sprayJsonAggReader[T](implicit r: RootJsonReader[T]): AggReader[T] = new AggReader[T] {
+    override def read(json: String): Try[T] = Try {
+      r.read(json.parseJson)
+    }
+  }
 }


### PR DESCRIPTION
`HitReader` is in all the json packages, but `AggReader` wasn't complete.

The only implementation missing now is the low level Jackson implementation, which is a lot more involved than these easy movers.

@sksamuel 