### PR TITLE
fix TermsAggregation.excludeExactValues

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/TermsAggregation.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/TermsAggregation.scala
@@ -57,7 +57,7 @@ case class TermsAggregation(name: String,
   def excludeExactValues(head: String, tail: String*): TermsAggregation = copy(excludeExactValues = head +: tail)
 
   def includeExactValues(includes: Seq[String]): TermsAggregation = copy(includeExactValues = includes)
-  def excludeExactValues(excludes: Seq[String]): TermsAggregation = copy(includeExactValues = excludes)
+  def excludeExactValues(excludes: Seq[String]): TermsAggregation = copy(excludeExactValues = excludes)
 
   def includeRegex(regex: String): TermsAggregation = copy(includeRegex = Some(regex))
   def excludeRegex(regex: String): TermsAggregation = copy(excludeRegex = Some(regex))


### PR DESCRIPTION
The overloaded method that accepts a Set[String] argument was incorrectly including that set instead of excluding.