### PR TITLE
Fix for JsonMapperException in ElasticError

### DIFF
--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/ElasticErrorTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/ElasticErrorTest.scala
@@ -1,0 +1,16 @@
+//Unpublished Work (c) 2018 Deere & Company
+package com.sksamuel.elastic4s.http
+
+import com.sksamuel.elastic4s.http.HttpEntity.StringEntity
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{FlatSpec, Matchers}
+
+
+class ElasticErrorTest extends FlatSpec with Matchers with ElasticDsl with MockitoSugar {
+
+  "ElasticError" should "properly handle an error response with an empty body" in {
+    val error = ElasticError.parse(HttpResponse(123, Some(StringEntity("{", None)), Map()))
+    assert(error.reason == "123")
+  }
+
+}

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/ElasticErrorTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/ElasticErrorTest.scala
@@ -8,7 +8,7 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class ElasticErrorTest extends FlatSpec with Matchers with ElasticDsl with MockitoSugar {
 
-  "ElasticError" should "properly handle an error response with an empty body" in {
+  "ElasticError" should "properly handle an error response with an incorrect body" in {
     val error = ElasticError.parse(HttpResponse(123, Some(StringEntity("{", None)), Map()))
     assert(error.reason == "123")
   }


### PR DESCRIPTION
Addresses #1582 

Adds error handling around potential JsonMapperExceptions if the response body in an ElasticSearch error is incomplete or otherwise malformed.