### PR TITLE
rename PorterStemTokenFilter's name to "porter_stem"

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/analyzers/TokenFilter.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/analyzers/TokenFilter.scala
@@ -42,7 +42,7 @@ case object KStemTokenFilter extends TokenFilter {
 }
 
 case object PorterStemTokenFilter extends TokenFilter {
-  val name = "porterStem"
+  val name = "porter_stem"
 }
 
 case object UniqueTokenFilter extends TokenFilter {


### PR DESCRIPTION
`"porterStem"` is not to spec for Elasticsearch 6.5.x and above as I outlined in the issue reported [here](https://github.com/sksamuel/elastic4s/issues/1692).

`"porter_stem"` is the correct value defined by elasticsearch.