### PR TITLE
add support in ElasticError for failed shards

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticError.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticError.scala
@@ -11,9 +11,20 @@ case class ElasticError(`type`: String,
                         index: Option[String],
                         shard: Option[String],
                         @JsonProperty("root_cause") rootCause: Seq[ElasticError],
-                        @JsonProperty("caused_by") causedBy: Option[ElasticError.CausedBy]) {
+                        @JsonProperty("caused_by") causedBy: Option[ElasticError.CausedBy],
+                        phase: Option[String] = None,
+                        grouped: Option[Boolean] = None,
+                        @JsonProperty("failed_shards") failedShards: Seq[FailedShard] = Seq()
+) {
   def asException: Exception = causedBy.fold(new RuntimeException(s"${`type`} $reason"))(cause => new RuntimeException(s"${`type`} $reason", new RuntimeException(cause.toString)))
 }
+
+case class FailedShard(
+  shard: Int,
+  index: Option[String],
+  node: Option[String],
+  reason: Option[ElasticError] // reason is a nested ElasticError here, rather than a string as it is in ElasticError
+)
 
 object ElasticError {
 

--- a/elastic4s-core/src/test/resources/error_response_with_failed_shards.json
+++ b/elastic4s-core/src/test/resources/error_response_with_failed_shards.json
@@ -1,0 +1,160 @@
+{
+  "error": {
+    "root_cause": [
+      {
+        "type": "query_shard_exception",
+        "reason": "failed to create query",
+        "index_uuid": "2d8the20RkivmZXZDwkp1Q",
+        "index": "items_landsat_20190129_0"
+      },
+      {
+        "type": "query_shard_exception",
+        "reason": "failed to create query",
+        "index_uuid": "5Hf4_3kfQyOOlDaxRutbfw",
+        "index": "items_mcd43a4_20190129_0"
+      },
+      {
+        "type": "query_shard_exception",
+        "reason": "failed to create query",
+        "index_uuid": "Eon1vwa_Rw6bBIX7yeiaGQ",
+        "index": "items_mod11a1_20190128_1"
+      },
+      {
+        "type": "query_shard_exception",
+        "reason": "failed to create query",
+        "index_uuid": "JymClp-5TlSFZR66coY3iQ",
+        "index": "items_mod13a1_20190129_0"
+      },
+      {
+        "type": "query_shard_exception",
+        "reason": "failed to create query",
+        "index_uuid": "kwb1hINcQp6kQfOB96QE6Q",
+        "index": "items_myd11a1_20190129_0"
+      },
+      {
+        "type": "query_shard_exception",
+        "reason": "failed to create query",
+        "index_uuid": "yQbbws04Q5KuoM3EJhzGYw",
+        "index": "items_myd13a1_20190129_0"
+      },
+      {
+        "type": "query_shard_exception",
+        "reason": "failed to create query",
+        "index_uuid": "7G0HbvMrR8egEYBEAGrI5w",
+        "index": "items_s2_20190129_0"
+      }
+    ],
+    "type": "search_phase_execution_exception",
+    "reason": "all shards failed",
+    "phase": "query",
+    "grouped": true,
+    "failed_shards": [
+      {
+        "shard": 0,
+        "index": "items_landsat_20190129_0",
+        "node": "X6_5FwQsQOSTMc-4wEjLCA",
+        "reason": {
+          "type": "query_shard_exception",
+          "reason": "failed to create query",
+          "index_uuid": "2d8the20RkivmZXZDwkp1Q",
+          "index": "items_landsat_20190129_0",
+          "caused_by": {
+            "type": "illegal_argument_exception",
+            "reason": "Points of LinearRing do not form a closed linestring"
+          }
+        }
+      },
+      {
+        "shard": 0,
+        "index": "items_mcd43a4_20190129_0",
+        "node": "CbJaMLCATb2DG4xGa7HUOA",
+        "reason": {
+          "type": "query_shard_exception",
+          "reason": "failed to create query",
+          "index_uuid": "5Hf4_3kfQyOOlDaxRutbfw",
+          "index": "items_mcd43a4_20190129_0",
+          "caused_by": {
+            "type": "illegal_argument_exception",
+            "reason": "Points of LinearRing do not form a closed linestring"
+          }
+        }
+      },
+      {
+        "shard": 0,
+        "index": "items_mod11a1_20190128_1",
+        "node": "KPg66KspQoKBeiOaDqOzUQ",
+        "reason": {
+          "type": "query_shard_exception",
+          "reason": "failed to create query",
+          "index_uuid": "Eon1vwa_Rw6bBIX7yeiaGQ",
+          "index": "items_mod11a1_20190128_1",
+          "caused_by": {
+            "type": "illegal_argument_exception",
+            "reason": "Points of LinearRing do not form a closed linestring"
+          }
+        }
+      },
+      {
+        "shard": 0,
+        "index": "items_mod13a1_20190129_0",
+        "node": "X6_5FwQsQOSTMc-4wEjLCA",
+        "reason": {
+          "type": "query_shard_exception",
+          "reason": "failed to create query",
+          "index_uuid": "JymClp-5TlSFZR66coY3iQ",
+          "index": "items_mod13a1_20190129_0",
+          "caused_by": {
+            "type": "illegal_argument_exception",
+            "reason": "Points of LinearRing do not form a closed linestring"
+          }
+        }
+      },
+      {
+        "shard": 0,
+        "index": "items_myd11a1_20190129_0",
+        "node": "KPg66KspQoKBeiOaDqOzUQ",
+        "reason": {
+          "type": "query_shard_exception",
+          "reason": "failed to create query",
+          "index_uuid": "kwb1hINcQp6kQfOB96QE6Q",
+          "index": "items_myd11a1_20190129_0",
+          "caused_by": {
+            "type": "illegal_argument_exception",
+            "reason": "Points of LinearRing do not form a closed linestring"
+          }
+        }
+      },
+      {
+        "shard": 0,
+        "index": "items_myd13a1_20190129_0",
+        "node": "KPg66KspQoKBeiOaDqOzUQ",
+        "reason": {
+          "type": "query_shard_exception",
+          "reason": "failed to create query",
+          "index_uuid": "yQbbws04Q5KuoM3EJhzGYw",
+          "index": "items_myd13a1_20190129_0",
+          "caused_by": {
+            "type": "illegal_argument_exception",
+            "reason": "Points of LinearRing do not form a closed linestring"
+          }
+        }
+      },
+      {
+        "shard": 0,
+        "index": "items_s2_20190129_0",
+        "node": "X6_5FwQsQOSTMc-4wEjLCA",
+        "reason": {
+          "type": "query_shard_exception",
+          "reason": "failed to create query",
+          "index_uuid": "7G0HbvMrR8egEYBEAGrI5w",
+          "index": "items_s2_20190129_0",
+          "caused_by": {
+            "type": "illegal_argument_exception",
+            "reason": "Points of LinearRing do not form a closed linestring"
+          }
+        }
+      }
+    ]
+  },
+  "status": 400
+}

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/ElasticErrorTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/ElasticErrorTest.scala
@@ -3,6 +3,8 @@ package com.sksamuel.elastic4s
 import com.sksamuel.elastic4s.HttpEntity.StringEntity
 import org.scalatest.{FlatSpec, Matchers}
 
+import scala.io.Source.fromResource
+
 class ElasticErrorTest extends FlatSpec with Matchers with ElasticDsl {
 
   "ElasticError" should "properly handle an error response with an invalid body" in {
@@ -13,6 +15,26 @@ class ElasticErrorTest extends FlatSpec with Matchers with ElasticDsl {
   it should "properly handle an error response with a missing body" in {
     val error = ElasticError.parse(HttpResponse(123, Some(StringEntity("", None)), Map()))
     assert(error.reason == "123")
+  }
+
+  it must "parse a large error response including failed_shards" in {
+    val error = ElasticError.parse(HttpResponse(123, Some(StringEntity(fromResource("error_response_with_failed_shards.json").mkString, None)), Map()))
+
+    assert(error.`type` == "search_phase_execution_exception")
+    assert(error.reason == "all shards failed")
+    assert(error.phase.contains("query"))
+    assert(error.grouped.contains(true))
+    assert(error.failedShards.size == 7)
+    assert(error.rootCause.size == 7)
+
+    val failedShard = error.failedShards.find(p ⇒ p.node.contains("X6_5FwQsQOSTMc-4wEjLCA")).get
+    assert(failedShard.shard == 0)
+    assert(failedShard.index contains "items_landsat_20190129_0")
+    assert(failedShard.node.contains("X6_5FwQsQOSTMc-4wEjLCA"))
+    assert(failedShard.reason.get.`type` == "query_shard_exception")
+    assert(failedShard.reason.get.reason == "failed to create query")
+    assert(failedShard.reason.get.indexUuid.contains("2d8the20RkivmZXZDwkp1Q"))
+    assert(failedShard.reason.get.causedBy.get.reason == "Points of LinearRing do not form a closed linestring")
   }
 
 }


### PR DESCRIPTION
Elastic sometimes reports error detail as part of the "failed_shards" error message attribute.  This PR adds support for parsing that part of the hierarchy, so users can programmatically access that part of the error message.  For example, the test case shows the error message from elastic when you do a geo_shape query with a Polygon that has a self-intersecting edge or multiple duplicated points. 