### PR TITLE
Add missing_bucket to all CompositeAggregation value sources

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/CompositeAggregation.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/CompositeAggregation.scala
@@ -7,20 +7,23 @@ import com.sksamuel.exts.OptionImplicits._
 sealed abstract class ValueSource(val valueSourceType: String, val name: String,
                                   val field: Option[String],
                                   val script: Option[Script],
-                                  val order: Option[String])
+                                  val order: Option[String],
+                                  val missingBucket: Boolean)
 
 case class TermsValueSource(override val name: String,
                             override val field: Option[String] = None,
                             override val script: Option[Script] = None,
-                            override val order: Option[String] = None)
-  extends ValueSource("terms", name, field, script, order)
+                            override val order: Option[String] = None,
+                            override val missingBucket: Boolean = false)
+  extends ValueSource("terms", name, field, script, order, missingBucket)
 
 case class HistogramValueSource(override val name: String,
                                 interval: Int,
                                 override val field: Option[String] = None,
                                 override val script: Option[Script] = None,
-                                override val order: Option[String] = None)
-  extends ValueSource("histogram", name, field, script, order)
+                                override val order: Option[String] = None,
+                                override val missingBucket: Boolean = false)
+  extends ValueSource("histogram", name, field, script, order, missingBucket)
 
 case class DateHistogramValueSource(override val name: String,
                                     interval: String,
@@ -29,8 +32,8 @@ case class DateHistogramValueSource(override val name: String,
                                     override val order: Option[String] = None,
                                     timeZone: Option[String] = None,
                                     format: Option[String] = None,
-                                    missingBucket: Boolean = false)
-  extends ValueSource("date_histogram", name, field, script, order)
+                                    override val missingBucket: Boolean = false)
+  extends ValueSource("date_histogram", name, field, script, order, missingBucket)
 
 
 case class CompositeAggregation(name: String,

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/CompositeAggregationBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/CompositeAggregationBuilder.scala
@@ -17,13 +17,13 @@ object CompositeAggregationBuilder {
       s.field.foreach(builder.field("field", _))
       s.script.foreach(s => builder.rawField("script", ScriptBuilderFn(s)))
       s.order.foreach(builder.field("order", _))
+      if(s.missingBucket){ builder.field("missing_bucket", true) }
       s match {
-        case HistogramValueSource(_, interval, _, _, _) => builder.field("interval", interval)
-        case DateHistogramValueSource(_, interval, _, _, _, timeZone, format, missingBucket) => {
+        case HistogramValueSource(_, interval, _, _, _, _) => builder.field("interval", interval)
+        case DateHistogramValueSource(_, interval, _, _, _, timeZone, format, _) => {
           builder.field("interval", interval)
           timeZone.foreach(builder.field("time_zone", _))
           format.foreach(builder.field("format", _))
-          if(missingBucket){ builder.field("missing_bucket", true) }
         }
         case _ =>
       }

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/CompositeAggregationBuilderTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/CompositeAggregationBuilderTest.scala
@@ -43,18 +43,18 @@ class CompositeAggregationBuilderTest extends FunSuite with Matchers {
   test("CompositeAggregationBuilder should respect all possible value types and attributes") {
     val search = SearchRequest("myindex").aggs(
       CompositeAggregation("comp", sources = Seq(
-        TermsValueSource("s1", field = Some("f1"), order = Some("desc")),
-        HistogramValueSource("s2", 5, field = Some("f2"), order = Some("desc")),
-        DateHistogramValueSource("s3", "5d", field = Some("f3"), order = Some("desc"), timeZone = Some("+01:00"))
+        TermsValueSource("s1", field = Some("f1"), order = Some("desc"), missingBucket = true),
+        HistogramValueSource("s2", 5, field = Some("f2"), order = Some("desc"), missingBucket = true),
+        DateHistogramValueSource("s3", "5d", field = Some("f3"), order = Some("desc"), timeZone = Some("+01:00"), missingBucket = true)
       ))
     )
 
     SearchBodyBuilderFn(search).string() shouldBe
-      """{"aggs":{"comp":{"composite":{"sources":[{"s1":{"terms":{"field":"f1","order":"desc"}}},{"s2":{"histogram":{"field":"f2","order":"desc","interval":5}}},{"s3":{"date_histogram":{"field":"f3","order":"desc","interval":"5d","time_zone":"+01:00"}}}]}}}}"""
+      """{"aggs":{"comp":{"composite":{"sources":[{"s1":{"terms":{"field":"f1","order":"desc","missing_bucket":true}}},{"s2":{"histogram":{"field":"f2","order":"desc","missing_bucket":true,"interval":5}}},{"s3":{"date_histogram":{"field":"f3","order":"desc","missing_bucket":true,"interval":"5d","time_zone":"+01:00"}}}]}}}}"""
 
   }
 
-  test("CompositeAggregationBuilder should build simple terms-valued composites with after paramters") {
+  test("CompositeAggregationBuilder should build simple terms-valued composites with after parameters") {
     val search = SearchRequest("myindex").aggs(
       CompositeAggregation("comp", sources = Seq(
         TermsValueSource("s1", field = Some("f1"))),


### PR DESCRIPTION
I've added the "missing_bucket" property to all value sources of a CompositeAggregation. The current version of elastic4s only had it for `DateHistogramValueSource`