### PR TITLE
Add support for realtime, preference, and refresh params in multiget

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/get/GetHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/get/GetHandlers.scala
@@ -32,7 +32,13 @@ trait GetHandlers {
     override def build(request: MultiGetRequest): ElasticRequest = {
       val body   = MultiGetBodyBuilder(request).string()
       val entity = HttpEntity(body, "application/json")
-      ElasticRequest("GET", "/_mget", entity)
+
+      val params = scala.collection.mutable.Map.empty[String, String]
+      request.preference.foreach(params.put("preference", _))
+      request.refresh.map(_.toString).foreach(params.put("refresh", _))
+      request.realtime.map(_.toString).foreach(params.put("realtime", _))
+
+      ElasticRequest("GET", "/_mget", params.toMap, entity)
     }
   }
 


### PR DESCRIPTION
This addresses #1646.

A couple things I was not sure about:
- Looking quickly, I didn't see existing examples of ensuring that we generate the expected get requests (including params, specifically), so I haven't added tests for this.
- I'd be happy to add this to the `multiget.md` doc... It seems like it'd have to go into a whole new usage pattern for how to set these fields, though - there doesn't seem to be a nice way to fit them into the `multiget(item, item, item)` DSL shown there, so it would have to show manual construction of the `MultiGetRequest` class.