### PR TITLE
Fix list task test

### DIFF
--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/tasks/TasksTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/tasks/TasksTest.scala
@@ -11,7 +11,7 @@ class TasksTest extends FlatSpec with DockerTests with Matchers {
       listTasks()
     }.await.result
 
-    resp.nodes.head._2.roles shouldBe Seq("master", "data", "ingest")
+    resp.nodes.head._2.roles should contain theSameElementsAs(Seq("master", "data", "ingest"))
     resp.nodes.head._2.tasks.values.forall(_.startTimeInMillis > 0) shouldBe true
   }
 


### PR DESCRIPTION
The `TasksTest` started to fail from [this PR](#1849) onwards, and it's seems like it's because a newest version of Elasticsearch (7.3.1) is used to run the tests. This PR fixes the failing test.