### PR TITLE
QueryString query time_zone support

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/QueryStringQuery.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/QueryStringQuery.scala
@@ -1,8 +1,10 @@
 package com.sksamuel.elastic4s.requests.searches.queries
 
+import com.sksamuel.elastic4s.EnumConversions
 import com.sksamuel.elastic4s.requests.analyzers.Analyzer
 import com.sksamuel.elastic4s.requests.searches.queries.matches.MultiMatchQueryBuilderType
 import com.sksamuel.exts.OptionImplicits._
+import org.joda.time.DateTimeZone
 
 case class QueryStringQuery(query: String,
                             allowLeadingWildcard: Option[Boolean] = None,
@@ -27,7 +29,8 @@ case class QueryStringQuery(query: String,
                             rewrite: Option[String] = None,
                             splitOnWhitespace: Option[Boolean] = None,
                             tieBreaker: Option[Double] = None,
-                            `type`: Option[MultiMatchQueryBuilderType] = None)
+                            `type`: Option[MultiMatchQueryBuilderType] = None,
+                            timeZone: Option[String] = None)
     extends Query {
 
   def rewrite(rewrite: String): QueryStringQuery = copy(rewrite = rewrite.some)
@@ -99,4 +102,7 @@ case class QueryStringQuery(query: String,
 
   def matchType(t: String): QueryStringQuery = matchType(MultiMatchQueryBuilderType.valueOf(t))
   def matchType(t: MultiMatchQueryBuilderType): QueryStringQuery = copy(`type` = t.some)
+
+  def timeZone(t: String): QueryStringQuery = copy(timeZone = t.some)
+  def timeZone(t: DateTimeZone): QueryStringQuery = timeZone(EnumConversions.timeZone(t))
 }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/text/QueryStringBodyFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/text/QueryStringBodyFn.scala
@@ -26,6 +26,7 @@ object QueryStringBodyFn {
     s.tieBreaker.foreach(builder.field("tie_breaker", _))
     s.`type`.map(EnumConversions.multiMatchQueryBuilderType).foreach(builder.field("type", _))
     s.rewrite.map(_.toString).foreach(builder.field("rewrite", _))
+    s.timeZone.foreach(builder.field("time_zone", _))
 
     if (s.fields.nonEmpty) {
       val fields = s.fields.map {

--- a/elastic4s-tests/src/test/resources/json/search/search_string.json
+++ b/elastic4s-tests/src/test/resources/json/search/search_string.json
@@ -15,7 +15,8 @@
             "boost": 6.5,
             "tie_breaker": 0.5,
             "rewrite": "writer",
-            "query": "coldplay"
+            "query": "coldplay",
+            "time_zone": "+02:00"
         }
     },
     "size": 5

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
@@ -86,7 +86,7 @@ class SearchDslTest extends FlatSpec with MockitoSugar with JsonSugar with OneIn
 
   it should "generate json for a string query" in {
     val req = search("*") limit 5 query {
-      stringQuery("coldplay") allowLeadingWildcard true analyzeWildcard true analyzer WhitespaceAnalyzer autoGeneratePhraseQueries true defaultField "name" boost 6.5 enablePositionIncrements true fuzzyMaxExpansions 4 fuzzyPrefixLength 3 lenient true phraseSlop 10 tieBreaker 0.5 operator "OR" rewrite "writer"
+      stringQuery("coldplay") allowLeadingWildcard true analyzeWildcard true analyzer WhitespaceAnalyzer autoGeneratePhraseQueries true defaultField "name" boost 6.5 enablePositionIncrements true fuzzyMaxExpansions 4 fuzzyPrefixLength 3 lenient true phraseSlop 10 tieBreaker 0.5 operator "OR" rewrite "writer" timeZone "+02:00"
     }
     req.request.entity.get.get should matchJsonResource("/json/search/search_string.json")
   }


### PR DESCRIPTION
Hi! Could you please review these changes?

I added missing time_zone parameter to QueryStringQuery

https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-top-level-params
> time_zone
> (Optional, string) Coordinated Universal Time (UTC) offset or IANA time zone used to convert date values in the query string to UTC.
> 
> Valid values are ISO 8601 UTC offsets, such as +01:00 or -08:00, and IANA time zone IDs, such as America/Los_Angeles.