### PR TITLE
Optimize memory usage in index request builder (7.1.x)

### DIFF
--- a/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClient.scala
+++ b/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClient.scala
@@ -245,6 +245,12 @@ class AkkaHttpClient private[akka] (
             .flatMap(value => ContentType.parse(value).right.toOption)
             .getOrElse(ContentTypes.`text/plain(UTF-8)`)
         HttpEntity(ct, ByteString(content))
+      case ElasticHttpEntity.ByteArrayEntity(content, contentType) =>
+        val ct =
+          contentType
+            .flatMap(value => ContentType.parse(value).right.toOption)
+            .getOrElse(ContentTypes.`text/plain(UTF-8)`)
+        HttpEntity(ct, ByteString(content))
       case ElasticHttpEntity.FileEntity(file, contentType) =>
         val ct = contentType
           .flatMap(value => ContentType.parse(value).right.toOption)

--- a/elastic4s-client-esjava/src/main/scala/com/sksamuel/elastic4s/http/JavaClient.scala
+++ b/elastic4s-client-esjava/src/main/scala/com/sksamuel/elastic4s/http/JavaClient.scala
@@ -8,7 +8,7 @@ import com.sksamuel.elastic4s.{ElasticClient, ElasticNodeEndpoint, ElasticProper
 import com.sksamuel.exts.Logging
 import org.apache.http.HttpHost
 import org.apache.http.client.config.RequestConfig
-import org.apache.http.entity.{AbstractHttpEntity, ContentType, FileEntity, InputStreamEntity, StringEntity}
+import org.apache.http.entity.{AbstractHttpEntity, ByteArrayEntity, ContentType, FileEntity, InputStreamEntity, StringEntity}
 import org.apache.http.impl.nio.client.HttpAsyncClientBuilder
 import org.elasticsearch.client.RestClientBuilder.{HttpClientConfigCallback, RequestConfigCallback}
 import org.elasticsearch.client.{Request, ResponseException, ResponseListener, RestClient}
@@ -27,6 +27,8 @@ class JavaClient(client: RestClient) extends HttpClient {
     case e: HttpEntity.StringEntity =>
       logger.debug(e.content)
       new StringEntity(e.content, ContentType.APPLICATION_JSON)
+    case e: HttpEntity.ByteArrayEntity =>
+      new ByteArrayEntity(e.content, ContentType.APPLICATION_JSON)
     case e: HttpEntity.InputStreamEntity =>
       logger.debug(e.content.toString)
       new InputStreamEntity(e.content, ContentType.APPLICATION_JSON)

--- a/elastic4s-client-sttp/src/main/scala/com/sksamuel/elastic4s/sttp/SttpRequestHttpClient.scala
+++ b/elastic4s-client-sttp/src/main/scala/com/sksamuel/elastic4s/sttp/SttpRequestHttpClient.scala
@@ -3,7 +3,7 @@ package com.sksamuel.elastic4s.sttp
 import java.io._
 import java.nio.file.Files
 
-import com.sksamuel.elastic4s.HttpEntity.{FileEntity, InputStreamEntity, StringEntity}
+import com.sksamuel.elastic4s.HttpEntity.{FileEntity, InputStreamEntity, StringEntity, ByteArrayEntity}
 import com.sksamuel.elastic4s.{ElasticRequest, ElasticsearchClientUri, HttpClient, HttpEntity, HttpResponse}
 import com.sksamuel.exts.OptionImplicits._
 import com.softwaremill.sttp._
@@ -49,6 +49,7 @@ class SttpRequestHttpClient(clientUri: ElasticsearchClientUri) extends HttpClien
     val r2 = entity.contentCharset.fold(r)(r.contentType)
     entity match {
       case StringEntity(content: String, _) => r2.body(content)
+      case ByteArrayEntity(content, _) => r2.body(content)
       case InputStreamEntity(in: InputStream, _) =>
         r2.body(Source.fromInputStream(in, "UTF8").getLines().mkString("\n"))
       case FileEntity(file: File, _) => r2.body(Files.readAllBytes(file.toPath))

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/HttpClient.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/HttpClient.scala
@@ -58,4 +58,8 @@ object HttpEntity {
 
     def get: String = Files.readAllLines(content.toPath).asScala.mkString("\n")
   }
+
+  case class ByteArrayEntity(content: Array[Byte], contentCharset: Option[String]) extends HttpEntity {
+    def get: String = new String(content, contentCharset.getOrElse("utf-8"))
+  }
 }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/IndexHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/IndexHandlers.scala
@@ -6,6 +6,7 @@ import java.nio.charset.StandardCharsets
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.sksamuel.elastic4s._
 import com.sksamuel.elastic4s.requests.common.RefreshPolicyHttpValue
+import com.sksamuel.elastic4s.HttpEntity.ByteArrayEntity
 import com.sksamuel.exts.collection.Maps
 
 trait IndexHandlers {
@@ -46,7 +47,7 @@ trait IndexHandlers {
       request.versionType.map(VersionTypeHttpString.apply).foreach(params.put("version_type", _))
 
       val body   = IndexContentBuilder(request)
-      val entity = HttpEntity(body.string(), "application/json")
+      val entity = ByteArrayEntity(body.bytes, Some("application/json"))
 
       logger.debug(s"Endpoint=$endpoint")
       ElasticRequest(method, endpoint, params.toMap, entity)


### PR DESCRIPTION
We observe OutOfMemoryError in our indexing application. This fix optimizes memory usage for indexing request builder. It fixes our problem and lowers memory and CPU usage for similar applications.