### PR TITLE
Fix endpoint path in ValidateHandler

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/validate/ValidateHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/validate/ValidateHandlers.scala
@@ -26,7 +26,7 @@ trait ValidateHandlers {
 
     override def build(request: ValidateRequest): ElasticRequest = {
 
-      val endpoint = s"${request.indexes.values.mkString(",")}/_validate/query"
+      val endpoint = s"/${request.indexes.values.mkString(",")}/_validate/query"
 
       val params = scala.collection.mutable.Map.empty[String, String]
       request.explain.map(_.toString).foreach(params.put("explain", _))


### PR DESCRIPTION
Without the initial "/" validate would produce an invalid HTTP request
-- i.e. GET foo instead of GET /foo -- that would e.g. upset
proxies like Nginx.

See https://www.ietf.org/rfc/rfc2396.txt page 10 or
https://stackoverflow.com/questions/27638278/do-http-paths-have-to-start-with-a-slash