### PR TITLE
Remove unnecessary parsing in IndexContentBuilder

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/bulk/BulkBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/bulk/BulkBuilderFn.scala
@@ -27,7 +27,7 @@ object BulkBuilderFn {
         builder.endObject()
 
         rows += builder.string
-        rows += IndexContentBuilder(index).string()
+        rows += IndexContentBuilder(index)
 
       case delete: DeleteByIdRequest =>
         val builder = XContentFactory.jsonBuilder()

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/IndexContentBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/IndexContentBuilder.scala
@@ -1,15 +1,14 @@
 package com.sksamuel.elastic4s.requests.indexes
 
-import com.sksamuel.elastic4s.{XContentBuilder, XContentFactory, XContentFieldValueWriter}
+import com.sksamuel.elastic4s.{XContentFactory, XContentFieldValueWriter}
 
 object IndexContentBuilder {
-  def apply(request: IndexRequest): XContentBuilder =
+  def apply(request: IndexRequest): String =
     request.source match {
-      case Some(json) => XContentFactory.parse(json)
+      case Some(json) => json
       case None =>
         val source = XContentFactory.jsonBuilder()
         request.fields.foreach(XContentFieldValueWriter(source, _))
-        source.endObject()
-        source
+        source.endObject().string()
     }
 }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/IndexHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/IndexHandlers.scala
@@ -47,7 +47,7 @@ trait IndexHandlers {
       request.versionType.map(VersionTypeHttpString.apply).foreach(params.put("version_type", _))
 
       val body   = IndexContentBuilder(request)
-      val entity = ByteArrayEntity(body.bytes, Some("application/json"))
+      val entity = ByteArrayEntity(body.getBytes, Some("application/json"))
 
       logger.debug(s"Endpoint=$endpoint")
       ElasticRequest(method, endpoint, params.toMap, entity)


### PR DESCRIPTION
I noticed that the request source field in IndexContentBuilder is parsed from String to XContentBuilder, and then in BulkBuilderFn from XContentBuilder to String. My suggestion is to remove unnecessary parsing to XContentBuilder and return String in IndexContentBuilder. 

I'm not sure, whether it was a overlooking or it was made on purpose.