### PR TITLE
AkkaHttpClient - retry even if all hosts are blacklisted

### DIFF
--- a/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClient.scala
+++ b/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClient.scala
@@ -169,12 +169,8 @@ class AkkaHttpClient private[akka] (
         }
       }
       .recoverWith {
-        case err: Throwable =>
-          if (isRetryException(err)) {
-            markDead().flatMap(_ => retryIfPossible(Left(err)))
-          } else {
-            markDead().flatMap(_ => Future.failed(err))
-          }
+        case err @ AllHostsBlacklistedException => retryIfPossible(Left(err))
+        case err: Throwable => markDead().flatMap(_ => retryIfPossible(Left(err)))
       }
   }
 
@@ -184,13 +180,6 @@ class AkkaHttpClient private[akka] (
       case StatusCodes.ServiceUnavailable => true
       case StatusCodes.GatewayTimeout     => true
       case _                              => false
-    }
-  }
-
-  private def isRetryException(t: Throwable): Boolean = {
-    t match {
-      case AllHostsBlacklistedException => false
-      case _                            => true
     }
   }
 

--- a/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientMockTest.scala
+++ b/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientMockTest.scala
@@ -212,28 +212,5 @@ class AkkaHttpClientMockTest
         Map.empty)
     }
 
-    "return error if all hosts are blacklisted" in {
-
-      val hosts = List(
-        "host1",
-        "host2"
-      )
-
-      val blacklist = mock[Blacklist]
-
-      val (_, httpPool) = mockHttpPool()
-
-      val client =
-        new AkkaHttpClient(AkkaHttpClientSettings(hosts), blacklist, httpPool)
-
-      (blacklist.contains _).expects("host1").returns(true)
-      (blacklist.size _).expects().returns(2)
-
-      client
-        .sendAsync(ElasticRequest("GET", "/test"))
-        .failed
-        .futureValue shouldBe AllHostsBlacklistedException
-    }
-
   }
 }


### PR DESCRIPTION
At the moment, once all hosts get blacklisted `AkkaHttpClient` drops requests without retrying. 

This PR motivation is to have following behaviour:

- When part of all hosts are blacklisted, send requests to hosts that are marked alive and ignore hosts that are marked dead
- When all hosts are blacklisted don't instantly fail, but wait (if possible) until some hosts are removed from blacklist and try to send request again **as they could have became alive**.
- Fail only when `maxRetryTimeout` is exceeded