### PR TITLE
Optimize memory usage in index request builder (6.7.x)

### DIFF
--- a/elastic4s-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClient.scala
+++ b/elastic4s-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClient.scala
@@ -237,6 +237,12 @@ class AkkaHttpClient private[akka](
             .flatMap(value => ContentType.parse(value).right.toOption)
             .getOrElse(ContentTypes.`text/plain(UTF-8)`)
         HttpEntity(ct, ByteString(content))
+      case ElasticHttpEntity.ByteArrayEntity(content, contentType) =>
+        val ct =
+          contentType
+            .flatMap(value => ContentType.parse(value).right.toOption)
+            .getOrElse(ContentTypes.`text/plain(UTF-8)`)
+        HttpEntity(ct, ByteString(content))
       case ElasticHttpEntity.FileEntity(file, contentType) =>
         val ct = contentType
           .flatMap(value => ContentType.parse(value).right.toOption)

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/ElasticsearchJavaRestClient.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/ElasticsearchJavaRestClient.scala
@@ -6,7 +6,7 @@ import java.util.zip.GZIPInputStream
 
 import com.sksamuel.elastic4s.Show
 import org.apache.http.client.config.RequestConfig
-import org.apache.http.entity.{AbstractHttpEntity, ContentType, FileEntity, InputStreamEntity, StringEntity}
+import org.apache.http.entity.{AbstractHttpEntity, ByteArrayEntity, ContentType, FileEntity, InputStreamEntity, StringEntity}
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder
 import org.elasticsearch.client.{ResponseException, ResponseListener, RestClient}
 import org.elasticsearch.client.RestClientBuilder.{HttpClientConfigCallback, RequestConfigCallback}
@@ -23,6 +23,8 @@ class ElasticsearchJavaRestClient(client: RestClient) extends HttpClient {
     case e: HttpEntity.StringEntity =>
       logger.debug(e.content)
       new StringEntity(e.content, ContentType.APPLICATION_JSON)
+    case e: HttpEntity.ByteArrayEntity =>
+      new ByteArrayEntity(e.content, ContentType.APPLICATION_JSON)
     case e: HttpEntity.InputStreamEntity =>
       logger.debug(e.content.toString)
       new InputStreamEntity(e.content, ContentType.APPLICATION_JSON)

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/HttpClient.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/HttpClient.scala
@@ -56,4 +56,8 @@ object HttpEntity {
 
     def get: String = Files.readAllLines(content.toPath).asScala.mkString("\n")
   }
+
+  case class ByteArrayEntity(content: Array[Byte], contentCharset: Option[String]) extends HttpEntity {
+    def get: String = new String(content, contentCharset.getOrElse("utf-8"))
+  }
 }

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/IndexHandlers.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/IndexHandlers.scala
@@ -4,6 +4,7 @@ import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.sksamuel.elastic4s.http.HttpEntity.ByteArrayEntity
 import com.sksamuel.elastic4s.http._
 import com.sksamuel.elastic4s.indexes.{GetIndexRequest, IndexContentBuilder, IndexRequest}
 import com.sksamuel.exts.collection.Maps
@@ -47,7 +48,7 @@ trait IndexHandlers {
       request.versionType.map(VersionTypeHttpString.apply).foreach(params.put("version_type", _))
 
       val body   = IndexContentBuilder(request)
-      val entity = HttpEntity(body.string, ContentType.APPLICATION_JSON.getMimeType)
+      val entity = ByteArrayEntity(body.bytes, Some(ContentType.APPLICATION_JSON.getMimeType))
 
       logger.debug(s"Endpoint=$endpoint")
       ElasticRequest(method, endpoint, params.toMap, entity)

--- a/elastic4s-sttp/src/main/scala/com/sksamuel/elastic4s/sttp/SttpRequestHttpClient.scala
+++ b/elastic4s-sttp/src/main/scala/com/sksamuel/elastic4s/sttp/SttpRequestHttpClient.scala
@@ -4,7 +4,7 @@ import java.io._
 import java.nio.file.Files
 
 import com.sksamuel.elastic4s.ElasticsearchClientUri
-import com.sksamuel.elastic4s.http.HttpEntity.{FileEntity, InputStreamEntity, StringEntity}
+import com.sksamuel.elastic4s.http.HttpEntity.{ByteArrayEntity, FileEntity, InputStreamEntity, StringEntity}
 import com.sksamuel.elastic4s.http.{ElasticRequest, HttpClient, HttpEntity, HttpResponse}
 import com.sksamuel.exts.OptionImplicits._
 import com.softwaremill.sttp._
@@ -50,6 +50,7 @@ class SttpRequestHttpClient(clientUri: ElasticsearchClientUri) extends HttpClien
     val r2 = entity.contentCharset.fold(r)(r.contentType)
     entity match {
       case StringEntity(content: String, _) => r2.body(content)
+      case ByteArrayEntity(content, _) => r2.body(content)
       case InputStreamEntity(in: InputStream, _) =>
         r2.body(Source.fromInputStream(in, "UTF8").getLines().mkString("\n"))
       case FileEntity(file: File, _) => r2.body(Files.readAllBytes(file.toPath))


### PR DESCRIPTION
We observe OutOfMemoryError in our indexing application. This fix optimizes memory usage for indexing request builder. It fixes our problem and lowers memory and CPU usage for similar applications.

I'll push fixes for 7.1.x and master later today.