### PR TITLE
Add pinned query

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.3.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.4.2
     environment:
       discovery.type: single-node
       network.host: 0.0.0.0

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/QueryApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/QueryApi.scala
@@ -176,6 +176,8 @@ trait QueryApi {
       PercolateQuery(field, `type`, source = Some(indexable.json(t)))
   }
 
+  def pinnedQuery(ids: List[String], organic: Query): PinnedQuery = PinnedQuery(ids, organic)
+
   def rangeQuery(field: String): RangeQuery = RangeQuery(field)
 
   def rawQuery(json: String): RawQuery = RawQuery(json)

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/PinnedQuery.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/PinnedQuery.scala
@@ -1,0 +1,3 @@
+package com.sksamuel.elastic4s.requests.searches.queries
+
+case class PinnedQuery(ids: List[String], organic: Query) extends Query

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/PinnedQueryBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/PinnedQueryBuilderFn.scala
@@ -1,0 +1,14 @@
+package com.sksamuel.elastic4s.requests.searches.queries
+
+import com.sksamuel.elastic4s.{XContentBuilder, XContentFactory}
+
+object PinnedQueryBuilderFn {
+  def apply(q: PinnedQuery): XContentBuilder = {
+    val builder = XContentFactory.jsonBuilder()
+    builder.startObject("pinned")
+    builder.array("ids", q.ids)
+    builder.rawField("organic", QueryBuilderFn(q.organic))
+    builder.endObject()
+    builder
+  }
+}

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/QueryBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/QueryBuilderFn.scala
@@ -39,6 +39,7 @@ object QueryBuilderFn {
     case q: NestedQuery         => NestedQueryBodyFn(q)
     case NoopQuery              => XContentFactory.jsonBuilder()
     case q: ParentIdQuery       => ParentIdQueryBodyFn(q)
+    case q: PinnedQuery         => PinnedQueryBuilderFn(q)
     case q: PrefixQuery         => PrefixQueryBodyFn(q)
     case q: QueryStringQuery    => QueryStringBodyFn(q)
     case r: RangeQuery          => RangeQueryBodyFn(r)

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/queries/PinnedQueryBodyFnTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/queries/PinnedQueryBodyFnTest.scala
@@ -1,0 +1,36 @@
+package com.sksamuel.elastic4s.requests.searches.queries
+
+import com.sksamuel.elastic4s.requests.searches.queries.matches.MatchAllQuery
+import org.scalatest.GivenWhenThen
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class PinnedQueryBodyFnTest extends AnyFunSuite with Matchers with GivenWhenThen {
+
+  test("Should correctly build pinned query") {
+    Given("Some pinned query")
+    val query = PinnedQuery(
+      ids = List("1", "2", "3"),
+      organic = MatchAllQuery()
+    )
+
+    When("Pinned query is built")
+    val queryBody = PinnedQueryBuilderFn(query)
+
+    Then("query should have right fields")
+    queryBody.string() shouldEqual pinnedQuery
+  }
+
+  def pinnedQuery: String =
+    """
+      |{
+      |   "pinned":{
+      |      "ids": ["1","2","3"],
+      |      "organic": {
+      |         "match_all": {}
+      |      }
+      |   }
+      |}
+    """.stripMargin.replaceAllLiterally(" ", "").replace("\n", "")
+
+}

--- a/elastic4s-tests/src/test/resources/json/search/search_pinned.json
+++ b/elastic4s-tests/src/test/resources/json/search/search_pinned.json
@@ -1,0 +1,11 @@
+{
+    "size": 5,
+    "query": {
+        "pinned": {
+            "ids": ["1", "2", "3"],
+            "organic": {
+                "match_all": {}
+            }
+        }
+    }
+}

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
@@ -7,7 +7,7 @@ import com.sksamuel.elastic4s.requests.searches._
 import com.sksamuel.elastic4s.requests.searches.aggs.{SubAggCollectionMode, TermsOrder}
 import com.sksamuel.elastic4s.requests.searches.queries.funcscorer.MultiValueMode
 import com.sksamuel.elastic4s.requests.searches.queries.geo.GeoDistance
-import com.sksamuel.elastic4s.requests.searches.queries.matches.{MultiMatchQueryBuilderType, ZeroTermsQuery}
+import com.sksamuel.elastic4s.requests.searches.queries.matches.{MatchAllQuery, MultiMatchQueryBuilderType, ZeroTermsQuery}
 import com.sksamuel.elastic4s.requests.searches.queries.{RegexpFlag, SimpleQueryStringFlag}
 import com.sksamuel.elastic4s.requests.searches.sort.{SortMode, SortOrder}
 import com.sksamuel.elastic4s.requests.searches.suggestion.{DirectGenerator, Fuzziness, SuggestMode}
@@ -68,6 +68,13 @@ class SearchDslTest extends FlatSpec with MockitoSugar with JsonSugar with OneIn
       termQuery("singer", "chris martin") boost 1.6
     } searchType SearchType.DEFAULT
     req.request.entity.get.get should matchJsonResource("/json/search/search_term.json")
+  }
+
+  it should "generate json for a pinned query" in {
+    val req = search("*") limit 5 query {
+      pinnedQuery(List("1", "2", "3"), matchAllQuery())
+    }
+    req.request.entity.get.get should matchJsonResource("/json/search/search_pinned.json")
   }
 
   it should "generate json for a range query" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/PinnedQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/PinnedQueryTest.scala
@@ -1,0 +1,32 @@
+package com.sksamuel.elastic4s.search.queries
+
+import com.sksamuel.elastic4s.requests.common.RefreshPolicy
+import com.sksamuel.elastic4s.testkit.DockerTests
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class PinnedQueryTest extends AnyFlatSpec with Matchers with DockerTests {
+
+  client.execute {
+    createIndex("sodas")
+  }.await
+
+  client.execute {
+    bulk(
+      indexInto("sodas").fields("name" -> "sprite zero", "style" -> "lemonade") id "5",
+      indexInto("sodas").fields("name" -> "coke zero", "style" -> "cola") id "9"
+    ).refresh(RefreshPolicy.Immediate)
+  }.await
+
+  "pinned query" should "match both ids in the correct order" in {
+    val resp = client.execute {
+      search("sodas").query {
+        pinnedQuery(ids = List("9"), organic = matchQuery("style", "lemonade"))
+      }
+    }.await.result
+
+    resp.totalHits shouldBe 2
+    resp.hits.hits.head.sourceField("name") shouldBe "coke zero"
+    resp.hits.hits.last.sourceField("name") shouldBe "sprite zero"
+  }
+}


### PR DESCRIPTION
Applying this PR will add the `pinned query` feature, which was introduced in Elasticsearch 7.4.0 (https://www.elastic.co/guide/en/elasticsearch/reference/7.4/query-dsl-pinned-query.html).