### PR TITLE
fix: add nested_filter to script sort

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/SortBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/SortBuilderFn.scala
@@ -84,6 +84,7 @@ object ScriptSortBuilderFn {
     scriptSort.order.map(a => builder.field("order", EnumConversions.order(a)))
     scriptSort.sortMode.map(a => builder.field("mode", EnumConversions.sortMode(a)))
     scriptSort.nestedPath.map(a => builder.field("nested_path", a))
+    scriptSort.nestedFilter.map(QueryBuilderFn.apply).map(_.string).foreach(builder.rawField("nested_filter", _))
 
     builder.endObject()
   }

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/queries/SortBuilderFnTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/queries/SortBuilderFnTest.scala
@@ -22,8 +22,10 @@ class SortBuilderFnTest extends AnyFunSuite with Matchers {
     val request = scriptSort(scr)
       .typed(ScriptSortType.Number)
       .order(SortOrder.Desc)
+      .nestedPath("foo.bar")
+      .nestedFilter(matchQuery("foo.bar", "foo"))
     SortBuilderFn(request).string() shouldBe
-      """{"_script":{"script":{"source":"dummy script","lang":"painless","params":{"nump":10.2,"stringp":"ciao","boolp":true}},"type":"number","order":"desc"}}"""
+      """{"_script":{"script":{"source":"dummy script","lang":"painless","params":{"nump":10.2,"stringp":"ciao","boolp":true}},"type":"number","order":"desc","nested_path":"foo.bar","nested_filter":{"match":{"foo.bar":{"query":"foo"}}}}}"""
   }
 
   test("geo distance sort does not generate unit field by default") {


### PR DESCRIPTION
This PR adds the `nested_filter` param construction in the `ScriptSortBuilderFn`.

Closes #1969

_Edit :_ Waiting for the build to pass.