### PR TITLE
added ignore unavailable indices option to msearch

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/MultiSearchBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/MultiSearchBuilderFn.scala
@@ -1,6 +1,7 @@
 package com.sksamuel.elastic4s.requests.searches
 
 import com.sksamuel.elastic4s.XContentFactory
+import com.sksamuel.elastic4s.requests.common.IndicesOptionsParams
 
 object MultiSearchBuilderFn {
 
@@ -16,6 +17,13 @@ object MultiSearchBuilderFn {
         .filter(_ != SearchType.DEFAULT)
         .map(SearchTypeHttpParameters.convert)
         .foreach(header.field("search_type", _))
+
+      search.indicesOptions.foreach {
+        IndicesOptionsParams(_).map {
+          case (n@"ignore_unavailable", v@"true") => header.field(n, v)
+          case _ => ()
+        }
+      }
       header.endObject()
 
       val body = SearchBodyBuilderFn(search)

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/MultiSearchBuilderFnTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/MultiSearchBuilderFnTest.scala
@@ -1,0 +1,26 @@
+package com.sksamuel.elastic4s.requests.searches
+
+import org.scalatest.{Matchers, WordSpec}
+import com.sksamuel.elastic4s.ElasticDsl._
+import com.sksamuel.elastic4s.requests.admin.IndicesOptionsRequest
+
+class MultiSearchBuilderFnTest extends WordSpec with Matchers {
+
+  private val searchRequest: SearchRequest = search("someIndex")
+
+  "MultiSearchBuilderFn" should {
+    "build multisearch request without indices options" in {
+      val searchStr = MultiSearchBuilderFn(multi(searchRequest))
+      searchStr.linesIterator.next shouldBe """{"index":"someIndex"}"""
+    }
+    "build multisearch request with default ignore_unavailable indices option" in {
+      val req = searchRequest indicesOptions IndicesOptionsRequest()
+      MultiSearchBuilderFn(multi(req)).linesIterator.next shouldBe """{"index":"someIndex"}"""
+    }
+    "build multisearch request with ignore_unavailable indices option" in {
+      val req = searchRequest indicesOptions IndicesOptionsRequest(ignoreUnavailable = true)
+      MultiSearchBuilderFn(multi(req)).linesIterator.next shouldBe """{"index":"someIndex","ignore_unavailable":"true"}"""
+
+    }
+  }
+}


### PR DESCRIPTION
Sometimes we need to make msearch and ignore unavailable indices here is possible solution. 