### PR TITLE
Add level parameter to cluster health query

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/cluster/ClusterApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/cluster/ClusterApi.scala
@@ -40,7 +40,8 @@ case class ClusterHealthRequest(indices: Seq[String],
                                 waitForEvents: Option[Priority] = None,
                                 waitForStatus: Option[HealthStatus] = None,
                                 waitForNodes: Option[String] = None,
-                                waitForNoRelocatingShards: Option[Boolean] = None) {
+                                waitForNoRelocatingShards: Option[Boolean] = None,
+                                level: Option[ClusterHealthLevel] = None) {
 
   def timeout(value: String): ClusterHealthRequest = copy(timeout = value.some)
 
@@ -56,4 +57,21 @@ case class ClusterHealthRequest(indices: Seq[String],
 
   def waitForNoRelocatingShards(waitForNoRelocatingShards: Boolean): ClusterHealthRequest =
     copy(waitForNoRelocatingShards = waitForNoRelocatingShards.some)
+
+  def level(level: ClusterHealthLevel): ClusterHealthRequest =
+    copy(level = level.some)
+}
+
+sealed trait ClusterHealthLevel
+
+object ClusterHealthLevel {
+  def valueOf(str: String): ClusterHealthLevel = str.toLowerCase match {
+    case "cluster" => Cluster
+    case "indices" => Indices
+    case "shards" => Shards
+  }
+
+  case object Cluster extends ClusterHealthLevel
+  case object Indices extends ClusterHealthLevel
+  case object Shards extends ClusterHealthLevel
 }

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/EnumConversions.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/EnumConversions.scala
@@ -1,20 +1,15 @@
 package com.sksamuel.elastic4s.http
 
-import com.sksamuel.elastic4s.{VersionType, DistanceUnit}
-import com.sksamuel.elastic4s.DistanceUnit.{Inch, Yard, Feet, Kilometers, NauticalMiles, Millimeters, Centimeters, Miles, Meters}
+import com.sksamuel.elastic4s.{DistanceUnit, VersionType}
+import com.sksamuel.elastic4s.DistanceUnit.{Centimeters, Feet, Inch, Kilometers, Meters, Miles, Millimeters, NauticalMiles, Yard}
+import com.sksamuel.elastic4s.cluster.ClusterHealthLevel
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 import com.sksamuel.elastic4s.searches.QueryRescoreMode.{Avg, Max, Min, Multiply, Total}
 import com.sksamuel.elastic4s.searches.aggs.{HistogramOrder, SubAggCollectionMode, TermsOrder}
 import com.sksamuel.elastic4s.searches.queries.funcscorer.{CombineFunction, FunctionScoreQueryScoreMode, MultiValueMode}
 import com.sksamuel.elastic4s.searches.queries.geo.GeoDistance.{Arc, Plane}
 import com.sksamuel.elastic4s.searches.queries.geo.{GeoDistance, GeoExecType, GeoValidationMethod}
-import com.sksamuel.elastic4s.searches.queries.matches.MultiMatchQueryBuilderType.{
-  BEST_FIELDS,
-  CROSS_FIELDS,
-  MOST_FIELDS,
-  PHRASE,
-  PHRASE_PREFIX
-}
+import com.sksamuel.elastic4s.searches.queries.matches.MultiMatchQueryBuilderType.{BEST_FIELDS, CROSS_FIELDS, MOST_FIELDS, PHRASE, PHRASE_PREFIX}
 import com.sksamuel.elastic4s.searches.queries.matches.{MultiMatchQueryBuilderType, ZeroTermsQuery}
 import com.sksamuel.elastic4s.searches.queries.{RegexpFlag, SimpleQueryStringFlag}
 import com.sksamuel.elastic4s.searches.sort.{SortMode, SortOrder}
@@ -82,9 +77,11 @@ object EnumConversions {
 
   def scoreMode(scoreMode: ScoreMode): String = scoreMode.toString.toLowerCase
 
-  def scoreMode(scoreMode: FunctionScoreQueryScoreMode): String = scoreMode.toString.toLowerCase
+  def scoreMode(scoreMode: FunctionScoreQueryScoreMode): String =
+    scoreMode.toString.toLowerCase
 
-  def boostMode(combineFunction: CombineFunction): String = combineFunction.toString.toLowerCase
+  def boostMode(combineFunction: CombineFunction): String =
+    combineFunction.toString.toLowerCase
 
   def geoExecType(execType: GeoExecType): String = execType.toString.toLowerCase
 
@@ -96,7 +93,7 @@ object EnumConversions {
 
   def collectMode(mode: SubAggCollectionMode): String = mode match {
     case SubAggCollectionMode.BreadthFirst => "breadth_first"
-    case SubAggCollectionMode.DepthFirst => "depth_first"
+    case SubAggCollectionMode.DepthFirst   => "depth_first"
   }
 
   def versionType(versionType: VersionType): String = versionType match {
@@ -112,7 +109,8 @@ object EnumConversions {
 
   def stringDistance(impl: StringDistanceImpl): String = impl.toString
 
-  def simpleQueryStringFlag(flag: SimpleQueryStringFlag): String = flag.toString.toUpperCase
+  def simpleQueryStringFlag(flag: SimpleQueryStringFlag): String =
+    flag.toString.toUpperCase
 
   def fuzziness(fuzziness: Fuzziness): String = fuzziness match {
     case Fuzziness.Zero => "0"
@@ -136,13 +134,14 @@ object EnumConversions {
     case ZeroTermsQuery.None => "none"
   }
 
-  def multiMatchQueryBuilderType(mtype: MultiMatchQueryBuilderType): String = mtype match {
-    case BEST_FIELDS   => "best_fields"
-    case MOST_FIELDS   => "most_fields"
-    case CROSS_FIELDS  => "cross_fields"
-    case PHRASE        => "phrase"
-    case PHRASE_PREFIX => "phrase_prefix"
-  }
+  def multiMatchQueryBuilderType(mtype: MultiMatchQueryBuilderType): String =
+    mtype match {
+      case BEST_FIELDS   => "best_fields"
+      case MOST_FIELDS   => "most_fields"
+      case CROSS_FIELDS  => "cross_fields"
+      case PHRASE        => "phrase"
+      case PHRASE_PREFIX => "phrase_prefix"
+    }
 
   def multiValueMode(mode: MultiValueMode): String =
     mode match {
@@ -153,4 +152,10 @@ object EnumConversions {
       case MultiValueMode.Median => "median"
     }
 
+  def clusterHealthLevel(level: ClusterHealthLevel): String =
+    level match {
+      case ClusterHealthLevel.Cluster => "cluster"
+      case ClusterHealthLevel.Indices => "indices"
+      case ClusterHealthLevel.Shards  => "shards"
+    }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/cluster/ClusterHealthHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/cluster/ClusterHealthHttpTest.scala
@@ -1,0 +1,156 @@
+package com.sksamuel.elastic4s.cluster
+
+import com.sksamuel.elastic4s.http.cluster.{ClusterHealthIndex, ClusterHealthShard}
+import com.sksamuel.elastic4s.testkit.DockerTests
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.util.Try
+
+class ClusterHealthHttpTest extends WordSpec with Matchers with DockerTests {
+
+  private val Index1Name = "cluster-health-1"
+  private val Index2Name = "cluster-health-2"
+  private val Index3Name = "cluster-health-3"
+
+  Try {
+    client.execute {
+      deleteIndex(Index1Name, Index2Name, Index3Name)
+    }.await
+  }
+
+  client.execute {
+    createIndex(Index1Name)
+      .shards(1)
+      .replicas(0)
+      .waitForActiveShards(1)
+  }.await
+
+  client.execute {
+    createIndex(Index2Name)
+      .shards(1)
+      .replicas(1)
+      .waitForActiveShards(1)
+  }.await
+
+  client.execute {
+    createIndex(Index3Name)
+      .shards(5)
+      .replicas(2)
+      .waitForActiveShards(1)
+  }.await
+
+  "cluster health request" should {
+    "return cluster health for whole cluster" in {
+
+      val health = client
+        .execute {
+          clusterHealth()
+        }.await.result
+
+      health.clusterName shouldBe "docker-cluster"
+      health.timeOut shouldBe false
+      health.status should fullyMatch regex "(yellow)|(red)".r
+      health.activeShards should be > 0
+      health.activePrimaryShards should be > 0
+      health.numberOfDataNodes shouldBe 1
+
+      health.indices shouldBe null
+    }
+  }
+
+  // active_shards_percent_as_number seems to be buggy and doesn't always filter correctly ;-(
+
+  "cluster health request with indices filter" should {
+    "return cluster health" in {
+
+      val health = client
+        .execute {
+          clusterHealth(Index1Name, Index2Name)
+        }.await.result
+
+      health.timeOut shouldBe false
+      health.clusterName shouldBe "docker-cluster"
+      health.status shouldBe "yellow"
+      health.numberOfNodes shouldBe 1
+      health.numberOfDataNodes shouldBe 1
+
+      health.activeShards shouldBe 2
+      health.activePrimaryShards shouldBe 2
+      health.relocatingShards shouldBe 0
+      health.initializingShards shouldBe 0
+      health.unassignedShards shouldBe 1
+      health.delayedUnassignedShards shouldBe 0
+      health.numberOfPendingTasks shouldBe 0
+      health.numberOfInFlightFetch shouldBe 0
+      health.activeShardsPercentAsNumber should be < 100.0
+
+      health.indices shouldBe null
+    }
+
+    "return cluster health with indices level" in {
+
+      val health = client
+        .execute {
+          clusterHealth(Index1Name, Index2Name) level ClusterHealthLevel.Indices
+        }.await.result
+
+      health.timeOut shouldBe false
+      health.clusterName shouldBe "docker-cluster"
+      health.status shouldBe "yellow"
+      health.numberOfNodes shouldBe 1
+      health.numberOfDataNodes shouldBe 1
+
+      health.activeShards shouldBe 2
+      health.activePrimaryShards shouldBe 2
+      health.relocatingShards shouldBe 0
+      health.initializingShards shouldBe 0
+      health.unassignedShards shouldBe 1
+      health.delayedUnassignedShards shouldBe 0
+      health.numberOfPendingTasks shouldBe 0
+      health.numberOfInFlightFetch shouldBe 0
+      health.activeShardsPercentAsNumber should be < 100.0
+
+      health.indices shouldBe Map(
+        Index1Name -> ClusterHealthIndex("green", 1, 0, 1, 1, 0, 0, 0, null),
+        Index2Name -> ClusterHealthIndex("yellow", 1, 1, 1, 1, 0, 0, 1, null)
+      )
+    }
+
+    "return cluster health with shards level" in {
+
+      val health = client
+        .execute {
+          clusterHealth(Index1Name, Index3Name) level ClusterHealthLevel.Shards
+        }.await.result
+
+      health.timeOut shouldBe false
+      health.clusterName shouldBe "docker-cluster"
+      health.status shouldBe "yellow"
+      health.numberOfNodes shouldBe 1
+      health.numberOfDataNodes shouldBe 1
+
+      health.activeShards shouldBe 6
+      health.activePrimaryShards shouldBe 6
+      health.relocatingShards shouldBe 0
+      health.initializingShards shouldBe 0
+      health.unassignedShards shouldBe 10
+      health.delayedUnassignedShards shouldBe 0
+      health.numberOfPendingTasks shouldBe 0
+      health.numberOfInFlightFetch shouldBe 0
+      health.activeShardsPercentAsNumber should be < 100.0
+
+      health.indices shouldBe Map(
+        Index1Name -> ClusterHealthIndex("green", 1, 0, 1, 1, 0, 0, 0, Map(
+          "0" -> ClusterHealthShard("green", primaryActive = true, 1, 0, 0, 0)
+        )),
+        Index3Name -> ClusterHealthIndex("yellow", 5, 2, 5, 5, 0, 0, 10, Map(
+          "0" -> ClusterHealthShard("yellow", primaryActive = true, 1, 0, 0, 2),
+          "1" -> ClusterHealthShard("yellow", primaryActive = true, 1, 0, 0, 2),
+          "2" -> ClusterHealthShard("yellow", primaryActive = true, 1, 0, 0, 2),
+          "3" -> ClusterHealthShard("yellow", primaryActive = true, 1, 0, 0, 2),
+          "4" -> ClusterHealthShard("yellow", primaryActive = true, 1, 0, 0, 2)
+        ))
+      )
+    }
+  }
+}


### PR DESCRIPTION
This adds support for the `level` parameter to the `clusterHealth` request which allows querying health at the index and shard level.

The default `clusterHealth` query will continue to behave as it does currently and adding a call to `level` will request the extra information:

```scala
// default (cluster level)
val health1 = client.execute {
    clusterHealth()
  }.await.result
// health.indices == null

// index level
val health2 = client.execute {
    clusterHealth() level ClusterHealthLevel.Indices
  }.await.result
// health2.indices == Map(index -> health)

// shard level
val health3 = client.execute {
    clusterHealth() level ClusterHealthLevel.Shards
  }.await.result
// health3.indices == Map(index -> health) with health.shards == Map(shard -> health)
```

Also added tests for the existing & new cluster health code.