### PR TITLE
fix sttp uri interpolation

### DIFF
--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/tasks/TasksTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/tasks/TasksTest.scala
@@ -11,7 +11,7 @@ class TasksTest extends FlatSpec with DockerTests with Matchers {
       listTasks()
     }.await.result
 
-    resp.nodes.head._2.roles should contain theSameElementsAs(Seq("master", "data", "ingest"))
+    resp.nodes.head._2.roles should contain allElementsOf (Seq("master", "data", "ingest"))
     resp.nodes.head._2.tasks.values.forall(_.startTimeInMillis > 0) shouldBe true
   }
 


### PR DESCRIPTION
Previous implementation generated url as `host:port/%2Findex%2F_search`.
This pr fixes it