### PR TITLE
Fix issues #1922 and #1799

### DIFF
--- a/elastic4s-http-streams/src/main/scala/com/sksamuel/elastic4s/streams/ScrollPublisher.scala
+++ b/elastic4s-http-streams/src/main/scala/com/sksamuel/elastic4s/streams/ScrollPublisher.scala
@@ -159,7 +159,6 @@ class PublishActor(client: ElasticClient, query: SearchRequest, s: Subscriber[_ 
       logger.debug("Response from ES came back empty; this means no more items upstream so will complete subscription")
       scrollId = resp.result.scrollId.getOrElse(scrollId)
       s.onComplete()
-      client.execute(clearScroll(scrollId))
       logger.debug("Stopping publisher actor")
       context.stop(self)
     // more results and we can unleash the beast (stashed requests) and switch back to ready mode

--- a/elastic4s-http-streams/src/main/scala/com/sksamuel/elastic4s/streams/ScrollPublisher.scala
+++ b/elastic4s-http-streams/src/main/scala/com/sksamuel/elastic4s/streams/ScrollPublisher.scala
@@ -157,6 +157,7 @@ class PublishActor(client: ElasticClient, query: SearchRequest, s: Subscriber[_ 
     // if we had no results from ES then we have nothing left to publish and our work here is done
     case Success(resp: RequestSuccess[SearchResponse]) if resp.result.isEmpty =>
       logger.debug("Response from ES came back empty; this means no more items upstream so will complete subscription")
+      scrollId = resp.result.scrollId.getOrElse(scrollId)
       s.onComplete()
       client.execute(clearScroll(scrollId))
       logger.debug("Stopping publisher actor")
@@ -167,5 +168,10 @@ class PublishActor(client: ElasticClient, query: SearchRequest, s: Subscriber[_ 
       queue ++= resp.result.hits.hits
       context become ready
       unstashAll()
+  }
+
+  override def postStop() = {
+    super.postStop()
+    client.execute(clearScroll(scrollId))
   }
 }


### PR DESCRIPTION
* Update `scrollId` even if the response `isEmpty`
* Override `postStop` to try to `clearScroll` before stopping actor 

Should close #1922. Should close #1799 