### PR TITLE
Add sourceAsString method to InnerHit

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/responses.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/responses.scala
@@ -120,6 +120,7 @@ case class InnerHit(index: String,
     }
   }
 
+  def sourceAsString: String = SourceAsContentBuilder(source).string()
 }
 
 case class SearchResponse(took: Long,


### PR DESCRIPTION
This method is the same as SearchHit#sourceAsString.

Relates to #1659.