### PR TITLE
Allowing field mappings

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/MappingHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/MappingHandlers.scala
@@ -15,7 +15,7 @@ trait MappingHandlers {
           val raw = ResponseHandler.fromResponse[Map[String, Map[String, Map[String, Any]]]](response)
           val raw2 = raw.map {
             case (index, types) =>
-              val mappings = types("mappings").getOrElse("properties", Map.empty)
+              val mappings = types("mappings").getOrElse("properties", types("mappings"))
               IndexMappings(index, mappings.asInstanceOf[Map[String, Any]])
           }.toSeq
           Right(raw2)

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/MappingHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/MappingHandlers.scala
@@ -15,7 +15,10 @@ trait MappingHandlers {
           val raw = ResponseHandler.fromResponse[Map[String, Map[String, Map[String, Any]]]](response)
           val raw2 = raw.map {
             case (index, types) =>
-              val mappings = types("mappings").getOrElse("properties", types("mappings"))
+              val mappings = types("mappings") match {
+                case Map.empty => Map.empty
+                case nonEmptyMap: Map[string, Any] => nonEmptyMap.getOrElse("properties", nonEmptyMap)
+              }
               IndexMappings(index, mappings.asInstanceOf[Map[String, Any]])
           }.toSeq
           Right(raw2)

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/MappingHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/MappingHandlers.scala
@@ -30,10 +30,16 @@ trait MappingHandlers {
 
 
     override def build(request: GetMappingRequest): ElasticRequest = {
-      val endpoint = request.indexes match {
+      val baseEndpoint = request.indexes match {
         case Indexes(Nil)       => "/_mapping"
         case Indexes(indexes)   => s"/${indexes.mkString(",")}/_mapping"
       }
+
+      val endpoint = request.fields match {
+        case Nil => baseEndpoint
+        case fields: Seq[String] => s"$baseEndpoint/field/${fields.mkString(",")}"
+      }
+
       ElasticRequest("GET", endpoint)
     }
   }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/mappings/GetMappingRequest.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/mappings/GetMappingRequest.scala
@@ -3,6 +3,8 @@ package com.sksamuel.elastic4s.requests.mappings
 import com.sksamuel.elastic4s.Indexes
 import com.sksamuel.exts.OptionImplicits._
 
-case class GetMappingRequest(indexes: Indexes, local: Option[Boolean] = None) {
-  def local(local: Boolean): GetMappingRequest = copy(local = local.some)
+case class GetMappingRequest(indexes: Indexes, fields: Seq[String] = Nil) {
+  def fields(first: String, rest: String*): GetMappingRequest = fields(first +: rest)
+
+  def fields(_fields: Seq[String]): GetMappingRequest = copy(fields = _fields)
 }


### PR DESCRIPTION
@sksamuel 

Couldn't find this feature: https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-field-mapping.html

This is PR adds the above functionality; it also removes `local` method from `GetMappingRequest` as I couldn't find any usage of it