### PR TITLE
Remove type field from PreIndexedShapes since it is deprecated

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/geo/GeoShapeQuery.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/geo/GeoShapeQuery.scala
@@ -58,7 +58,7 @@ case class GeometryCollectionShape(shapes: Seq[ShapeDefinition]) extends Collect
 
 sealed trait Shape
 case class InlineShape(shape: ShapeDefinition)                                     extends Shape
-case class PreindexedShape(id: String, index: Index, `type`: String, path: String) extends Shape
+case class PreindexedShape(id: String, index: Index, path: String) extends Shape
 
 case class GeoShapeQuery(field: String,
                          shape: Shape,
@@ -75,8 +75,8 @@ case class GeoShapeQuery(field: String,
   def strategy(strategy: SpatialStrategy): GeoShapeQuery = copy(strategy = strategy.some)
 
   def inlineShape(shape: ShapeDefinition) = copy(shape = InlineShape(shape))
-  def preindexedShape(id: String, index: Index, `type`: String, path: String) =
-    copy(shape = PreindexedShape(id, index, `type`, path))
+  def preindexedShape(id: String, index: Index, path: String) =
+    copy(shape = PreindexedShape(id, index, path))
 
   def ignoreUnmapped(ignore: Boolean): GeoShapeQuery = copy(ignoreUnmapped = ignore.some)
 }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/geo/GeoShapeQueryBodyFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/geo/GeoShapeQueryBodyFn.scala
@@ -25,11 +25,10 @@ object GeoShapeQueryBodyFn {
         buildShapeDefinition(shape, builder)
         builder.endObject()
 
-      case PreindexedShape(id, index, tpe, path) =>
+      case PreindexedShape(id, index,  path) =>
         builder.startObject("indexed_shape")
         builder.field("id", id)
         builder.field("index", index.name)
-        builder.field("type", tpe)
         builder.field("path", path)
         builder.endObject()
     }


### PR DESCRIPTION
The `type` field on preindexed geo_shape queries is deprecated, resulting in warnings from ES. removed the unnecessary type parameter from the PreIndexedShape entity.