### PR TITLE
Allowing field mappings

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/mappings/GetFieldMappingRequest.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/mappings/GetFieldMappingRequest.scala
@@ -2,4 +2,4 @@ package com.sksamuel.elastic4s.requests.mappings
 
 import com.sksamuel.elastic4s.Indexes
 
-case class GetMappingRequest(indexes: Indexes)
+case class GetFieldMappingRequest(indexes: Indexes, fields: Seq[String])

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/mappings/MappingApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/mappings/MappingApi.scala
@@ -12,6 +12,8 @@ trait MappingApi {
 
   def getMapping(indexes: Indexes): GetMappingRequest               = GetMappingRequest(indexes)
 
+  def getMapping(indexes: Indexes, fields: String*): GetFieldMappingRequest = GetFieldMappingRequest(indexes, fields)
+
   def putMapping(indexes: Indexes): PutMappingRequest               = PutMappingRequest(IndexesAndType(indexes))
 
   @deprecated("types are deprecated now", "7.0")


### PR DESCRIPTION
@sksamuel 

Couldn't find this feature: https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-get-field-mapping.html

Originally I had opened a pr that merges this functionality into the existing `GetMappingRequest` and modified the respective `MappingHandler`. I realized that at the end of the day, I judged the two requests and responses to be just different enough to warrant a separate `Request` and thus a separate `Handler`. 

This PR also removes `local` method from `GetMappingRequest` as I couldn't find any usage of it