### PR TITLE
[6.7.x] add include_type_name param

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 sudo: required
 
 language: scala
@@ -11,7 +13,7 @@ cache:
     - $HOME/.sbt
 
 before_install:
-- docker run -d -p 9200:9200 -p 9300:9300 -e "path.repo=/tmp" -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:6.5.2
+- docker run -d -p 9200:9200 -p 9300:9300 -e "path.repo=/tmp" -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:6.8.4
 
 before_cache:
   - find $HOME/.sbt -name "*.lock" | xargs rm

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/indexes/GetIndexRequest.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/indexes/GetIndexRequest.scala
@@ -1,3 +1,8 @@
 package com.sksamuel.elastic4s.indexes
 
-case class GetIndexRequest(index: String)
+import com.sksamuel.exts.OptionImplicits._
+
+case class GetIndexRequest(index: String, includeTypeName: Option[Boolean] = None) {
+
+  def includeTypeName(includeTypeName: Boolean): GetIndexRequest = copy(includeTypeName = includeTypeName.some)
+}

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/GetMappingRequest.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/GetMappingRequest.scala
@@ -3,7 +3,7 @@ package com.sksamuel.elastic4s.mappings
 import com.sksamuel.elastic4s.IndexesAndTypes
 import com.sksamuel.exts.OptionImplicits._
 
-case class GetMappingRequest(indexesAndTypes: IndexesAndTypes, local: Option[Boolean] = None) {
+case class GetMappingRequest(indexesAndTypes: IndexesAndTypes, local: Option[Boolean] = None, includeTypeName: Option[Boolean] = None) {
 
   def types(first: String, rest: String*): GetMappingRequest = types(first +: rest)
 
@@ -11,4 +11,6 @@ case class GetMappingRequest(indexesAndTypes: IndexesAndTypes, local: Option[Boo
     copy(indexesAndTypes = IndexesAndTypes(indexesAndTypes.indexes, types))
 
   def local(local: Boolean): GetMappingRequest = copy(local = local.some)
+
+  def includeTypeName(includeTypeName: Boolean): GetMappingRequest = copy(includeTypeName = includeTypeName.some)
 }

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/IndexHandlers.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/IndexHandlers.scala
@@ -59,8 +59,10 @@ trait IndexHandlers {
 
     override def build(request: GetIndexRequest): ElasticRequest = {
       val endpoint = "/" + request.index
-      val method   = "GET"
-      ElasticRequest(method, endpoint)
+      val params   = scala.collection.mutable.Map.empty[String, String]
+      request.includeTypeName.map(_.toString).foreach(params.put("include_type_name", _))
+
+      ElasticRequest("GET", endpoint, params.toMap)
     }
   }
 }

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/IndexHandlers.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/IndexHandlers.scala
@@ -59,8 +59,8 @@ trait IndexHandlers {
 
     override def build(request: GetIndexRequest): ElasticRequest = {
       val endpoint = "/" + request.index
-      val params   = scala.collection.mutable.Map.empty[String, String]
-      request.includeTypeName.map(_.toString).foreach(params.put("include_type_name", _))
+      val params   = scala.collection.mutable.Map.empty[String, Boolean]
+      request.includeTypeName.foreach(params.put("include_type_name", _))
 
       ElasticRequest("GET", endpoint, params.toMap)
     }

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/mappings/MappingHandlers.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/mappings/MappingHandlers.scala
@@ -41,8 +41,8 @@ trait MappingHandlers {
         case IndexesAndTypes(indexes, Nil)   => s"/${indexes.mkString(",")}/_mapping"
         case IndexesAndTypes(indexes, types) => s"/${indexes.mkString(",")}/_mapping/${types.mkString(",")}"
       }
-      val params   = scala.collection.mutable.Map.empty[String, String]
-      request.includeTypeName.map(_.toString).foreach(params.put("include_type_name", _))
+      val params   = scala.collection.mutable.Map.empty[String, Boolean]
+      request.includeTypeName.foreach(params.put("include_type_name", _))
 
       ElasticRequest("GET", endpoint, params.toMap)
     }

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/mappings/MappingHandlers.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/index/mappings/MappingHandlers.scala
@@ -41,7 +41,10 @@ trait MappingHandlers {
         case IndexesAndTypes(indexes, Nil)   => s"/${indexes.mkString(",")}/_mapping"
         case IndexesAndTypes(indexes, types) => s"/${indexes.mkString(",")}/_mapping/${types.mkString(",")}"
       }
-      ElasticRequest("GET", endpoint)
+      val params   = scala.collection.mutable.Map.empty[String, String]
+      request.includeTypeName.map(_.toString).foreach(params.put("include_type_name", _))
+
+      ElasticRequest("GET", endpoint, params.toMap)
     }
   }
 


### PR DESCRIPTION
In rolling update to es `6.8` to `7.x`, These parameters need to be set for 6.8 and 7.x compatibility.