### PR TITLE
add auto_generate_synonyms_phrase_query parameter

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/QueryStringQuery.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/QueryStringQuery.scala
@@ -9,6 +9,7 @@ case class QueryStringQuery(query: String,
                             analyzeWildcard: Option[Boolean] = None,
                             analyzer: Option[String] = None,
                             autoGeneratePhraseQueries: Option[Boolean] = None,
+                            autoGenerateSynonymsPhraseQuery: Option[Boolean] = None,
                             boost: Option[Double] = None,
                             defaultOperator: Option[String] = None,
                             defaultField: Option[String] = None,
@@ -90,6 +91,9 @@ case class QueryStringQuery(query: String,
 
   def autoGeneratePhraseQueries(autoGeneratePhraseQueries: Boolean): QueryStringQuery =
     copy(autoGeneratePhraseQueries = autoGeneratePhraseQueries.some)
+
+  def autoGenerateSynonymsPhraseQuery(autoGenerateSynonymsPhraseQuery: Boolean): QueryStringQuery =
+    copy(autoGenerateSynonymsPhraseQuery = autoGenerateSynonymsPhraseQuery.some)
 
   def phraseSlop(phraseSlop: Int): QueryStringQuery = copy(phraseSlop = phraseSlop.some)
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/SimpleStringQuery.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/SimpleStringQuery.scala
@@ -29,7 +29,7 @@ case class SimpleStringQuery(query: String,
                              lenient: Option[Boolean] = None,
                              fields: Seq[(String, Option[Double])] = Nil,
                              flags: Seq[SimpleQueryStringFlag] = Nil,
-                             minimumShouldMatch: Option[String] = None),
+                             minimumShouldMatch: Option[String] = None,
                              autoGenerateSynonymsPhraseQuery: Option[Boolean] = None)
     extends Query {
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/SimpleStringQuery.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/SimpleStringQuery.scala
@@ -29,7 +29,8 @@ case class SimpleStringQuery(query: String,
                              lenient: Option[Boolean] = None,
                              fields: Seq[(String, Option[Double])] = Nil,
                              flags: Seq[SimpleQueryStringFlag] = Nil,
-                             minimumShouldMatch: Option[Int] = None)
+                             minimumShouldMatch: Option[Int] = None,
+                             autoGenerateSynonymsPhraseQuery: Option[Boolean] = None)
     extends Query {
 
   def quoteFieldSuffix(suffix: String): SimpleStringQuery     = copy(quote_field_suffix = suffix.some)
@@ -50,4 +51,7 @@ case class SimpleStringQuery(query: String,
   def asfields(fields: String*): SimpleStringQuery          = copy(fields = this.fields ++ fields.map(f => (f, None)))
   def field(name: String): SimpleStringQuery                = copy(fields = fields :+ (name, None))
   def field(name: String, boost: Double): SimpleStringQuery = copy(fields = fields :+ (name, boost.some))
+
+  def autoGenerateSynonymsPhraseQuery(autoGenerateSynonymsPhraseQuery: Boolean): SimpleStringQuery =
+    copy(autoGenerateSynonymsPhraseQuery = autoGenerateSynonymsPhraseQuery.some)
 }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/matches/MultiMatchQuery.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/matches/MultiMatchQuery.scala
@@ -54,7 +54,8 @@ case class MultiMatchQuery(text: String,
                            tieBreaker: Option[Double] = None,
                            `type`: Option[MultiMatchQueryBuilderType] = None,
                            zeroTermsQuery: Option[ZeroTermsQuery] = None,
-                           boost: Option[Double] = None)
+                           boost: Option[Double] = None,
+                           autoGenerateSynonymsPhraseQuery: Option[Boolean] = None)
     extends Query {
 
   def fuzzyRewrite(f: String): MultiMatchQuery       = copy(fuzzyRewrite = f.some)
@@ -89,4 +90,6 @@ case class MultiMatchQuery(text: String,
   def tieBreaker(tieBreaker: Double): MultiMatchQuery      = copy(tieBreaker = tieBreaker.some)
   def zeroTermsQuery(ztq: String): MultiMatchQuery         = copy(zeroTermsQuery = ZeroTermsQuery.valueOf(ztq).some)
   def zeroTermsQuery(ztq: ZeroTermsQuery): MultiMatchQuery = copy(zeroTermsQuery = ztq.some)
+  def autoGenerateSynonymsPhraseQuery(autoGenerateSynonymsPhraseQuery: Boolean): MultiMatchQuery =
+    copy(autoGenerateSynonymsPhraseQuery = autoGenerateSynonymsPhraseQuery.some)
 }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/text/MultiMatchBodyFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/text/MultiMatchBodyFn.scala
@@ -25,6 +25,7 @@ object MultiMatchBodyFn {
     q.slop.foreach(builder.field("slop", _))
     q.tieBreaker.foreach(builder.field("tie_breaker", _))
     q.zeroTermsQuery.map(EnumConversions.zeroTermsQuery).foreach(builder.field("zero_terms_query", _))
+    q.autoGenerateSynonymsPhraseQuery.map(_.toString).foreach(builder.field("auto_generate_synonyms_phrase_query", _))
     q.boost.foreach(builder.field("boost", _))
     q.queryName.foreach(builder.field("_name", _))
     builder.endObject()

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/text/QueryStringBodyFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/text/QueryStringBodyFn.scala
@@ -17,6 +17,7 @@ object QueryStringBodyFn {
     s.fuzziness.map(_.toString).foreach(builder.field("fuzziness", _))
     s.phraseSlop.map(_.toString).foreach(builder.field("phrase_slop", _))
     s.autoGeneratePhraseQueries.map(_.toString).foreach(builder.field("auto_generate_phrase_queries", _))
+    s.autoGenerateSynonymsPhraseQuery.map(_.toString).foreach(builder.field("auto_generate_synonyms_phrase_query", _))
     s.allowLeadingWildcard.map(_.toString).foreach(builder.field("allow_leading_wildcard", _))
     s.enablePositionIncrements.map(_.toString).foreach(builder.field("enable_position_increments", _))
     s.boost.foreach(builder.field("boost", _))

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/text/SimpleStringBodyFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/text/SimpleStringBodyFn.scala
@@ -11,6 +11,7 @@ object SimpleStringBodyFn {
     s.analyzeWildcard.map(_.toString).foreach(builder.field("analyze_wildcard", _))
     s.lenient.map(_.toString).foreach(builder.field("lenient", _))
     s.minimumShouldMatch.map(_.toString).foreach(builder.field("minimum_should_match", _))
+    s.autoGenerateSynonymsPhraseQuery.map(_.toString).foreach(builder.field("auto_generate_synonyms_phrase_query", _))
     s.quote_field_suffix.foreach(builder.field("quote_field_suffix", _))
     if (s.fields.nonEmpty) {
       val fields = s.fields.map {


### PR DESCRIPTION
Add to multi_match_query, query_string and simple_query_string.

Introduced in ES 6.1 https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html#query-dsl-match-query-synonyms