### PR TITLE
Fix text field index options

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/mappings/CommonFieldBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/mappings/CommonFieldBuilder.scala
@@ -116,6 +116,7 @@ object FieldBuilderFn {
         text.maxInputLength.foreach(builder.field("max_input_length", _))
         text.ignoreAbove.foreach(builder.field("ignore_above", _))
         text.similarity.foreach(builder.field("similarity", _))
+        text.indexOptions.foreach(builder.field("index_options", _))
 
       case keyword: KeywordField =>
         keyword.eagerGlobalOrdinals.foreach(builder.field("eager_global_ordinals", _))

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/mappings/TextField.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/mappings/TextField.scala
@@ -55,6 +55,7 @@ case class TextField(name: String,
   override def includeInAll(includeInAll: Boolean): T = copy(includeInAll = includeInAll.some)
 
   override def index(index: Boolean): T = copy(index = index.toString.some)
+  def indexOptions(indexOptions: String): T = copy(indexOptions = indexOptions.some)
 
   def positionIncrementGap(positionIncrementGap: Int): T = copy(positionIncrementGap = positionIncrementGap.some)
   def maxInputLength(maxInputLength: Int): T             = copy(maxInputLength = maxInputLength.some)

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/TextFieldTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/TextFieldTest.scala
@@ -11,6 +11,7 @@ class TextFieldTest extends FlatSpec with Matchers with ElasticApi {
       .fielddata(true)
       .stored(true)
       .index(true)
+      .indexOptions("freqs")
       .norms(true)
       .normalizer("mynorm")
       .analyzer(ArmenianLanguageAnalyzer)
@@ -25,6 +26,6 @@ class TextFieldTest extends FlatSpec with Matchers with ElasticApi {
       .nullable(false)
       .nullValue("nully")
     FieldBuilderFn(field).string() shouldBe
-      """{"type":"text","analyzer":"armenian","boost":1.2,"copy_to":["copy1","copy2"],"doc_values":true,"index":"true","normalizer":"mynorm","norms":true,"null_value":"nully","search_analyzer":"english","store":true,"fielddata":true,"max_input_length":12,"ignore_above":30,"similarity":"classic"}"""
+      """{"type":"text","analyzer":"armenian","boost":1.2,"copy_to":["copy1","copy2"],"doc_values":true,"index":"true","normalizer":"mynorm","norms":true,"null_value":"nully","search_analyzer":"english","store":true,"fielddata":true,"max_input_length":12,"ignore_above":30,"similarity":"classic","index_options":"freqs"}"""
   }
 }


### PR DESCRIPTION
TextField contains parameter `index_options` but it is unused in
CommonFieldBuilder omitting the value from mappings.