### PR TITLE
Ingest requests and handlers

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/ingest/IngestApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/ingest/IngestApi.scala
@@ -1,0 +1,8 @@
+package com.sksamuel.elastic4s.requests.ingest
+
+trait IngestApi {
+
+  def putPipeline(id: String, description: String, processors: Seq[Processor]): PutPipelineRequest =
+    PutPipelineRequest(id, description, processors)
+
+}

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/ingest/IngestHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/ingest/IngestHandlers.scala
@@ -1,0 +1,23 @@
+package com.sksamuel.elastic4s.requests.ingest
+
+import com.sksamuel.elastic4s.{ElasticRequest, Handler, HttpEntity, XContentBuilder, XContentFactory}
+
+trait IngestHandlers {
+
+  implicit object PutPipelineRequestHandler extends Handler[PutPipelineRequest, PutPipelineResponse] {
+    private def processorToXContent(p: Processor): XContentBuilder = {
+      val xcb = XContentFactory.jsonBuilder()
+      xcb.rawField(p.name, XContentFactory.parse(p.configuration))
+      xcb
+    }
+
+    override def build(request: PutPipelineRequest): ElasticRequest = {
+      val xcb = XContentFactory.jsonBuilder()
+      xcb.field("description", request.description)
+      xcb.array("processors", request.processors.map(processorToXContent).toArray)
+      xcb.endObject()
+      ElasticRequest("PUT", s"_ingest/pipeline/${request.id}", HttpEntity(xcb.string()))
+    }
+  }
+
+}

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/ingest/IngestHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/ingest/IngestHandlers.scala
@@ -7,7 +7,7 @@ trait IngestHandlers {
   implicit object PutPipelineRequestHandler extends Handler[PutPipelineRequest, PutPipelineResponse] {
     private def processorToXContent(p: Processor): XContentBuilder = {
       val xcb = XContentFactory.jsonBuilder()
-      xcb.rawField(p.name, XContentFactory.parse(p.configuration))
+      xcb.rawField(p.name, p.buildProcessorBody())
       xcb
     }
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/ingest/Processor.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/ingest/Processor.scala
@@ -1,0 +1,3 @@
+package com.sksamuel.elastic4s.requests.ingest
+
+case class Processor(name: String, configuration: String)

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/ingest/Processor.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/ingest/Processor.scala
@@ -1,3 +1,41 @@
 package com.sksamuel.elastic4s.requests.ingest
 
-case class Processor(name: String, configuration: String)
+import com.sksamuel.elastic4s.{XContentBuilder, XContentFactory}
+
+/**
+  * Abstract representation of a processor with a constant name (e.g. "geoip") and an [[XContentBuilder]] that
+  * constructs the body (e.g. { "field" : "ip" } ).
+  */
+trait Processor {
+  def name: String
+  def buildProcessorBody(): XContentBuilder
+}
+
+/**
+  * Processor defined by its name and raw Json options.
+  */
+case class CustomProcessor(name: String, rawJsonOptions: String) extends Processor {
+  override def buildProcessorBody(): XContentBuilder = XContentFactory.parse(rawJsonOptions)
+}
+
+
+/**
+  * Processor that enriches an IP address with geographical information.
+  * See docs for options: https://www.elastic.co/guide/en/elasticsearch/reference/current/geoip-processor.html
+  */
+case class GeoIPProcessor(field: String, targetField: Option[String] = None, databaseFile: Option[String] = None,
+                          properties: Option[Seq[String]] = None, ignoreMissing: Option[Boolean] = None,
+                          firstOnly: Option[Boolean] = None) extends Processor {
+  override def name: String = "geoip"
+  override def buildProcessorBody(): XContentBuilder = {
+    val xcb = XContentFactory.jsonBuilder()
+    xcb.field("field", field)
+    targetField.foreach(xcb.field("target_field", _))
+    databaseFile.foreach(xcb.field("database_file", _))
+    properties.foreach(p => xcb.array("properties", p.toArray))
+    ignoreMissing.foreach(xcb.field("ignore_missing", _))
+    firstOnly.foreach(xcb.field("first_only", _))
+    xcb
+  }
+}
+

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/ingest/PutPipelineRequest.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/ingest/PutPipelineRequest.scala
@@ -1,0 +1,8 @@
+package com.sksamuel.elastic4s.requests.ingest
+
+case class PutPipelineRequest(id: String, description: String, processors: Seq[Processor] = Seq.empty)
+
+object PutPipelineRequest {
+  def apply(id: String, description: String, processor: Processor): PutPipelineRequest =
+    PutPipelineRequest(id, description, Seq(processor))
+}

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/ingest/PutPipelineResponse.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/ingest/PutPipelineResponse.scala
@@ -1,0 +1,3 @@
+package com.sksamuel.elastic4s.requests.ingest
+
+case class PutPipelineResponse(acknowledged: Boolean)

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/ingest/PutPipelineRequestHandlerTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/ingest/PutPipelineRequestHandlerTest.scala
@@ -1,0 +1,80 @@
+package com.sksamuel.elastic4s.requests.ingest
+
+import com.sksamuel.elastic4s.{ElasticRequest, HttpEntity, XContentFactory}
+import org.scalatest.{FlatSpec, Matchers}
+
+class PutPipelineRequestHandlerTest extends FlatSpec with IngestHandlers with Matchers {
+
+  import PutPipelineRequestHandler._
+
+  // See the docs: https://www.elastic.co/guide/en/elasticsearch/reference/master/geoip-processor.html#geoip-processor
+  it should "build a pipeline request with a geoip processor" in {
+    val req = PutPipelineRequest("geoip", "Add geoip info", Processor("geoip", "{\"field\": \"ip\"}"))
+    val correctJson =
+      XContentFactory.parse("""
+        |{
+        |  "description" : "Add geoip info",
+        |  "processors" : [
+        |    {
+        |      "geoip" : {
+        |        "field" : "ip"
+        |      }
+        |    }
+        |  ]
+        |}
+        |""".stripMargin).string()
+    build(req) shouldBe ElasticRequest("PUT", "_ingest/pipeline/geoip", HttpEntity(correctJson))
+  }
+
+  it should "build a pipeline request with a langdetect processor" in {
+    val req = PutPipelineRequest("langdetect-pipeline", "A pipeline to do whatever",
+      Processor("langdetect", "{\"field\": \"my_field\", \"target_field\": \"language\" }"))
+    val correctJson = XContentFactory.parse(
+      """
+        |{
+        |  "description": "A pipeline to do whatever",
+        |  "processors": [
+        |    {
+        |      "langdetect" : {
+        |        "field" : "my_field",
+        |        "target_field" : "language"
+        |      }
+        |    }
+        |  ]
+        |}
+        |
+        |""".stripMargin).string()
+    build(req) shouldBe ElasticRequest("PUT", "_ingest/pipeline/langdetect-pipeline", HttpEntity(correctJson))
+  }
+
+  it should "build a pipeline request with multiple processors" in {
+    val req = PutPipelineRequest("multi-pipeline", "A pipeline with multiple processors",
+      Seq(
+        Processor("geoip", "{\"field\": \"ip\"}"),
+        Processor("langdetect", "{\"field\": \"my_field\", \"target_field\": \"language\" }")
+      ))
+    val correctJson = XContentFactory.parse(
+      """
+        |{
+        |  "description": "A pipeline with multiple processors",
+        |  "processors": [
+        |    {
+        |      "geoip" : {
+        |        "field" : "ip"
+        |      }
+        |    },
+        |    {
+        |      "langdetect" : {
+        |        "field" : "my_field",
+        |        "target_field" : "language"
+        |      }
+        |    }
+        |  ]
+        |}
+        |""".stripMargin).string()
+    build(req) shouldBe ElasticRequest("PUT", "_ingest/pipeline/multi-pipeline", HttpEntity(correctJson))
+  }
+
+
+}
+

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/ingest/PutPipelineRequestHandlerTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/ingest/PutPipelineRequestHandlerTest.scala
@@ -7,7 +7,7 @@ class PutPipelineRequestHandlerTest extends FlatSpec with IngestHandlers with Ma
 
   import PutPipelineRequestHandler._
 
-  // See the docs: https://www.elastic.co/guide/en/elasticsearch/reference/master/geoip-processor.html#geoip-processor
+  // Docs: https://www.elastic.co/guide/en/elasticsearch/reference/master/geoip-processor.html#geoip-processor
   it should "build a pipeline request with a geoip processor" in {
     val req = PutPipelineRequest("geoip", "Add geoip info", Processor("geoip", "{\"field\": \"ip\"}"))
     val correctJson =
@@ -26,6 +26,7 @@ class PutPipelineRequestHandlerTest extends FlatSpec with IngestHandlers with Ma
     build(req) shouldBe ElasticRequest("PUT", "_ingest/pipeline/geoip", HttpEntity(correctJson))
   }
 
+  // Docs: https://github.com/spinscale/elasticsearch-ingest-langdetect#usage
   it should "build a pipeline request with a langdetect processor" in {
     val req = PutPipelineRequest("langdetect-pipeline", "A pipeline to do whatever",
       Processor("langdetect", "{\"field\": \"my_field\", \"target_field\": \"language\" }"))


### PR DESCRIPTION
This addresses: https://github.com/sksamuel/elastic4s/issues/1926

Some specific places where feedback would be great:
- Not sure the request names are great. Some of the other requests include the http verb (e.g. `PutMappingRequest`), while others do not (e.g. `IndexRequest`). I went with the former but can easily change.
- Does the package make sense? I figured `requests.ingest` makes sense since the endpoints are all prefixed with `_ingest`.
- Passing the `configuration` json as a raw string doesn't seem great, but there's precedent, like the `source` field in the `IndexRequest` case class.

For the tests I just made sure that the scala-based requests match the pure http/json requests in the docs for a couple common pipelines/processors. I can make this more rigorous if needed.

Also, thanks to @eliza-jane for helping out at the Boston scala project night!