### PR TITLE
[6.5.x] Add support for include_in_root|parent settings for nested fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,4 @@ script:
 - sbt clean test
 
 jdk:
-- oraclejdk8
+- openjdk8

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/CommonFieldBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/CommonFieldBuilder.scala
@@ -108,6 +108,8 @@ object FieldBuilderFn {
 
       case nested: NestedField =>
         nested.dynamic.foreach(builder.field("dynamic", _))
+        nested.includeInParent.foreach(builder.field("include_in_parent", _))
+        nested.includeInRoot.foreach(builder.field("include_in_root", _))
 
       case text: TextField =>
         text.eagerGlobalOrdinals.foreach(builder.field("eager_global_ordinals", _))

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/NestedField.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/NestedField.scala
@@ -10,6 +10,8 @@ case class NestedField(name: String,
                        dynamic: Option[String] = None,
                        enabled: Option[Boolean] = None,
                        includeInAll: Option[Boolean] = None,
+                       includeInParent: Option[Boolean] = None,
+                       includeInRoot: Option[Boolean] = None,
                        index: Option[String] = None,
                        indexOptions: Option[String] = None,
                        fields: Seq[FieldDefinition] = Nil,
@@ -43,6 +45,16 @@ case class NestedField(name: String,
   override def enabled(enabled: Boolean): T = copy(enabled = enabled.some)
 
   override def includeInAll(includeInAll: Boolean): T = copy(includeInAll = includeInAll.some)
+
+  @deprecated(
+    "This setting was removed from the Elasticsearch documentation in version 2.0. See the following discussion regarding removing support in a future version of elasticsearch: https://github.com/elastic/elasticsearch/issues/12461"
+  )
+  def includeInParent(includeInParent: Boolean): T = copy(includeInParent = includeInParent.some)
+
+  @deprecated(
+    "This setting was removed from the Elasticsearch documentation in version 2.0. See the following discussion regarding removing support in a future version of elasticsearch: https://github.com/elastic/elasticsearch/issues/12461"
+  )
+  def includeInRoot(includeInRoot: Boolean): T = copy(includeInRoot = includeInRoot.some)
 
   override def index(index: Boolean): T = copy(index = index.toString.some)
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/mappings/NestedFieldTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/mappings/NestedFieldTest.scala
@@ -1,0 +1,30 @@
+package com.sksamuel.elastic4s.mappings
+
+import com.sksamuel.elastic4s.ElasticApi
+import org.scalatest.{FlatSpec, Matchers}
+
+class NestedFieldTest extends FlatSpec with Matchers with ElasticApi {
+
+  val field: NestedField = nestedField("myfield")
+
+  "A NestedField" should "support boolean dynamic property" in {
+    FieldBuilderFn(field.dynamic(true)).string() shouldBe
+      """{"type":"nested","dynamic":"true"}"""
+  }
+
+  it should "support string dynamic property" in {
+    FieldBuilderFn(field.dynamic("strict")).string() shouldBe
+      """{"type":"nested","dynamic":"strict"}"""
+  }
+
+  it should "support include_in_root property" in {
+    FieldBuilderFn(field.includeInRoot(true)).string() shouldBe
+      """{"type":"nested","include_in_root":true}"""
+  }
+
+  it should "support include_in_parent property" in {
+    FieldBuilderFn(field.includeInParent(true)).string() shouldBe
+      """{"type":"nested","include_in_parent":true}"""
+  }
+}
+


### PR DESCRIPTION
The `include_in_root` and `include_in_parent` settings for `nested` fields were removed from the elasticsearch documentation in version 2.0 (see: [1.7](https://www.elastic.co/guide/en/elasticsearch/reference/1.7/mapping-nested-type.html) vs [2.0](https://www.elastic.co/guide/en/elasticsearch/reference/2.0/nested.html)).
However these settings are still supported by all versions of elasticsearch (tested on current latest version 7.5.2), and a [discussion about removing support for these settings](https://github.com/elastic/elasticsearch/issues/12461) is stalled since May 2018.

Since this is still supported by elasticsearch, I think elastic4s should support this too.
Also, how are you managing porting to other releases? I think this should be ported to all other version as well. Should I open separate PRs for the other releases?