### PR TITLE
Allowing field mappings

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/MappingHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/MappingHandlers.scala
@@ -38,10 +38,8 @@ trait MappingHandlers {
       possibleFieldMapping.size match {
         case 0 => Map.empty
         case _: Int => possibleFieldMapping.head._2 match {
-          case map: Map[String, Any] =>
-            map.getOrElse("mapping", Map.empty)
-          case _ =>
-            Map.empty
+          case map: Map[String, Any] => map.getOrElse("mapping", Map.empty)
+          case _ => Map.empty
         }
       }
     }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/mappings/GetMappingRequest.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/mappings/GetMappingRequest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s.requests.mappings
 
 import com.sksamuel.elastic4s.Indexes
-import com.sksamuel.exts.OptionImplicits._
 
-case class GetMappingRequest(indexes: Indexes, local: Option[Boolean] = None) {
-  def local(local: Boolean): GetMappingRequest = copy(local = local.some)
+case class GetMappingRequest(indexes: Indexes, fields: Seq[String] = Nil) {
+  def fields(first: String, rest: String*): GetMappingRequest = fields(first +: rest)
+
+  def fields(_fields: Seq[String]): GetMappingRequest = copy(fields = _fields)
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/MappingHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/MappingHttpTest.scala
@@ -18,6 +18,10 @@ class MappingHttpTest extends WordSpec with DockerTests with Matchers with Befor
       client.execute {
         deleteIndex("indexnoprops")
       }.await
+
+      client.execute {
+        deleteIndex("indexnopropsempty")
+      }.await
     }
 
     client.execute {
@@ -38,6 +42,12 @@ class MappingHttpTest extends WordSpec with DockerTests with Matchers with Befor
     client.execute {
       createIndex("indexnoprops").mappings(
         mapping().dynamic(DynamicMapping.Strict)
+      )
+    }.await
+
+    client.execute {
+      createIndex("indexnopropsempty").mappings(
+        mapping()
       )
     }.await
   }
@@ -71,6 +81,54 @@ class MappingHttpTest extends WordSpec with DockerTests with Matchers with Befor
       }.await.result
 
       val properties = mappings.find(_.index == "indexnoprops").get.mappings
+
+      properties shouldBe Map.empty
+    }
+
+    "handle properly completely empty mapping" in {
+
+      val mappings = client.execute {
+        getMapping("indexnopropsempty")
+      }.await.result
+
+      val properties = mappings.find(_.index == "indexnopropsempty").get.mappings
+
+      properties shouldBe Map.empty
+    }
+  }
+
+  "specific field mapping get" should {
+    "return specified mapping" in {
+      val mappings = client.execute {
+        getMapping("index").fields("a")
+      }.await.result
+
+      val properties = mappings.find(_.index == "index").get.mappings
+      properties.size shouldBe 1
+      val a = properties("a").asInstanceOf[Map[String, Any]]
+      a("type") shouldBe "text"
+      a("store") shouldBe true
+      a("analyzer") shouldBe "whitespace"
+    }
+
+    "handle properly mapping without properties" in {
+
+      val mappings = client.execute {
+        getMapping("indexnoprops").fields("a")
+      }.await.result
+
+      val properties = mappings.find(_.index == "indexnoprops").get.mappings
+
+      properties shouldBe Map.empty
+    }
+
+    "handle properly completely empty mapping" in {
+
+      val mappings = client.execute {
+        getMapping("indexnopropsempty").fields("a")
+      }.await.result
+
+      val properties = mappings.find(_.index == "indexnopropsempty").get.mappings
 
       properties shouldBe Map.empty
     }


### PR DESCRIPTION
@sksamuel 

Couldn't find this feature: https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-field-mapping.html

This is PR adds the above functionality; it also removes `local` method from `GetMappingRequest` as I couldn't find any usage of it