### PR TITLE
Added Utility Function getAgg to `HasAggregations` trait

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggresponses.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggresponses.scala
@@ -403,6 +403,11 @@ trait HasAggregations extends Transformable {
 
   def dataAsMap: Map[String, Any] = if(data != null) data else Map.empty
 
+  def getAgg(name: String): Option[Aggregations] = dataAsMap.get(name) match {
+    case Some(agg: Map[_, _]) => Some(Aggregations(agg.asInstanceOf[Map[String, Any]]))
+    case _ => None
+  }
+
   def contains(name: String): Boolean = data.contains(name)
   def names: Iterable[String] = data.keys
 


### PR DESCRIPTION
Added Utility Function `getAgg` to `HasAggregations` trait so that it'd easier to traverse cascaded aggregations in a generic way.
e.g.:
```scala
val agg:Option[Aggregations] = response.aggregations.getAgg("named-aggration")
```
or 
```scala
val agg:Option[Aggregations] = response.aggregations
                                          .getAgg("named-aggration")
                                          .flatMap(_.getAgg("sub-named-aggreation"))
```