### PR TITLE
Customization of HttpRequests in AkkaHttpClient

### DIFF
--- a/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClient.scala
+++ b/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClient.scala
@@ -218,7 +218,7 @@ class AkkaHttpClient private[akka] (
 
   private def toRequest(request: ElasticRequest,
                         host: String): Try[HttpRequest] = Try {
-    HttpRequest(
+    val httpRequest = HttpRequest(
       method = HttpMethods.getForKeyCaseInsensitive(request.method).getOrElse(HttpMethod.custom(request.method)),
       uri = Uri(request.endpoint)
         .withQuery(Query(request.params))
@@ -226,6 +226,7 @@ class AkkaHttpClient private[akka] (
         .withScheme(scheme),
       entity = request.entity.map(toEntity).getOrElse(HttpEntity.Empty)
     )
+    settings.requestCallback(httpRequest)
   }
 
   private def toResponse(response: HttpResponse,

--- a/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientSettings.scala
+++ b/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientSettings.scala
@@ -43,5 +43,4 @@ case class AkkaHttpClientSettings(https: Boolean,
                                   blacklistMinDuration: FiniteDuration = AkkaHttpClientSettings.default.blacklistMinDuration,
                                   blacklistMaxDuration: FiniteDuration = AkkaHttpClientSettings.default.blacklistMaxDuration,
                                   maxRetryTimeout: FiniteDuration = AkkaHttpClientSettings.default.maxRetryTimeout,
-                                  requestCallback: HttpRequest => HttpRequest = identity ) {
-}
+                                  requestCallback: HttpRequest => HttpRequest = identity)

--- a/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientSettings.scala
+++ b/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientSettings.scala
@@ -2,9 +2,10 @@ package com.sksamuel.elastic4s.akka
 
 import java.util.concurrent.TimeUnit
 
+import akka.http.scaladsl.model.HttpRequest
+
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
-
 import akka.http.scaladsl.settings.ConnectionPoolSettings
 import com.typesafe.config.{Config, ConfigFactory}
 
@@ -41,4 +42,6 @@ case class AkkaHttpClientSettings(https: Boolean,
                                   poolSettings: ConnectionPoolSettings,
                                   blacklistMinDuration: FiniteDuration = AkkaHttpClientSettings.default.blacklistMinDuration,
                                   blacklistMaxDuration: FiniteDuration = AkkaHttpClientSettings.default.blacklistMaxDuration,
-                                  maxRetryTimeout: FiniteDuration = AkkaHttpClientSettings.default.maxRetryTimeout)
+                                  maxRetryTimeout: FiniteDuration = AkkaHttpClientSettings.default.maxRetryTimeout,
+                                  requestCallback: HttpRequest => HttpRequest = identity ) {
+}


### PR DESCRIPTION
The purpose of this pull request is to add support for customization of HttpRequests in AkkaHttpClient by adding requestCallback to AkkaHttpClientSettings. It can then be used for example to add basic authentication header to requests:
`  val addBasicAuthorization: HttpRequest => HttpRequest = { request =>
    esConfig.credentials match {
      case None => request
      case Some(bc) =>
        val authorization = headers.Authorization(BasicHttpCredentials(bc.username, bc.password))
        request.copy(headers = request.headers :+ authorization)
    }
  }

  val settings = AkkaHttpClientSettings(
    https                = esConfig.uri.options.getOrElse("ssl", "false") == "true",
    hosts                = esConfig.uri.hosts.map { case (host, port) => s"$host:$port" }.toVector,
    queueSize            = 1000,
    poolSettings         = poolSettings,
    blacklistMinDuration = esConfig.blacklistMinDuration,
    blacklistMaxDuration = esConfig.blacklistMaxDuration,
    maxRetryTimeout      = esConfig.maxRetryTimeout,
    requestCallback = addBasicAuthorization
  )`