### PR TITLE
Fix SearchType for MultiSearch

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/MultiSearchBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/MultiSearchBuilderFn.scala
@@ -14,7 +14,10 @@ object MultiSearchBuilderFn {
         header.field("type", search.indexesTypes.types.mkString(","))
       search.pref.foreach(header.field("preference", _))
       search.requestCache.map(_.toString).foreach(header.field("request_cache", _))
-      search.searchType.map(_.toString).foreach(header.field("search_type", _))
+      search.searchType
+        .filter(_ != SearchType.DEFAULT)
+        .map(SearchTypeHttpParameters.convert)
+        .foreach(header.field("search_type", _))
       header.endObject()
 
       val body = SearchBodyBuilderFn(search)

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/SearchType.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/SearchType.scala
@@ -6,7 +6,7 @@ object SearchType {
   case object DfsQueryThenFetch extends SearchType
   case object QueryThenFetch    extends SearchType
 
-  val DEFAULT: DfsQueryThenFetch.type = DfsQueryThenFetch
+  val DEFAULT: QueryThenFetch.type = QueryThenFetch
   val QUERY_THEN_FETCH: QueryThenFetch.type = QueryThenFetch
   val DFS_QUERY_THEN_FETCH: DfsQueryThenFetch.type = DfsQueryThenFetch
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/MultiSearchHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/MultiSearchHttpTest.scala
@@ -1,6 +1,7 @@
 package com.sksamuel.elastic4s.search
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
+import com.sksamuel.elastic4s.requests.searches.SearchType
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -82,6 +83,26 @@ class MultiSearchHttpTest
       """{"index":"jtull","preference":"first_preference"}
         |{"query":{"match":{"name":{"query":"aqualung"}}}}
         |{"index":"unknown","preference":"second_preference"}
+        |{"query":{"match_all":{}}}
+        |""".stripMargin
+
+    request.entity.head.get shouldBe expectedEntity
+  }
+
+  it should "correctly set the search type" in {
+
+    val request = MultiSearchHandler.build(
+      multi(
+        search("jtull") query matchQuery("name", "aqualung") searchType SearchType.DFS_QUERY_THEN_FETCH,
+        search("unknown") query matchAllQuery()
+      )
+    )
+
+
+    val expectedEntity =
+      """{"index":"jtull","search_type":"dfs_query_then_fetch"}
+        |{"query":{"match":{"name":{"query":"aqualung"}}}}
+        |{"index":"unknown"}
         |{"query":{"match_all":{}}}
         |""".stripMargin
 


### PR DESCRIPTION
Hey again,

here's another fix for MultiSearch. During implementation I noticed that you specified the default search type as `DfsQueryThenFetch`. The official [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-search-type.html#query-then-fetch) although states that the default is `QueryThenFetch`. I changed that. There's no test failing except for the `DateRangeQueryHttpTest` which is also broken on master.

It would be cool to get this also into a 6.5 release of elastic4s.

Cheers and many thanks!
Timo