### PR TITLE
Close the ElasticSource output port when no more elements is scroll response

### DIFF
--- a/elastic4s-streams-akka/src/main/scala/com/sksamuel/elastic4s/akka/streams/ElasticSource.scala
+++ b/elastic4s-streams-akka/src/main/scala/com/sksamuel/elastic4s/akka/streams/ElasticSource.scala
@@ -56,6 +56,10 @@ class ElasticSource(client: ElasticClient, settings: SourceSettings)
                 push(out, buffer.dequeue)
                 maybeFetch()
               }
+              // complete when no more elements to emit
+              if (searchr.hits.hits.length == 0) {
+                complete(out)
+              }
           }
       }
     }


### PR DESCRIPTION
Small fix: the ElasticSource graph stage never closes the output port when there is no more elements in the scroll response, so the stream never ends.