### PR TITLE
use string instead of int for minimum_should_match in query_string and simple_query_string

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/QueryStringQuery.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/QueryStringQuery.scala
@@ -19,7 +19,7 @@ case class QueryStringQuery(query: String,
                             fuzzyPrefixLength: Option[Int] = None,
                             fuzzyRewrite: Option[String] = None,
                             lenient: Option[Boolean] = None,
-                            minimumShouldMatch: Option[Int] = None,
+                            minimumShouldMatch: Option[String] = None,
                             phraseSlop: Option[Int] = None,
                             quoteFieldSuffix: Option[String] = None,
                             queryName: Option[String] = None,
@@ -67,7 +67,7 @@ case class QueryStringQuery(query: String,
   def lenient(lenient: Boolean): QueryStringQuery =
     copy(lenient = lenient.some)
 
-  def minimumShouldMatch(minimumShouldMatch: Int): QueryStringQuery =
+  def minimumShouldMatch(minimumShouldMatch: String): QueryStringQuery =
     copy(minimumShouldMatch = minimumShouldMatch.some)
 
   def enablePositionIncrements(enablePositionIncrements: Boolean): QueryStringQuery =

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/SimpleStringQuery.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/SimpleStringQuery.scala
@@ -29,7 +29,7 @@ case class SimpleStringQuery(query: String,
                              lenient: Option[Boolean] = None,
                              fields: Seq[(String, Option[Double])] = Nil,
                              flags: Seq[SimpleQueryStringFlag] = Nil,
-                             minimumShouldMatch: Option[Int] = None)
+                             minimumShouldMatch: Option[String] = None)
     extends Query {
 
   def quoteFieldSuffix(suffix: String): SimpleStringQuery     = copy(quote_field_suffix = suffix.some)
@@ -41,7 +41,7 @@ case class SimpleStringQuery(query: String,
 
   def lenient(lenient: Boolean): SimpleStringQuery = copy(lenient = lenient.some)
 
-  def minimumShouldMatch(minimumShouldMatch: Int): SimpleStringQuery =
+  def minimumShouldMatch(minimumShouldMatch: String): SimpleStringQuery =
     copy(minimumShouldMatch = minimumShouldMatch.some)
 
   def analyzeWildcard(analyzeWildcard: Boolean): SimpleStringQuery =


### PR DESCRIPTION
This is needed to specify absolute values, percentages or a combination of both
https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-minimum-should-match.html