### PR TITLE
Fix `FetchSourceContext` case class

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/common/FetchSourceContext.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/common/FetchSourceContext.scala
@@ -1,5 +1,15 @@
 package com.sksamuel.elastic4s.requests.common
 
 case class FetchSourceContext(fetchSource: Boolean,
-                              includes: Array[String] = Array.empty,
-                              excludes: Array[String] = Array.empty)
+                              includes: Set[String] = Set.empty,
+                              excludes: Set[String] = Set.empty)
+
+object FetchSourceContext {
+  def apply(fetchSource: Boolean,
+            includes: Array[String],
+            excludes: Array[String]): FetchSourceContext =
+    FetchSourceContext(fetchSource, includes.toSet, excludes.toSet)
+
+  def apply(fetchSource: Boolean, includes: Array[String]): FetchSourceContext =
+    FetchSourceContext(fetchSource, includes.toSet)
+}

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/get/MultiGetBodyBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/get/MultiGetBodyBuilder.scala
@@ -15,9 +15,9 @@ object MultiGetBodyBuilder {
         if (context.includes.nonEmpty || context.excludes.nonEmpty) {
           builder.startObject("_source")
           if (context.includes.nonEmpty)
-            builder.array("include", context.includes)
+            builder.array("include", context.includes.toList)
           if (context.excludes.nonEmpty)
-            builder.array("exclude", context.excludes)
+            builder.array("exclude", context.excludes.toList)
           builder.endObject()
         } else
           builder.field("_source", boolean = false)


### PR DESCRIPTION
Using `Array` properties in case classes destroys the ordinarily expected
equality and immutablity properties of case classes.

This change makes `FetchSourceContext` instances comparable and immutable.