### PR TITLE
rename PorterStemTokenFilter's name to "porter_stem"

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/analyzers/TokenFilter.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/analyzers/TokenFilter.scala
@@ -40,7 +40,7 @@ case object KStemTokenFilter extends TokenFilter {
 }
 
 case object PorterStemTokenFilter extends TokenFilter {
-  val name = "porterStem"
+  val name = "porter_stem"
 }
 
 case object UniqueTokenFilter extends TokenFilter {


### PR DESCRIPTION
[This is a copy of this change against 6.5.x]

`"porterStem"` is not to spec for Elasticsearch 6.5.x and above as I outlined in the issue reported [here](https://github.com/sksamuel/elastic4s/issues/1692).

`"porter_stem"` is the correct value defined by elasticsearch.