### PR TITLE
add support for new analysis package

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/CreateIndexTemplateRequest.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/CreateIndexTemplateRequest.scala
@@ -16,7 +16,9 @@ case class CreateIndexTemplateRequest(name: String,
                                       pattern: String,
                                       settings: Map[String, Any] = Map.empty,
                                       mappings: Seq[MappingDefinition] = Nil,
-                                      analysis: Option[AnalysisDefinition] = None,
+                                      @deprecated("use the new analysis package", "7.0.1")
+                                      _analysis: Option[AnalysisDefinition] = None,
+                                      analysis: Option[com.sksamuel.elastic4s.requests.analysis.Analysis] = None,
                                       order: Option[Int] = None,
                                       version: Option[Int] = None,
                                       create: Option[Boolean] = None,
@@ -32,12 +34,14 @@ case class CreateIndexTemplateRequest(name: String,
   def analysis(analyzers: Iterable[AnalyzerDefinition]): CreateIndexTemplateRequest =
     analysis(analyzers, Nil)
 
+  def analysis(analysis: com.sksamuel.elastic4s.requests.analysis.Analysis): CreateIndexTemplateRequest = copy(analysis = analysis.some)
+
   @deprecated("use new analysis package", "7.2.0")
   def analysis(analyzers: Iterable[AnalyzerDefinition],
                normalizers: Iterable[NormalizerDefinition]): CreateIndexTemplateRequest =
-    analysis match {
-      case None    => copy(analysis = AnalysisDefinition(analyzers, normalizers).some)
-      case Some(a) => copy(analysis = AnalysisDefinition(a.analyzers ++ analyzers, a.normalizers ++ normalizers).some)
+    _analysis match {
+      case None => copy(_analysis = AnalysisDefinition(analyzers, normalizers).some)
+      case Some(a) => copy(_analysis = AnalysisDefinition(a.analyzers ++ analyzers, a.normalizers ++ normalizers).some)
     }
 
   @deprecated("use new analysis package", "7.2.0")

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/IndexTemplateHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/IndexTemplateHandlers.scala
@@ -1,6 +1,7 @@
 package com.sksamuel.elastic4s.requests.indexes
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.sksamuel.elastic4s.requests.analysis.AnalysisBuilder
 import com.sksamuel.elastic4s.requests.mappings.MappingBuilderFn
 import com.sksamuel.elastic4s.requests.searches.queries.QueryBuilderFn
 import com.sksamuel.elastic4s.{ElasticError, ElasticRequest, Handler, HttpEntity, HttpResponse, ResponseHandler, XContentBuilder, XContentFactory}
@@ -81,9 +82,7 @@ object CreateIndexTemplateBodyFn {
       create.settings.foreach {
         case (key, value) => builder.autofield(key, value)
       }
-      create.analysis.foreach { analysis =>
-        AnalysisBuilderFn.build(analysis, builder)
-      }
+      builder.rawField("analysis", AnalysisBuilder.build(create.analysis.get))
       builder.endObject()
     }
 

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/index/CreateIndexTemplateRequestTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/index/CreateIndexTemplateRequestTest.scala
@@ -1,0 +1,22 @@
+package com.sksamuel.elastic4s.requests.index
+
+import com.sksamuel.elastic4s.ElasticDsl
+import com.sksamuel.elastic4s.requests.analysis.{Analysis, CustomNormalizer}
+import org.scalatest.{FunSuite, Matchers}
+
+class CreateIndexTemplateRequestTest extends FunSuite with ElasticDsl with Matchers {
+
+  test("testing if entity created by createIndexTemplate has proper form"){
+
+    val lowerCaseNormalizer = CustomNormalizer("lowercase", Nil, List("lowercase"))
+
+    val templateName = "test_template"
+
+    val templateDef = createIndexTemplate(templateName, "index_pattern")
+      .analysis(Analysis(Nil, normalizers = List(lowerCaseNormalizer)))
+
+    val expectedEntityContent = """{"index_patterns":["index_pattern"],"settings":{"analysis":{"normalizer":{"lowercase":{"type":"custom","filter":["lowercase"]}}}}}"""
+
+    CreateIndexTemplateHandler.build(templateDef).entity.get.get shouldBe expectedEntityContent
+  }
+}


### PR DESCRIPTION
Hi,

I've added support for new analysis package in CreateIndexTemplateRequest, analogously to what was done in CreateIndexRequest, since all the analysis functions in that object had deprecated annotations.