### PR TITLE
Release/6.7.x remove deprecation WARNINGS from log

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/admin/domain.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/admin/domain.scala
@@ -6,7 +6,7 @@ import com.sksamuel.exts.OptionImplicits._
 case class OpenIndexRequest(indexes: Indexes)
 case class CloseIndexRequest(indexes: Indexes)
 case class GetSegmentsRequest(indexes: Indexes)
-case class IndicesExistsRequest(indexes: Indexes)
+case class IndicesExistsRequest(indexes: Indexes, includeTypeName:Option[Boolean]=None)
 case class TypesExistsRequest(indexes: Seq[String], types: Seq[String])
 case class AliasExistsRequest(alias: String)
 case class IndexStatsRequest(indices: Indexes)

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/indexes/CreateIndex.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/indexes/CreateIndex.scala
@@ -15,7 +15,8 @@ case class CreateIndexRequest(name: String,
                               rawSource: Option[String] = None,
                               waitForActiveShards: Option[Int] = None,
                               aliases: Set[IndexAliasRequest] = Set.empty,
-                              settings: IndexSettings = new IndexSettings) {
+                              settings: IndexSettings = new IndexSettings,
+                              includeTypeName: Option[Boolean] = None) {
 
   def alias(name: String): CreateIndexRequest = alias(IndexAliasRequest(name, None))
   def alias(name: String, filter: Query): CreateIndexRequest =
@@ -56,4 +57,6 @@ case class CreateIndexRequest(name: String,
   def normalizers(normalizers: Iterable[NormalizerDefinition]): CreateIndexRequest = analysis(Nil, normalizers)
 
   def source(source: String): CreateIndexRequest = copy(rawSource = source.some)
+
+  def includeTypeName(included:Boolean): CreateIndexRequest = copy(includeTypeName = included.some)
 }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/indexes/CreateIndexTemplateRequest.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/indexes/CreateIndexTemplateRequest.scala
@@ -20,7 +20,8 @@ case class CreateIndexTemplateRequest(name: String,
                                       order: Option[Int] = None,
                                       version: Option[Int] = None,
                                       create: Option[Boolean] = None,
-                                      aliases: Seq[TemplateAlias] = Nil) {
+                                      aliases: Seq[TemplateAlias] = Nil,
+                                      includeTypeName:Option[Boolean]=None) {
   require(name.nonEmpty, "template name must not be null or empty")
   require(pattern.nonEmpty, "pattern must not be null or empty")
 
@@ -69,4 +70,6 @@ case class CreateIndexTemplateRequest(name: String,
 
   def aliases(first: TemplateAlias, rest: TemplateAlias*): CreateIndexTemplateRequest = aliases(first +: rest)
   def aliases(aliases: Iterable[TemplateAlias]): CreateIndexTemplateRequest           = copy(aliases = aliases.toSeq)
+
+  def includeTypeName(include:Boolean):CreateIndexTemplateRequest = copy(includeTypeName=include.some)
 }

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/IndexTemplateHandlers.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/IndexTemplateHandlers.scala
@@ -41,9 +41,13 @@ trait IndexTemplateHandlers {
 
     override def build(request: CreateIndexTemplateRequest): ElasticRequest = {
       val endpoint = s"/_template/" + request.name
+
+      val params = scala.collection.mutable.Map.empty[String, Any]
+      request.includeTypeName.foreach(params.put("include_type_name", _))
+
       val body     = CreateIndexTemplateBodyFn(request)
       val entity   = HttpEntity(body.string, ContentType.APPLICATION_JSON.getMimeType)
-      ElasticRequest("PUT", endpoint, entity)
+      ElasticRequest("PUT", endpoint, params.toMap, entity)
     }
   }
 
@@ -67,7 +71,7 @@ trait IndexTemplateHandlers {
 
     override def build(request: GetIndexTemplateRequest): ElasticRequest = {
       val endpoint = s"/_template/" + request.indexes.string
-      ElasticRequest("GET", endpoint)
+      ElasticRequest("GET", endpoint, Map("include_type_name"->true))
     }
   }
 }

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/admin/IndexAdminHandlers.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/admin/IndexAdminHandlers.scala
@@ -110,7 +110,7 @@ trait IndexAdminHandlers {
 
     override def build(request: IndicesExistsRequest): ElasticRequest = {
       val endpoint = s"/${request.indexes.string}"
-      ElasticRequest("HEAD", endpoint)
+      ElasticRequest("HEAD", endpoint, Map("include_type_name" -> true))
     }
   }
 
@@ -184,6 +184,7 @@ trait IndexAdminHandlers {
 
       val params = scala.collection.mutable.Map.empty[String, Any]
       request.waitForActiveShards.foreach(params.put("wait_for_active_shards", _))
+      request.includeTypeName.foreach(params.put("include_type_name", _))
 
       val body   = CreateIndexContentBuilder(request).string()
       val entity = HttpEntity(body, ContentType.APPLICATION_JSON.getMimeType)

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/admin/IndexAdminHandlers.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/admin/IndexAdminHandlers.scala
@@ -110,7 +110,9 @@ trait IndexAdminHandlers {
 
     override def build(request: IndicesExistsRequest): ElasticRequest = {
       val endpoint = s"/${request.indexes.string}"
-      ElasticRequest("HEAD", endpoint, Map("include_type_name" -> true))
+      val params   = scala.collection.mutable.Map.empty[String, String]
+      request.includeTypeName.map(_.toString).foreach(params.put("include_type_name", _))
+      ElasticRequest("HEAD", endpoint, params.toMap)
     }
   }
 

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/ElasticErrorTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/ElasticErrorTest.scala
@@ -1,0 +1,15 @@
+package com.sksamuel.elastic4s.http
+
+import com.sksamuel.elastic4s.http.HttpEntity.StringEntity
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{FlatSpec, Matchers}
+
+
+class ElasticErrorTest extends FlatSpec with Matchers with ElasticDsl with MockitoSugar {
+
+  "ElasticError" should "properly handle an error response with an incorrect body" in {
+    val error = ElasticError.parse(HttpResponse(123, Some(StringEntity("{", None)), Map()))
+    assert(error.reason == "123")
+  }
+
+}


### PR DESCRIPTION
When using elastic4s 6.7.0 on ES 6.7.2, I got a _LOT_ of deprecation warnings in my integration tests 
Most of them come from CREATE/EXISTS index (-template) requests because of the `type` still present.
This PR removes these warning by implementing the ES suggested query parameter `include_type_name` 