### PR TITLE
handle Product in XContentBuilder, use XContentBuilder.autofield in SourceAsContentBuilder

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/SourceAsContentBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/SourceAsContentBuilder.scala
@@ -4,50 +4,7 @@ object SourceAsContentBuilder {
 
   def apply(source: Map[String, Any]): XContentBuilder = {
     val builder = XContentFactory.jsonBuilder()
-
-    def addMap(map: Map[String, Any]): Unit =
-      map.foreach {
-        case (key, value: Map[String, Any]) =>
-          builder.startObject(key)
-          addMap(value)
-          builder.endObject()
-        case (key, values: Seq[Any]) =>
-          builder.startArray(key)
-          addSeq(values)
-          builder.endArray()
-        case (key, value) =>
-          value match {
-            case x: String  => builder.field(key, x)
-            case x: Double  => builder.field(key, x)
-            case x: Float   => builder.field(key, x)
-            case x: Boolean => builder.field(key, x)
-            case x: Long    => builder.field(key, x)
-            case x: Int     => builder.field(key, x)
-            case x: Short   => builder.field(key, x)
-            case x: Byte    => builder.field(key, x)
-            case null       => builder.nullField(key)
-          }
-      }
-
-    def addSeq(values: Seq[Any]): Unit =
-      values.foreach {
-        case map: Map[String, Any] =>
-          builder.startObject()
-          addMap(map)
-          builder.endObject()
-        case seq: Seq[Any] =>
-          builder.startArray()
-          addSeq(seq)
-          builder.endArray()
-        case product: Product =>
-          builder.startArray()
-          addSeq(product.productIterator.toSeq)
-          builder.endArray()
-        case other =>
-          builder.autovalue(other)
-      }
-
-    addMap(source)
+    source.foreach((builder.autofield _).tupled)
     builder
   }
 }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/XContentBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/XContentBuilder.scala
@@ -183,6 +183,7 @@ class XContentBuilder(root: JsonNode) {
       case values: Iterator[_]             => autovalue(values.toSeq)
       case values: java.util.Collection[_] => autovalue(values.asScala)
       case values: java.util.Iterator[_]   => autovalue(values.asScala.toSeq)
+      case values: Product                 => autovalue(values.productIterator.toSeq)
       case map: Map[_, _] =>
         startObject()
         map.foreach { case (k, v) => autofield(k.toString, v) }
@@ -222,6 +223,7 @@ class XContentBuilder(root: JsonNode) {
       case values: Iterator[_]             => autoarray(name, values.toSeq)
       case values: java.util.Collection[_] => autoarray(name, values.asScala.toSeq)
       case values: java.util.Iterator[_]   => autoarray(name, values.asScala.toSeq)
+      case values: Product                 => autoarray(name, values.productIterator.toSeq)
       case map: Map[_, _] =>
         startObject(name)
         map.foreach { case (k, v) => autofield(k.toString, v) }

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/SourceAsContentBuilderTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/SourceAsContentBuilderTest.scala
@@ -8,4 +8,9 @@ class SourceAsContentBuilderTest extends FunSuite with Matchers {
     val map = Map("name" -> "sammy", "teams" -> Seq(("football", "boro"), ("baseball", "phillies")), "projects" -> null)
     SourceAsContentBuilder(map).string() shouldBe """{"name":"sammy","teams":[["football","boro"],["baseball","phillies"]],"projects":null}"""
   }
+
+  test("source as content builder should handle bigdecimals") {
+    val map = Map("dec" -> BigDecimal("9223372036854776000"))
+    SourceAsContentBuilder(map).string() shouldBe """{"dec":9.223372036854776E+18}"""
+  }
 }


### PR DESCRIPTION
`SourceAsContentBuilder` didn't work for `BigDecimal`. It seems that `SourceAsContentBuilder.apply` was basically a copy of `XContentBuilder`, so switch to calling `autofield` instead and be done with it.

Only issue is, `XContentBuilder` didn't handle `Product`s before. I'm not sure if handling that can cause any negative side effects.