### PR TITLE
Replace SearchError with ElasticError to be able to read the root cause

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/MultiSearchResponse.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/MultiSearchResponse.scala
@@ -1,29 +1,22 @@
 package com.sksamuel.elastic4s.requests.searches
 
-import com.fasterxml.jackson.annotation.JsonProperty
-import com.sksamuel.elastic4s.HitReader
+import com.sksamuel.elastic4s.{ElasticError, HitReader}
 
 import scala.util.Try
 
-case class SearchError(`type`: String,
-                       `reason`: String,
-                       @JsonProperty("resource.type") resourceType: String,
-                       @JsonProperty("resource.id") resourceId: String,
-                       index_uuid: String,
-                       index: String)
 
-case class MultisearchResponseItem(index: Int, status: Int, response: Either[SearchError, SearchResponse])
+case class MultisearchResponseItem(index: Int, status: Int, response: Either[ElasticError, SearchResponse])
 
 case class MultiSearchResponse(items: Seq[MultisearchResponseItem]) {
 
   def size: Int = items.size
 
-  def failures: Seq[SearchError] = items.map(_.response).collect {
-    case left: Left[SearchError, SearchResponse] => left.left.get
+  def failures: Seq[ElasticError] = items.map(_.response).collect {
+    case left: Left[ElasticError, SearchResponse] => left.left.get
   }
 
   def successes: Seq[SearchResponse] = items.map(_.response).collect {
-    case right: Right[SearchError, SearchResponse] => right.right.get
+    case right: Right[ElasticError, SearchResponse] => right.right.get
   }
 
   def to[T: HitReader]: IndexedSeq[T] = successes.flatMap(_.hits.hits).map(_.to[T]).toIndexedSeq

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/SearchHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/SearchHandlers.scala
@@ -3,7 +3,7 @@ package com.sksamuel.elastic4s.requests.searches
 import java.net.URLEncoder
 
 import com.sksamuel.elastic4s.requests.common.IndicesOptionsParams
-import com.sksamuel.elastic4s.{ElasticRequest, Handler, HttpEntity, HttpResponse, JacksonSupport, ResponseHandler}
+import com.sksamuel.elastic4s.{ElasticError, ElasticRequest, Handler, HttpEntity, HttpResponse, JacksonSupport, ResponseHandler}
 
 trait SearchHandlers {
 
@@ -24,7 +24,7 @@ trait SearchHandlers {
                   val status = element.get("status").intValue()
                   val either =
                     if (element.has("error"))
-                      Left(JacksonSupport.mapper.treeToValue[SearchError](element.get("error")))
+                      Left(JacksonSupport.mapper.treeToValue[ElasticError](element.get("error")))
                     else
                       Right(JacksonSupport.mapper.treeToValue[SearchResponse](element))
                   MultisearchResponseItem(index, status, either)


### PR DESCRIPTION
Hey,

it happened sometimes that we misconfigured our searches (for instance we configured an aggregation with a non-fitting field name). The problem was that we only got a generic `all_shards_failed` error with no useful information. The root cause has not been shown. I saw that `ElasticError` has been introduced recently which improves the situation but it wasn't used in the `MultiSearchHandler`. I removed `SearchError` in the `MultiSearchHandler` and replaced it with `ElasticError`.

Cheers!
Timo
