### PR TITLE
Scala 2.13.0 WIP

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ lazy val root = Project("elastic4s", file("."))
     clientesjava,
     cats_effect,
     scalaz,
-    monix,
+//  monix,
     tests,
     testkit,
     circe,

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticRequest.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticRequest.scala
@@ -14,10 +14,10 @@ object ElasticRequest {
     apply(method, endpoint, Map.empty[String, Any], body)
 
   def apply(method: String, endpoint: String, params: Map[String, Any]): ElasticRequest =
-    apply(method, endpoint, params.mapValues(_.toString), None)
+    apply(method, endpoint, params.mapValues(_.toString).toMap, None)
 
   def apply(method: String, endpoint: String, params: Map[String, Any], body: HttpEntity): ElasticRequest =
-    apply(method, endpoint, params.mapValues(_.toString), Some(body))
+    apply(method, endpoint, params.mapValues(_.toString).toMap, Some(body))
 
   implicit val ElasticRequestShow: Show[ElasticRequest] = new Show[ElasticRequest] {
     override def show(t: ElasticRequest): String = {

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/IndexHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/IndexHandlers.scala
@@ -63,7 +63,7 @@ trait IndexHandlers {
 
     override def responseHandler: ResponseHandler[Map[String, GetIndexResponse]] = {
       ResponseHandler.default[Map[String, GetIndexResponse]].map { map =>
-        map.mapValues { resp => if (resp.mappings.meta == null) resp.copy(mappings = resp.mappings.copy(meta = Map.empty)) else resp }
+        map.mapValues { resp => if (resp.mappings.meta == null) resp.copy(mappings = resp.mappings.copy(meta = Map.empty)) else resp }.toMap
       }
     }
   }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/SearchIterator.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/SearchIterator.scala
@@ -28,15 +28,15 @@ object SearchIterator {
 
       import com.sksamuel.elastic4s.ElasticDsl._
 
-      private var iterator: Iterator[SearchHit] = Iterator.empty
+      private var internalIterator: Iterator[SearchHit] = Iterator.empty
       private var scrollId: Option[String]      = None
 
-      override def hasNext: Boolean = iterator.hasNext || {
-        iterator = fetchNext()
-        iterator.hasNext
+      override def hasNext: Boolean = internalIterator.hasNext || {
+        internalIterator = fetchNext()
+        internalIterator.hasNext
       }
 
-      override def next(): SearchHit = iterator.next()
+      override def next(): SearchHit = internalIterator.next()
 
       def fetchNext(): Iterator[SearchHit] = {
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggresponses.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggresponses.scala
@@ -116,7 +116,7 @@ object KeyedDateRangeAggResult {
   private[elastic4s] def fromData(name: String, data: Map[String, Any]): KeyedDateRangeAggResult =
     KeyedDateRangeAggResult(
       name,
-      data("buckets").asInstanceOf[Map[String, Map[String, Any]]].mapValues(DateRangeBucket(_))
+      data("buckets").asInstanceOf[Map[String, Map[String, Any]]].mapValues(DateRangeBucket(_)).toMap
     )
 }
 
@@ -162,7 +162,7 @@ case class KeyedRangeAggResult(name: String,
 object KeyedRangeAggResult {
   def apply(name: String, data: Map[String, Any]): KeyedRangeAggResult = KeyedRangeAggResult(
     name,
-    data("buckets").asInstanceOf[Map[String, Map[String, Any]]].mapValues(RangeBucket(_)),
+    data("buckets").asInstanceOf[Map[String, Map[String, Any]]].mapValues(RangeBucket(_)).toMap,
     data
   )
 }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/responses.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/responses.scala
@@ -6,6 +6,7 @@ import com.sksamuel.elastic4s.requests.explain.Explanation
 import com.sksamuel.elastic4s.requests.get.{HitField, MetaDataFields}
 import com.sksamuel.elastic4s.{Hit, HitReader, SourceAsContentBuilder}
 
+import scala.reflect.ClassTag
 import scala.util.Try
 
 case class SearchHit(@JsonProperty("_id") id: String,
@@ -74,7 +75,7 @@ case class SearchHit(@JsonProperty("_id") id: String,
           )
         }
       )
-    }
+    }.toMap
 
   def innerHits: Map[String, InnerHits] = buildInnerHits(inner_hits)
 }
@@ -160,10 +161,10 @@ case class SearchResponse(took: Long,
       }
       .toMap
 
-  def termSuggestion(name: String): Map[String, TermSuggestionResult] = suggestion(name).mapValues(_.toTerm)
-  def completionSuggestion(name: String): Map[String, CompletionSuggestionResult] = suggestion(name).mapValues(_.toCompletion)
-  def phraseSuggestion(name: String): Map[String, PhraseSuggestionResult] = suggestion(name).mapValues(_.toPhrase)
+  def termSuggestion(name: String): Map[String, TermSuggestionResult] = suggestion(name).mapValues(_.toTerm).toMap
+  def completionSuggestion(name: String): Map[String, CompletionSuggestionResult] = suggestion(name).mapValues(_.toCompletion).toMap
+  def phraseSuggestion(name: String): Map[String, PhraseSuggestionResult] = suggestion(name).mapValues(_.toPhrase).toMap
 
-  def to[T: HitReader]: IndexedSeq[T] = hits.hits.map(_.to[T]).toIndexedSeq
+  def to[T: HitReader: ClassTag]: IndexedSeq[T] = hits.hits.map(_.to[T]).toIndexedSeq
   def safeTo[T: HitReader]: IndexedSeq[Try[T]] = hits.hits.map(_.safeTo[T]).toIndexedSeq
 }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateRequest.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateRequest.scala
@@ -41,6 +41,7 @@ case class UpdateRequest(index: Index,
   def doc(doc: String): UpdateRequest                               = copy(documentSource = doc.some)
 
   // Sets the fields to use for updates when a script is not specified.
+  def doc(field: (String, Any)): UpdateRequest = doc(Map(field))
   def doc(fields: (String, Any)*): UpdateRequest = doc(fields.toMap)
 
   // Sets the fields to use for updates when a script is not specified.
@@ -58,6 +59,7 @@ case class UpdateRequest(index: Index,
   def docAsUpsert[T: Indexable](t: T): UpdateRequest = doc(t).copy(docAsUpsert = true.some)
 
   // Uses this document as both the update value and for creating a new doc if the doc does not already exist
+  def docAsUpsert(field: (String, Any)): UpdateRequest = docAsUpsert(Map(field))
   def docAsUpsert(fields: (String, Any)*): UpdateRequest = docAsUpsert(fields.toMap)
 
   // Uses this document as both the update value and for creating a new doc if the doc does not already exist

--- a/elastic4s-http-streams/src/main/scala/com/sksamuel/elastic4s/streams/BulkIndexingSubscriber.scala
+++ b/elastic4s-http-streams/src/main/scala/com/sksamuel/elastic4s/streams/BulkIndexingSubscriber.scala
@@ -249,7 +249,7 @@ class BulkActor[T](client: ElasticClient,
   private def index(): Unit = {
 
     def bulkDef: BulkRequest = {
-      val defs   = buffer.map(t => builder.request(t))
+      val defs   = buffer.map(t => builder.request(t)).toSeq
       val policy = if (config.refreshAfterOp) RefreshPolicy.Immediate else RefreshPolicy.NONE
       BulkRequest(defs).refresh(policy)
     }

--- a/elastic4s-http-streams/src/main/scala/com/sksamuel/elastic4s/streams/ScrollPublisher.scala
+++ b/elastic4s-http-streams/src/main/scala/com/sksamuel/elastic4s/streams/ScrollPublisher.scala
@@ -164,7 +164,7 @@ class PublishActor(client: ElasticClient, query: SearchRequest, s: Subscriber[_ 
     // more results and we can unleash the beast (stashed requests) and switch back to ready mode
     case Success(resp: RequestSuccess[SearchResponse]) =>
       scrollId = resp.result.scrollId.getOrError("Response did not include a scroll id")
-      queue.enqueue(resp.result.hits.hits: _*)
+      queue ++= resp.result.hits.hits
       context become ready
       unstashAll()
   }

--- a/elastic4s-streams-akka/src/main/scala/com/sksamuel/elastic4s/akka/streams/ElasticSource.scala
+++ b/elastic4s-streams-akka/src/main/scala/com/sksamuel/elastic4s/akka/streams/ElasticSource.scala
@@ -51,7 +51,7 @@ class ElasticSource(client: ElasticClient, settings: SourceSettings)
             case Some(id) =>
               scrollId = id
               fetching = false
-              buffer.enqueue(searchr.hits.hits: _*)
+              buffer ++= searchr.hits.hits
               if (isAvailable(out)) {
                 push(out, buffer.dequeue)
                 maybeFetch()

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/json/XContentBuilderTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/json/XContentBuilderTest.scala
@@ -41,7 +41,7 @@ class XContentBuilderTest extends FunSuite with Matchers {
   }
 
   test("should support biginteger arrays") {
-    XContentFactory.obj().autoarray("bigintegers", Array(new BigInteger("123"), new BigInteger("456"))).string shouldBe """{"bigintegers":[123,456]}"""
+    XContentFactory.obj().autoarray("bigintegers", Seq(new BigInteger("123"), new BigInteger("456"))).string shouldBe """{"bigintegers":[123,456]}"""
   }
 
   test("should support long arrays") {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/KeyedDateRangeAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/KeyedDateRangeAggregationHttpTest.scala
@@ -83,7 +83,7 @@ class KeyedDateRangeAggregationHttpTest extends FreeSpec with DockerTests with M
       resp.totalHits shouldBe 6
 
       val agg = resp.aggs.keyedDateRange("agg1")
-      agg.buckets.mapValues(_.copy(data = Map.empty)) shouldBe Map(
+      agg.buckets.mapValues(_.copy(data = Map.empty)).toMap shouldBe Map(
         "old" -> DateRangeBucket(Some("1.1976768E12"), Some("15/12/2007"), Some("1.3555296E12"), Some("15/12/2012"), None, 3, Map.empty),
         "new" -> DateRangeBucket(Some("1.3555296E12"), Some("15/12/2012"), Some("1.513296E12"), Some("15/12/2017"), None, 3, Map.empty)
       )
@@ -102,7 +102,7 @@ class KeyedDateRangeAggregationHttpTest extends FreeSpec with DockerTests with M
       resp.totalHits shouldBe 6
 
       val agg = resp.aggs.keyedDateRange("agg1")
-      agg.buckets.mapValues(_.copy(data = Map.empty)) shouldBe Map(
+      agg.buckets.mapValues(_.copy(data = Map.empty)).toMap shouldBe Map(
         "old" -> DateRangeBucket(Some("1.1976768E12"), Some("15/12/2007"), Some("1.3555296E12"), Some("15/12/2012"), None, 3, Map.empty),
         "new" -> DateRangeBucket(Some("1.3555296E12"), Some("15/12/2012"), Some("1.513296E12"), Some("15/12/2017"), None, 3, Map.empty)
       )

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/KeyedRangeAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/KeyedRangeAggregationHttpTest.scala
@@ -50,7 +50,7 @@ class KeyedRangeAggregationHttpTest extends FreeSpec with DockerTests with Match
       resp.totalHits shouldBe 6
 
       val agg = resp.aggs.keyedRange("agg1")
-      agg.buckets.mapValues(_.copy(data = Map.empty)) shouldBe Map(
+      agg.buckets.mapValues(_.copy(data = Map.empty)).toMap shouldBe Map(
         "meh" -> RangeBucket(None, None, Some(5.5), 1, Map.empty),
         "cool" -> RangeBucket(None, Some(5.5), Some(7.5), 2, Map.empty),
         "awesome" -> RangeBucket(None, Some(7.5), None, 3, Map.empty)

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
@@ -913,7 +913,7 @@ class SearchDslTest extends FlatSpec with MockitoSugar with JsonSugar with OneIn
   }
 
   it should "generate json for docvalue fields" in {
-    val req = search("music") matchAllQuery() docValues ("field1", "field2")
+    val req = search("music").matchAllQuery docValues ("field1", "field2")
     req.request.entity.get.get should matchJsonResource("/json/search/search_doc_values.json")
   }
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -13,25 +13,25 @@ object Build extends AutoPlugin {
     val org                    = "com.sksamuel.elastic4s"
     val AkkaVersion            = "2.5.23"
     val AkkaHttpVersion        = "10.1.8"
-    val CatsVersion            = "1.6.0"
-    val CatsEffectVersion      = "1.3.1"
-    val CirceVersion           = "0.12.0-M2"
+    val CatsVersion            = "2.0.0-M4"
+    val CatsEffectVersion      = "2.0.0-M4"
+    val CirceVersion           = "0.12.0-M3"
     val CommonsIoVersion       = "2.6"
     val ElasticsearchVersion   = "7.0.1"
-    val ExtsVersion            = "1.61.0"
+    val ExtsVersion            = "1.61.1"
     val JacksonVersion         = "2.9.9"
     val Json4sVersion          = "3.6.7"
     val AWSJavaSdkVersion      = "2.5.52"
     val Log4jVersion           = "2.11.1"
     val MockitoVersion         = "1.10.19"
     val MonixVersion           = "2.3.3"
-    val PlayJsonVersion        = "2.7.3"
+    val PlayJsonVersion        = "2.7.4"
     val ReactiveStreamsVersion = "1.0.2"
     val ScalatestVersion       = "3.0.8"
-    val ScalamockVersion       = "4.1.0"
+    val ScalamockVersion       = "4.3.0"
     val ScalazVersion          = "7.2.27"
     val SprayJsonVersion       = "1.3.5"
-    val SttpVersion            = "1.5.18"
+    val SttpVersion            = "1.6.0"
     val Slf4jVersion           = "1.7.26"
   }
 
@@ -42,8 +42,8 @@ object Build extends AutoPlugin {
 
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
     organization := org,
-    scalaVersion := "2.12.8",
-    crossScalaVersions := Seq("2.11.12", "2.12.8"),
+    scalaVersion := "2.13.0",
+    crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0"),
     publishMavenStyle := true,
     resolvers += Resolver.mavenLocal,
     resolvers += Resolver.url("https://artifacts.elastic.co/maven"),


### PR DESCRIPTION
Fixes #1668 

Changes are source compatible with Scala 2.12 and 2.11. All tests are passing.

I had to sprinkle `toMap` and `toSeq` in multiple because of 2.13 collections migration. Most notably `Map.mapValues` returns a `MapView` now. In places where equality is checked, the view needs to be forced manually.

2.13 introduced changes to varargs treatment. I had to introduce `doc(field: (String, Any))` method taking a single tuple, because I got ambiguities errors between `doc(field: (String, Any)*)` and `def doc[T: Indexable](t: T)`.

Pending issues
- monix submodule is temporarily disabled because no build for Scala 2.13 is available yet
- cats, cats-effect and circe dependencies are at milestone releases