### PR TITLE
value type of after of composite aggregation should be Any

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/CompositeAggregation.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/CompositeAggregation.scala
@@ -38,7 +38,7 @@ case class CompositeAggregation(name: String,
                                 size: Option[Int] = None,
                                 subaggs: Seq[AbstractAggregation] = Nil,
                                 metadata: Map[String, AnyRef] = Map.empty,
-                                after: Option[Map[String, AnyRef]] = None)
+                                after: Option[Map[String, Any]] = None)
   extends Aggregation {
 
   type T = CompositeAggregation
@@ -47,7 +47,7 @@ case class CompositeAggregation(name: String,
 
   def size(size: Int): CompositeAggregation = copy(size = size.some)
 
-  def after(after: Map[String, AnyRef]): CompositeAggregation = copy(after = after.some)
+  def after(after: Map[String, Any]): CompositeAggregation = copy(after = after.some)
 
   override def subAggregations(aggs: Iterable[AbstractAggregation]): T = copy(subaggs = aggs.toSeq)
 

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/CompositeAggregationBuilderTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/CompositeAggregationBuilderTest.scala
@@ -54,4 +54,15 @@ class CompositeAggregationBuilderTest extends FunSuite with Matchers {
 
   }
 
+  test("CompositeAggregationBuilder should build simple terms-valued composites with after paramters") {
+    val search = SearchRequest("myindex").aggs(
+      CompositeAggregation("comp", sources = Seq(
+        TermsValueSource("s1", field = Some("f1"))),
+        after = Some(Map("myafter1" -> 1, "myafter2" -> "2"))
+      )
+    )
+
+    SearchBodyBuilderFn(search).string() shouldBe
+      """{"aggs":{"comp":{"composite":{"sources":[{"s1":{"terms":{"field":"f1"}}}],"after":{"myafter1":1,"myafter2":"2"}}}}}"""
+  }
 }


### PR DESCRIPTION
- As the official example says, the value can be number.
"after": { "date": 1494288000000, "product": "mad max" }
- https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-composite-aggregation.html#_after