### PR TITLE
(akka client) do not read response if method is HEAD

### DIFF
--- a/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/HttpPoolFactory.scala
+++ b/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/HttpPoolFactory.scala
@@ -12,7 +12,7 @@ import akka.stream.scaladsl.Flow
   */
 private[akka] trait HttpPoolFactory {
 
-  def create[T](): Flow[(HttpRequest, T), (Try[HttpResponse], T), NotUsed]
+  def create[T](): Flow[(HttpRequest, T), (HttpRequest, Try[HttpResponse], T), NotUsed]
 
   def shutdown(): Future[Unit]
 }

--- a/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientTest.scala
+++ b/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientTest.scala
@@ -94,5 +94,11 @@ class AkkaHttpClientTest extends FlatSpec with Matchers with DockerTests with Be
 
   }
 
+  it should "work with head methods" in {
+    client.execute(
+      indexExists("unknown_index")
+    ).await.result
+  }
+
 }
 

--- a/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/TestHttpPoolFactory.scala
+++ b/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/TestHttpPoolFactory.scala
@@ -11,10 +11,10 @@ import akka.stream.scaladsl.Flow
 class TestHttpPoolFactory(sendRequest: HttpRequest => Try[HttpResponse],
                           timeout: FiniteDuration = 2.seconds) extends HttpPoolFactory {
 
-  override def create[T](): Flow[(HttpRequest, T), (Try[HttpResponse], T), NotUsed] = {
+  override def create[T](): Flow[(HttpRequest, T), (HttpRequest, Try[HttpResponse], T), NotUsed] = {
     Flow[(HttpRequest, T)]
       .map {
-        case (r, s) => (Try(sendRequest(r)).flatten, s)
+        case (r, s) => (r, Try(sendRequest(r)).flatten, s)
       }
   }
 


### PR DESCRIPTION
When doing head requests, ES sends the Content-Length header.
In order to avoid the client trying to read a response that will never
be sent, ignore response for HEAD operations

fixes #1704 