### PR TITLE
#948 missing percentiles fix into 5.6.X

### DIFF
--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/aggs/PercentilesAggregationBuilder.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/aggs/PercentilesAggregationBuilder.scala
@@ -12,6 +12,8 @@ object PercentilesAggregationBuilder {
     val builder = AggregationBuilders.percentiles(agg.name)
     agg.field.foreach(builder.field)
     agg.missing.foreach(builder.missing)
+    if (agg.percents.nonEmpty)
+      builder.percentiles(agg.percents: _*)
     agg.numberOfSignificantValueDigits.foreach(builder.numberOfSignificantValueDigits)
     agg.format.foreach(builder.format)
     agg.script.map(ScriptBuilder.apply).foreach(builder.script)


### PR DESCRIPTION
This is the same fix as [https://github.com/sksamuel/elastic4s/issues/948](url) being applied to version 5.6.X