### PR TITLE
Indices options support for indices exist request

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/admin/domain.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/admin/domain.scala
@@ -12,7 +12,6 @@ case class OpenIndexRequest(indexes: Indexes,
 
 case class CloseIndexRequest(indexes: Indexes)
 case class GetSegmentsRequest(indexes: Indexes)
-case class IndicesExistsRequest(indexes: Indexes)
 case class TypesExistsRequest(indexes: Seq[String], types: Seq[String])
 case class AliasExistsRequest(alias: String)
 case class IndexStatsRequest(indices: Indexes)
@@ -21,6 +20,11 @@ case class IndicesOptionsRequest(allowNoIndices: Boolean = false,
                                  ignoreUnavailable: Boolean = false,
                                  expandWildcardsOpen: Boolean = false,
                                  expandWildcardClosed: Boolean = false)
+
+case class IndicesExistsRequest(
+  indexes: Indexes,
+  indicesOptions: Option[IndicesOptionsRequest] = None
+)
 
 case class ClearCacheRequest(indexes: Seq[String],
                              fieldDataCache: Option[Boolean] = None,

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/admin/IndexAdminHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/admin/IndexAdminHandlers.scala
@@ -3,6 +3,7 @@ package com.sksamuel.elastic4s.requests.indexes.admin
 import java.net.URLEncoder
 
 import com.sksamuel.elastic4s.requests.admin.{AliasExistsRequest, ClearCacheRequest, CloseIndexRequest, FlushIndexRequest, GetSegmentsRequest, IndexShardStoreRequest, IndicesExistsRequest, OpenIndexRequest, RefreshIndexRequest, ShrinkIndexRequest, TypesExistsRequest, UpdateIndexLevelSettingsRequest}
+import com.sksamuel.elastic4s.requests.common.IndicesOptionsParams
 import com.sksamuel.elastic4s.requests.indexes._
 import com.sksamuel.elastic4s.requests.indexes.admin.IndexShardStoreResponse.StoreStatusResponse
 import com.sksamuel.elastic4s.{ElasticError, ElasticRequest, Handler, HttpEntity, HttpResponse, ResponseHandler, XContentFactory}
@@ -106,7 +107,10 @@ trait IndexAdminHandlers {
 
     override def build(request: IndicesExistsRequest): ElasticRequest = {
       val endpoint = s"/${request.indexes.string}"
-      ElasticRequest("HEAD", endpoint)
+
+      val params = request.indicesOptions.map(IndicesOptionsParams(_)).getOrElse(Map.empty)
+
+      ElasticRequest("HEAD", endpoint, params)
     }
   }
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/IndexExistsTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/IndexExistsTest.scala
@@ -1,5 +1,6 @@
 package com.sksamuel.elastic4s.requests.indexes
 
+import com.sksamuel.elastic4s.requests.admin.{IndicesExistsRequest, IndicesOptionsRequest}
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.{Matchers, WordSpec}
 
@@ -28,6 +29,19 @@ class IndexExistsTest extends WordSpec with Matchers with DockerTests {
     "return false for non existing index" in {
       client.execute {
         indexExists("qweqwewqe")
+      }.await.result.isExists shouldBe false
+    }
+  }
+
+  "an index exist request with wildcard" should {
+    "return true when no indices were found and allowNoIndices=true" in {
+      client.execute {
+        IndicesExistsRequest(indexes = "qweqwe*", indicesOptions = Some(IndicesOptionsRequest(allowNoIndices = true)))
+      }.await.result.isExists shouldBe true
+    }
+    "return false when no indices were found and allowNoIndices=false" in {
+      client.execute {
+        IndicesExistsRequest(indexes = "qweqwe*", indicesOptions = Some(IndicesOptionsRequest(allowNoIndices = false)))
       }.await.result.isExists shouldBe false
     }
   }


### PR DESCRIPTION
We need a way to pass allow_no_indices param when checking for existence of indices using a wildcard.
For example, `HEAD /nonexistent*?allow_no_indices=false` returns 404 Not Found and HEAD /nonexistent* always returns 200 Ok.

This PR adds indices options to IndicesExistsRequest.