### PR TITLE
Downgrade slf4j version to 1.7.26

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -11,7 +11,7 @@ object Build extends Build {
   val ScalatestVersion = "3.0.5"
   val MockitoVersion = "1.9.5"
   val JacksonVersion = "2.9.6"
-  val Slf4jVersion = "1.8.0-beta2"
+  val Slf4jVersion = "1.7.26"
   val ScalaLoggingVersion = "3.9.0"
   val ElasticsearchVersion = "1.7.5"
   val Log4jVersion = "1.2.17"

--- a/project/build.properties
+++ b/project/build.properties
@@ -14,4 +14,4 @@
 # limitations under the License.
 #Project properties
 #Mon Feb 28 11:55:49 PST 2011
-sbt.version=0.13.7
+sbt.version=0.13.17


### PR DESCRIPTION
The `release/1.7.x` branch had its slf4j version upgraded to 1.8.0-beta2 [a while back](https://github.com/sksamuel/elastic4s/commit/520011012272fd85817eaf0616fe84a73d6ff92e). This has rendered the 1.7.7 release unusable to us, due to pulling our slf4j version up to the experimental 1.8 minor release. Can we release 1.7.8 with the non-beta version of slf4j?

NOTE: I also upgraded sbt to 0.13.17 to fix a coursier resolution error.