### PR TITLE
Fixing warning on updates

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateHandlers.scala
@@ -61,7 +61,7 @@ trait UpdateHandlers {
     override def build(request: UpdateRequest): ElasticRequest = {
 
       val endpoint =
-        s"/${URLEncoder.encode(request.index.index, "UTF-8")}/_doc/${URLEncoder.encode(request.id, "UTF-8")}/_update"
+        s"/${URLEncoder.encode(request.index.index, "UTF-8")}/_update/${URLEncoder.encode(request.id, "UTF-8")}"
 
       val params = scala.collection.mutable.Map.empty[String, Any]
       request.fetchSource.foreach { context =>

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateRequest.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateRequest.scala
@@ -30,7 +30,7 @@ case class UpdateRequest(index: Index,
                          documentFields: Map[String, Any] = Map.empty,
                          documentSource: Option[String] = None)
     extends BulkCompatibleRequest {
-  require(index != null, "indexAndTypes must not be null or empty")
+  require(index != null, "index must not be null or empty")
   require(id.toString.nonEmpty, "id must not be null or empty")
 
   // detects if a doc has not change and if so will not perform any action


### PR DESCRIPTION
@sksamuel 

I'm very new to elasticsearch and as such, new to elastic4s so all relevant disclaimers apply. 

I think this is a change needed to stop the warning I'm getting for 7.1.1 Elasticsearch. My guess is that other similar changes are needed.

`WARNING: request [POST http://10.36.66.105:9200/mtg/_doc/19daee72-1612-5372-b622-e03a3329a6f0/_update?retry_on_conflict=5] returned 1 warnings: [299 Elasticsearch-7.1.1-7a013de "[types removal] Specifying types in document update requests is deprecated, use the endpoint /{index}/_update/{id} instead."]`