### PR TITLE
Fix Levenshtein and Jaro-Winkler string distance naming

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/suggestion/TermSuggestion.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/suggestion/TermSuggestion.scala
@@ -34,15 +34,15 @@ object StringDistance {
   def valueOf(str: String): StringDistance = str.toUpperCase match {
     case "INTERNAL"            => INTERNAL
     case "DAMERAU_LEVENSHTEIN" => DAMERAU_LEVENSHTEIN
-    case "LEVENSTEIN"          => LEVENSTEIN
-    case "JAROWINKLER"         => JAROWINKLER
+    case "LEVENSHTEIN"         => LEVENSHTEIN
+    case "JARO_WINKLER"        => JARO_WINKLER
     case "NGRAM"               => NGRAM
   }
 
   case object INTERNAL            extends StringDistance
   case object DAMERAU_LEVENSHTEIN extends StringDistance
-  case object LEVENSTEIN          extends StringDistance
-  case object JAROWINKLER         extends StringDistance
+  case object LEVENSHTEIN         extends StringDistance
+  case object JARO_WINKLER        extends StringDistance
   case object NGRAM               extends StringDistance
 }
 

--- a/elastic4s-tests/src/test/resources/json/search/search_suggestions_multiple.json
+++ b/elastic4s-tests/src/test/resources/json/search/search_suggestions_multiple.json
@@ -29,7 +29,7 @@
             "term": {
                 "field": "names",
                 "max_inspections": 3,
-                "string_distance": "LEVENSTEIN"
+                "string_distance": "LEVENSHTEIN"
             }
         },
         "my-suggestion-4": {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
@@ -801,7 +801,7 @@ class SearchDslTest extends FlatSpec with MockitoSugar with JsonSugar with OneIn
     val req = search("music") query "coldplay" suggestions(
       termSuggestion("my-suggestion-1", "names", "clocks by culdpaly") maxEdits 2 mode "Popular" shardSize 2 accuracy 0.6,
       termSuggestion("my-suggestion-2", "names", "aqualuck by jethro toll") size 5 mode "Missing" minDocFreq 0.2 prefixLength 3,
-      termSuggestion("my-suggestion-3", "names", "bountiful day by u22") maxInspections 3 stringDistance "levenstein",
+      termSuggestion("my-suggestion-3", "names", "bountiful day by u22") maxInspections 3 stringDistance "levenshtein",
       termSuggestion("my-suggestion-4", "names", "whatever some text") maxTermFreq 0.5 minWordLength 5 mode
         SuggestMode.Always
     )


### PR DESCRIPTION
Applying this PR will fix the naming of and the `valueOf`-method for the case objects of the Levenshtein and Jaro-Winkler string distance options. Right now they result in an `IllegalArgumentException("Illegal distance option ...")`.