### PR TITLE
Remove unused and optimize imports

### DIFF
--- a/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClient.scala
+++ b/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClient.scala
@@ -1,20 +1,16 @@
 package com.sksamuel.elastic4s.akka
 
-import scala.concurrent.{Future, Promise}
-import scala.util.{Failure, Success, Try}
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.Uri.Query
 import akka.http.scaladsl.model._
 import akka.stream.scaladsl.{FileIO, Keep, Sink, Source, StreamConverters}
 import akka.stream.{ActorMaterializer, OverflowStrategy, QueueOfferResult}
 import akka.util.ByteString
-import com.sksamuel.elastic4s.ElasticRequest
 import com.sksamuel.elastic4s.HttpEntity.StringEntity
-import com.sksamuel.elastic4s.{
-  HttpClient => ElasticHttpClient,
-  HttpEntity => ElasticHttpEntity,
-  HttpResponse => ElasticHttpResponse
-}
+import com.sksamuel.elastic4s.{ElasticRequest, HttpClient ⇒ ElasticHttpClient, HttpEntity ⇒ ElasticHttpEntity, HttpResponse ⇒ ElasticHttpResponse}
+
+import scala.concurrent.{Future, Promise}
+import scala.util.{Failure, Success, Try}
 
 class AkkaHttpClient private[akka] (
     settings: AkkaHttpClientSettings,

--- a/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientSettings.scala
+++ b/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientSettings.scala
@@ -3,11 +3,11 @@ package com.sksamuel.elastic4s.akka
 import java.util.concurrent.TimeUnit
 
 import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.settings.ConnectionPoolSettings
+import com.typesafe.config.{Config, ConfigFactory}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
-import akka.http.scaladsl.settings.ConnectionPoolSettings
-import com.typesafe.config.{Config, ConfigFactory}
 
 object AkkaHttpClientSettings {
 

--- a/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/DefaultHttpPoolFactory.scala
+++ b/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/DefaultHttpPoolFactory.scala
@@ -1,15 +1,15 @@
 package com.sksamuel.elastic4s.akka
 
-import scala.concurrent.Future
-import scala.concurrent.duration.Duration
-import scala.util.Try
-
 import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 import akka.http.scaladsl.settings.ConnectionPoolSettings
 import akka.stream.scaladsl.Flow
+
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration
+import scala.util.Try
 
 private[akka] class DefaultHttpPoolFactory(settings: ConnectionPoolSettings)(
   implicit system: ActorSystem)

--- a/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/HttpPoolFactory.scala
+++ b/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/HttpPoolFactory.scala
@@ -1,11 +1,11 @@
 package com.sksamuel.elastic4s.akka
 
-import scala.concurrent.Future
-import scala.util.Try
-
 import akka.NotUsed
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 import akka.stream.scaladsl.Flow
+
+import scala.concurrent.Future
+import scala.util.Try
 
 /**
   * Factory for Akka's http pool flow.

--- a/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientMockTest.scala
+++ b/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientMockTest.scala
@@ -1,16 +1,15 @@
 package com.sksamuel.elastic4s.akka
 
-import scala.concurrent.duration._
-import scala.util.{Failure, Success, Try}
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse, StatusCodes, Uri}
-import com.sksamuel.elastic4s.ElasticRequest
-import com.sksamuel.elastic4s.akka.AkkaHttpClient.AllHostsBlacklistedException
-import com.sksamuel.elastic4s.{HttpEntity => ElasticEntity, HttpResponse => ElasticResponse}
+import com.sksamuel.elastic4s.{ElasticRequest, HttpEntity ⇒ ElasticEntity, HttpResponse ⇒ ElasticResponse}
 import org.scalamock.function.MockFunction1
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent._
 import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
 
 class AkkaHttpClientMockTest
   extends WordSpec

--- a/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/DefaultBlacklistTest.scala
+++ b/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/DefaultBlacklistTest.scala
@@ -1,9 +1,9 @@
 package com.sksamuel.elastic4s.akka
 
+import org.scalatest.{Matchers, WordSpec}
+
 import scala.concurrent.duration._
 import scala.language.postfixOps
-
-import org.scalatest.{Matchers, WordSpec}
 
 class DefaultBlacklistTest extends WordSpec with Matchers {
 

--- a/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/TestHttpPoolFactory.scala
+++ b/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/TestHttpPoolFactory.scala
@@ -1,12 +1,12 @@
 package com.sksamuel.elastic4s.akka
 
-import scala.concurrent.Future
-import scala.concurrent.duration.{FiniteDuration, _}
-import scala.util.Try
-
 import akka.NotUsed
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 import akka.stream.scaladsl.Flow
+
+import scala.concurrent.Future
+import scala.concurrent.duration.{FiniteDuration, _}
+import scala.util.Try
 
 class TestHttpPoolFactory(sendRequest: HttpRequest => Try[HttpResponse],
                           timeout: FiniteDuration = 2.seconds) extends HttpPoolFactory {

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticApi.scala
@@ -1,23 +1,22 @@
 package com.sksamuel.elastic4s
 
-import com.sksamuel.elastic4s.requests.{ExistsApi, TypesApi}
+import com.sksamuel.elastic4s.requests.admin.IndexAdminApi
+import com.sksamuel.elastic4s.requests.alias.AliasesApi
+import com.sksamuel.elastic4s.requests.analyzers.{AnalyzerApi, NormalizerApi, TokenFilterApi, TokenizerApi}
+import com.sksamuel.elastic4s.requests.bulk.BulkApi
+import com.sksamuel.elastic4s.requests.cat.CatsApi
 import com.sksamuel.elastic4s.requests.cluster.ClusterApi
 import com.sksamuel.elastic4s.requests.count.CountApi
 import com.sksamuel.elastic4s.requests.delete.DeleteApi
 import com.sksamuel.elastic4s.requests.explain.ExplainApi
+import com.sksamuel.elastic4s.requests.get.GetApi
 import com.sksamuel.elastic4s.requests.indexes.admin.{ForceMergeApi, IndexRecoveryApi}
 import com.sksamuel.elastic4s.requests.indexes.{CreateIndexApi, DeleteIndexApi, IndexApi, IndexTemplateApi}
+import com.sksamuel.elastic4s.requests.locks.LocksApi
 import com.sksamuel.elastic4s.requests.mappings.MappingApi
 import com.sksamuel.elastic4s.requests.mappings.dynamictemplate.DynamicTemplateApi
-import com.sksamuel.elastic4s.requests.admin.IndexAdminApi
-import com.sksamuel.elastic4s.requests.alias.AliasesApi
-import com.sksamuel.elastic4s.requests.analyzers.{AnalyzerApi, NormalizerApi, TokenFilterApi, TokenizerApi}
 import com.sksamuel.elastic4s.requests.nodes.NodesApi
 import com.sksamuel.elastic4s.requests.reindex.ReindexApi
-import com.sksamuel.elastic4s.requests.bulk.BulkApi
-import com.sksamuel.elastic4s.requests.cat.CatsApi
-import com.sksamuel.elastic4s.requests.get.GetApi
-import com.sksamuel.elastic4s.requests.locks.LocksApi
 import com.sksamuel.elastic4s.requests.script.ScriptApi
 import com.sksamuel.elastic4s.requests.searches._
 import com.sksamuel.elastic4s.requests.searches.aggs.AggregationApi
@@ -36,6 +35,7 @@ import com.sksamuel.elastic4s.requests.task.TaskApi
 import com.sksamuel.elastic4s.requests.termvectors.TermVectorApi
 import com.sksamuel.elastic4s.requests.update.UpdateApi
 import com.sksamuel.elastic4s.requests.validate.ValidateApi
+import com.sksamuel.elastic4s.requests.{ExistsApi, TypesApi}
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticDsl.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticDsl.scala
@@ -16,10 +16,10 @@ import com.sksamuel.elastic4s.requests.reindex.ReindexHandlers
 import com.sksamuel.elastic4s.requests.searches.queries.validate.ValidateHandlers
 import com.sksamuel.elastic4s.requests.searches.template.SearchTemplateHandlers
 import com.sksamuel.elastic4s.requests.searches.{SearchHandlers, SearchScrollHandlers}
-import com.sksamuel.elastic4s.requests.security.roles.admin.RoleAdminHandlers
 import com.sksamuel.elastic4s.requests.security.roles.RoleHandlers
-import com.sksamuel.elastic4s.requests.security.users.admin.UserAdminHandlers
+import com.sksamuel.elastic4s.requests.security.roles.admin.RoleAdminHandlers
 import com.sksamuel.elastic4s.requests.security.users.UserHandlers
+import com.sksamuel.elastic4s.requests.security.users.admin.UserAdminHandlers
 import com.sksamuel.elastic4s.requests.settings.SettingsHandlers
 import com.sksamuel.elastic4s.requests.snapshots.SnapshotHandlers
 import com.sksamuel.elastic4s.requests.task.TaskHandlers

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/TypesApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/TypesApi.scala
@@ -1,6 +1,5 @@
 package com.sksamuel.elastic4s.requests
 
-import com.sksamuel.elastic4s.requests.mappings.FieldType.{BinaryType, BooleanType, ByteType, CompletionType, DateType, DoubleType, FloatType, GeoPointType, GeoShapeType, IntegerType, IpType, KeywordType, LongType, NestedType, ObjectType, PercolatorType, ShortType, TextType, TokenCountType}
 import com.sksamuel.elastic4s.requests.mappings.{BasicField, CompletionField, GeoshapeField, JoinField, KeywordField, NestedField, ObjectField, RangeField, SearchAsYouTypeField, TextField}
 import com.sksamuel.elastic4s.requests.script.{Script, ScriptField}
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/cluster/health.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/cluster/health.scala
@@ -1,9 +1,7 @@
 package com.sksamuel.elastic4s.requests.cluster
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.sksamuel.elastic4s.{ElasticRequest, Handler}
 import com.sksamuel.elastic4s.requests.common.{HealthStatus, Priority}
-
 import com.sksamuel.exts.OptionImplicits._
 
 case class ClusterHealthRequest(indices: Seq[String],

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/cluster/settings.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/cluster/settings.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.elastic4s.requests.cluster
 
-import com.sksamuel.elastic4s.{ElasticRequest, Handler, HttpEntity, XContentBuilder, XContentFactory}
+import com.sksamuel.elastic4s.{XContentBuilder, XContentFactory}
 
 case class ClusterSettingsRequest(persistentSettings: Map[String, String], transientSettings: Map[String, String]) {
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/CreateIndex.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/CreateIndex.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.elastic4s.requests.indexes
 
 import com.sksamuel.elastic4s.requests.analyzers.{AnalyzerDefinition, NormalizerDefinition}
-import com.sksamuel.elastic4s.requests.mappings.{Analysis, MappingDefinition}
+import com.sksamuel.elastic4s.requests.mappings.MappingDefinition
 import com.sksamuel.elastic4s.requests.searches.queries.Query
 import com.sksamuel.exts.OptionImplicits._
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/ExistsHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/ExistsHandlers.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.elastic4s.requests.indexes
 
-import com.sksamuel.elastic4s.requests.ExistsRequest
 import com.sksamuel.elastic4s._
+import com.sksamuel.elastic4s.requests.ExistsRequest
 
 trait ExistsHandlers {
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/IndexHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/IndexHandlers.scala
@@ -4,9 +4,9 @@ import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.sksamuel.elastic4s.HttpEntity.ByteArrayEntity
 import com.sksamuel.elastic4s._
 import com.sksamuel.elastic4s.requests.common.RefreshPolicyHttpValue
-import com.sksamuel.elastic4s.HttpEntity.ByteArrayEntity
 import com.sksamuel.exts.collection.Maps
 
 trait IndexHandlers {

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/IndexStatsHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/IndexStatsHandlers.scala
@@ -1,8 +1,8 @@
 package com.sksamuel.elastic4s.requests.indexes
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.sksamuel.elastic4s.{ElasticRequest, Handler}
 import com.sksamuel.elastic4s.requests.admin.IndexStatsRequest
+import com.sksamuel.elastic4s.{ElasticRequest, Handler}
 
 case class Docs(count: Long, deleted: Long)
 case class Store(@JsonProperty("size_in_bytes") sizeInBytes: Long)

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/MappingHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/MappingHandlers.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.elastic4s.requests.indexes
 
-import com.sksamuel.elastic4s.requests.mappings.{GetFieldMappingRequest, GetMappingRequest, PutMappingRequest}
 import com.sksamuel.elastic4s._
+import com.sksamuel.elastic4s.requests.mappings.{GetFieldMappingRequest, GetMappingRequest, PutMappingRequest}
 
 case class IndexMappings(index: String, mappings: Map[String, Any])
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/alias/AliasActionBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/alias/AliasActionBuilder.scala
@@ -1,8 +1,8 @@
 package com.sksamuel.elastic4s.requests.indexes.alias
 
-import com.sksamuel.elastic4s.{XContentBuilder, XContentFactory}
 import com.sksamuel.elastic4s.requests.alias.{AddAliasActionRequest, IndicesAliasesRequest, RemoveAliasAction}
 import com.sksamuel.elastic4s.requests.searches.queries.QueryBuilderFn
+import com.sksamuel.elastic4s.{XContentBuilder, XContentFactory}
 
 object AliasActionBuilder {
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/mappings/dynamictemplate/DynamicTemplateApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/mappings/dynamictemplate/DynamicTemplateApi.scala
@@ -1,7 +1,6 @@
 package com.sksamuel.elastic4s.requests.mappings.dynamictemplate
 
 import com.sksamuel.elastic4s.ElasticApi
-import com.sksamuel.elastic4s.requests.mappings.FieldType._
 import com.sksamuel.elastic4s.requests.mappings._
 import com.sksamuel.elastic4s.requests.script.ScriptField
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/SearchBodyBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/SearchBodyBuilderFn.scala
@@ -1,12 +1,12 @@
 package com.sksamuel.elastic4s.requests.searches
 
-import com.sksamuel.elastic4s.{EnumConversions, XContentBuilder, XContentFactory}
 import com.sksamuel.elastic4s.requests.common.FetchSourceContextBuilderFn
 import com.sksamuel.elastic4s.requests.script.ScriptBuilderFn
 import com.sksamuel.elastic4s.requests.searches.aggs.AggregationBuilderFn
 import com.sksamuel.elastic4s.requests.searches.collapse.CollapseBuilderFn
 import com.sksamuel.elastic4s.requests.searches.queries.{QueryBuilderFn, SortBuilderFn}
 import com.sksamuel.elastic4s.requests.searches.suggestion.{CompletionSuggestion, CompletionSuggestionBuilderFn, PhraseSuggestion, PhraseSuggestionBuilderFn, TermSuggestion, TermSuggestionBuilderFn}
+import com.sksamuel.elastic4s.{EnumConversions, XContentBuilder, XContentFactory}
 
 object SearchBodyBuilderFn {
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggresponses.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggresponses.scala
@@ -1,7 +1,5 @@
 package com.sksamuel.elastic4s.requests.searches
 
-import java.util
-
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.sksamuel.elastic4s.requests.common.DocumentRef
 import com.sksamuel.elastic4s.{AggReader, JacksonSupport, SourceAsContentBuilder}

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/AggregationBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/AggregationBuilderFn.scala
@@ -1,8 +1,8 @@
 package com.sksamuel.elastic4s.requests.searches.aggs
 
-import com.sksamuel.elastic4s.{XContentBuilder, XContentFactory}
 import com.sksamuel.elastic4s.requests.searches.DateHistogramInterval
 import com.sksamuel.elastic4s.requests.searches.aggs.pipeline._
+import com.sksamuel.elastic4s.{XContentBuilder, XContentFactory}
 
 object AggregationBuilderFn {
   def apply(agg: AbstractAggregation): XContentBuilder = {

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/SigTermsAggregation.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/SigTermsAggregation.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.elastic4s.requests.searches.aggs
 
-import com.sksamuel.elastic4s.requests.searches.{IncludeExclude, IncludePartition}
 import com.sksamuel.elastic4s.requests.searches.queries.Query
+import com.sksamuel.elastic4s.requests.searches.{IncludeExclude, IncludePartition}
 import com.sksamuel.exts.OptionImplicits._
 
 case class SigTermsAggregation(name: String,

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/GaussianDecayScoreBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/GaussianDecayScoreBuilderFn.scala
@@ -2,11 +2,7 @@ package com.sksamuel.elastic4s.requests.searches.queries
 
 import com.sksamuel.elastic4s.requests.script.ScriptBuilderFn
 import com.sksamuel.elastic4s.requests.searches.queries.funcscorer._
-import com.sksamuel.elastic4s.{
-  EnumConversions,
-  XContentBuilder,
-  XContentFactory
-}
+import com.sksamuel.elastic4s.{EnumConversions, XContentBuilder, XContentFactory}
 
 object GaussianDecayScoreBuilderFn {
   def apply(g: GaussianDecayScore): XContentBuilder = {

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/InnerHit.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/InnerHit.scala
@@ -1,8 +1,8 @@
 package com.sksamuel.elastic4s.requests.searches.queries
 
 import com.sksamuel.elastic4s.requests.common.FetchSourceContext
-import com.sksamuel.elastic4s.requests.searches.{Highlight, HighlightField, HighlightOptions}
 import com.sksamuel.elastic4s.requests.searches.sort.Sort
+import com.sksamuel.elastic4s.requests.searches.{Highlight, HighlightField, HighlightOptions}
 import com.sksamuel.exts.OptionImplicits._
 
 case class InnerHit(name: String,

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/QueryBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/QueryBuilderFn.scala
@@ -1,6 +1,5 @@
 package com.sksamuel.elastic4s.requests.searches.queries
 
-import com.sksamuel.elastic4s.{XContentBuilder, XContentFactory}
 import com.sksamuel.elastic4s.requests.searches.RawQueryBodyFn
 import com.sksamuel.elastic4s.requests.searches.queries.compound.{BoolQueryBuilderFn, BoostingQueryBodyFn, ConstantScoreBodyFn, DisMaxQueryBodyFn}
 import com.sksamuel.elastic4s.requests.searches.queries.funcscorer.{FunctionScoreQuery, ScriptScore}
@@ -10,6 +9,7 @@ import com.sksamuel.elastic4s.requests.searches.queries.nested.{HasChildBodyFn, 
 import com.sksamuel.elastic4s.requests.searches.queries.span.{SpanContainingQuery, SpanContainingQueryBodyFn, SpanFirstQuery, SpanFirstQueryBodyFn, SpanMultiTermQuery, SpanMultiTermQueryBodyFn, SpanNearQuery, SpanNearQueryBodyFn, SpanNotQuery, SpanNotQueryBodyFn, SpanOrQuery, SpanOrQueryBodyFn, SpanTermQuery, SpanTermQueryBodyFn, SpanWithinQuery, SpanWithinQueryBodyFn}
 import com.sksamuel.elastic4s.requests.searches.queries.term.{ExistsQueryBodyFn, FuzzyQueryBodyFn, IdQueryBodyFn, PrefixQueryBodyFn, RangeQueryBodyFn, RegexQueryBodyFn, TermQuery, TermQueryBodyFn, TermsLookupQuery, TermsLookupQueryBodyFn, TermsQuery, TermsQueryBodyFn, TermsSetQuery, TermsSetQueryBodyFn, TypeQueryBodyFn, WildcardQueryBodyFn}
 import com.sksamuel.elastic4s.requests.searches.queries.text.{CommonTermsQueryBodyFn, MatchBoolPrefixBodyFn, MatchPhrasePrefixBodyFn, MatchPhraseQueryBodyFn, MatchQueryBuilderFn, MultiMatchBodyFn, QueryStringBodyFn, SimpleStringBodyFn}
+import com.sksamuel.elastic4s.{XContentBuilder, XContentFactory}
 
 object QueryBuilderFn {
   def apply(q: Query): XContentBuilder = q match {

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/funcscorer/ScoreApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/funcscorer/ScoreApi.scala
@@ -1,7 +1,6 @@
 package com.sksamuel.elastic4s.requests.searches.queries.funcscorer
 
 import com.sksamuel.elastic4s.requests.script.Script
-import com.sksamuel.elastic4s.requests.searches.queries.Query
 
 trait ScoreApi {
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/text/MatchBoolPrefixBodyFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/text/MatchBoolPrefixBodyFn.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.elastic4s.requests.searches.queries.text
 
-import com.sksamuel.elastic4s.requests.searches.queries.matches.{MatchBoolPrefix}
+import com.sksamuel.elastic4s.requests.searches.queries.matches.MatchBoolPrefix
 import com.sksamuel.elastic4s.{XContentBuilder, XContentFactory}
 
 object MatchBoolPrefixBodyFn {

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/responses.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/responses.scala
@@ -1,8 +1,5 @@
 package com.sksamuel.elastic4s.requests.searches
 
-import scala.reflect.ClassTag
-import scala.util.Try
-
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer
@@ -11,6 +8,9 @@ import com.sksamuel.elastic4s.requests.common.Shards
 import com.sksamuel.elastic4s.requests.explain.Explanation
 import com.sksamuel.elastic4s.requests.get.{HitField, MetaDataFields}
 import com.sksamuel.elastic4s.{Hit, HitReader, SourceAsContentBuilder}
+
+import scala.reflect.ClassTag
+import scala.util.Try
 
 case class SearchHit(@JsonProperty("_id") id: String,
                      @JsonProperty("_index") index: String,

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/security/roles/RoleHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/security/roles/RoleHandlers.scala
@@ -1,7 +1,8 @@
 package com.sksamuel.elastic4s.requests.security.roles
 
 import java.net.URLEncoder
-import com.sksamuel.elastic4s.{Handler, ElasticRequest, ResponseHandler}
+
+import com.sksamuel.elastic4s.{ElasticRequest, Handler}
 
 trait RoleHandlers {
 	private val ROLE_BASE_PATH = "/_security/role/"

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/security/roles/admin/RoleAdminHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/security/roles/admin/RoleAdminHandlers.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s.requests.security.roles.admin
 
 import java.net.URLEncoder
-import com.sksamuel.elastic4s.{Handler, ResponseHandler, HttpResponse, ElasticError, ElasticRequest, HttpEntity}
-import com.sksamuel.elastic4s.requests.security.roles.{CreateOrUpdateRoleRequest, CreateRole, UpdateRole, CreateRoleResponse, CreateOrUpdateRoleContentBuilder, DeleteRoleRequest}
+
+import com.sksamuel.elastic4s.requests.security.roles.{CreateOrUpdateRoleContentBuilder, CreateOrUpdateRoleRequest, CreateRole, CreateRoleResponse, DeleteRoleRequest, UpdateRole}
+import com.sksamuel.elastic4s.{ElasticError, ElasticRequest, Handler, HttpEntity, HttpResponse, ResponseHandler}
 
 trait RoleAdminHandlers {
 	private val ROLE_BASE_PATH = "/_security/role/"

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/security/users/UserHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/security/users/UserHandlers.scala
@@ -1,7 +1,8 @@
 package com.sksamuel.elastic4s.requests.security.users
 
 import java.net.URLEncoder
-import com.sksamuel.elastic4s.{Handler, ElasticRequest, ResponseHandler}
+
+import com.sksamuel.elastic4s.{ElasticRequest, Handler}
 
 trait UserHandlers {
 	private val ROLE_BASE_PATH = "/_security/user/"

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/security/users/admin/UserAdminHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/security/users/admin/UserAdminHandlers.scala
@@ -1,9 +1,9 @@
 package com.sksamuel.elastic4s.requests.security.users.admin
 
 import java.net.URLEncoder
-import com.sksamuel.elastic4s.{Handler, ResponseHandler, HttpResponse, ElasticError, ElasticRequest, HttpEntity}
-import com.sksamuel.elastic4s.requests.security.users.{CreateOrUpdateUserRequest, CreateUserResponse, CreateOrUpdateUserContentBuilder, CreateUser, UpdateUser}
-import com.sksamuel.elastic4s.requests.security.users.DeleteUserRequest
+
+import com.sksamuel.elastic4s.requests.security.users.{CreateOrUpdateUserContentBuilder, CreateOrUpdateUserRequest, CreateUser, CreateUserResponse, DeleteUserRequest, UpdateUser}
+import com.sksamuel.elastic4s.{ElasticError, ElasticRequest, Handler, HttpEntity, HttpResponse, ResponseHandler}
 
 trait UserAdminHandlers {
 	private val USER_BASE_PATH = "/_security/user/"

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/task/TaskApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/task/TaskApi.scala
@@ -1,7 +1,8 @@
 package com.sksamuel.elastic4s.requests.task
 
-import scala.concurrent.duration.FiniteDuration
 import com.sksamuel.exts.OptionImplicits._
+
+import scala.concurrent.duration.FiniteDuration
 
 trait TaskApi {
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateRequest.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateRequest.scala
@@ -2,7 +2,7 @@ package com.sksamuel.elastic4s.requests.update
 
 import com.sksamuel.elastic4s._
 import com.sksamuel.elastic4s.requests.bulk.BulkCompatibleRequest
-import com.sksamuel.elastic4s.requests.common.{FetchSourceContext, RefreshPolicy, VersionType}
+import com.sksamuel.elastic4s.requests.common.{FetchSourceContext, RefreshPolicy}
 import com.sksamuel.elastic4s.requests.script.Script
 import com.sksamuel.exts.OptionImplicits._
 

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/ElasticClientResponsesTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/ElasticClientResponsesTest.scala
@@ -1,6 +1,5 @@
 package com.sksamuel.elastic4s
 
-import com.sksamuel.elastic4s.{ElasticDsl, RequestFailure, RequestSuccess, Response}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/ElasticErrorTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/ElasticErrorTest.scala
@@ -1,10 +1,10 @@
 package com.sksamuel.elastic4s
 
 import com.sksamuel.elastic4s.HttpEntity.StringEntity
-
-import scala.io.Source
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.io.Source
 
 class ElasticErrorTest extends AnyFlatSpec with Matchers with ElasticDsl {
 

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/FieldsMapperTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/FieldsMapperTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s
 
-import scala.collection.JavaConverters._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+
+import scala.collection.JavaConverters._
 
 class FieldsMapperTest extends AnyFunSuite with Matchers {
 

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/JsonSugar.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/JsonSugar.scala
@@ -3,8 +3,8 @@ package com.sksamuel.elastic4s
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
-import org.scalatest.matchers.{MatchResult, Matcher}
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.matchers.{MatchResult, Matcher}
 
 trait JsonSugar extends Matchers {
 

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/bulk/BulkHandlersTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/bulk/BulkHandlersTest.scala
@@ -3,8 +3,8 @@ package com.sksamuel.elastic4s.requests.bulk
 import com.sksamuel.elastic4s.ElasticRequest
 import com.sksamuel.elastic4s.HttpEntity.StringEntity
 import com.sksamuel.elastic4s.requests.indexes.IndexRequest
-import org.scalatest.matchers.should.Matchers._
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers._
 
 class BulkHandlersTest extends AnyFlatSpec with BulkHandlers {
 

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/get/GetHandlerTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/get/GetHandlerTest.scala
@@ -3,8 +3,8 @@ package com.sksamuel.elastic4s.requests.get
 import com.sksamuel.elastic4s.HttpEntity.StringEntity
 import com.sksamuel.elastic4s.{ElasticError, HttpResponse}
 import org.scalatest.EitherValues
-import org.scalatest.matchers.should.Matchers._
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers._
 
 class GetHandlerTest extends AnyFlatSpec with GetHandlers with EitherValues {
 

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/DerivativeAggBuilderTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/DerivativeAggBuilderTest.scala
@@ -1,10 +1,10 @@
 package com.sksamuel.elastic4s.requests.searches
 
 import com.sksamuel.elastic4s.requests.searches.aggs.pipeline.GapPolicy
-
-import scala.concurrent.duration._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration._
 
 class DerivativeAggBuilderTest extends AnyFunSuite with Matchers {
 

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/collapse/CollapseBuilderFnTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/collapse/CollapseBuilderFnTest.scala
@@ -1,6 +1,5 @@
 package com.sksamuel.elastic4s.requests.searches.collapse
 
-import com.sksamuel.elastic4s.requests.searches.collapse.{CollapseBuilderFn, CollapseRequest}
 import com.sksamuel.elastic4s.requests.searches.queries.InnerHit
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/testutils/StringExtensionsTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/testutils/StringExtensionsTest.scala
@@ -1,8 +1,8 @@
 package com.sksamuel.elastic4s.testutils
 
 import com.sksamuel.elastic4s.testutils.StringExtensions.StringOps
-import org.scalatest.matchers.should.Matchers.convertToStringShouldWrapper
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers.convertToStringShouldWrapper
 
 class StringExtensionsTest extends AnyFlatSpec {
 

--- a/elastic4s-effect-cats/src/main/scala/com/sksamuel/elastic4s/cats/effect/instances/CatsEffectInstances.scala
+++ b/elastic4s-effect-cats/src/main/scala/com/sksamuel/elastic4s/cats/effect/instances/CatsEffectInstances.scala
@@ -1,9 +1,9 @@
 package com.sksamuel.elastic4s.cats.effect.instances
 
 import cats.effect.Async
-import cats.{Functor => CatsFunctor}
-import com.sksamuel.elastic4s.{Executor, Functor}
+import cats.{Functor ⇒ CatsFunctor}
 import com.sksamuel.elastic4s.cats.effect.CatsEffectExecutor
+import com.sksamuel.elastic4s.{Executor, Functor}
 
 trait CatsEffectInstances {
   implicit def catsFunctor[F[_]: CatsFunctor]: Functor[F] = new Functor[F] {

--- a/elastic4s-effect-monix/src/main/scala/com/sksamuel/elastic4s/monix/TaskExecutor.scala
+++ b/elastic4s-effect-monix/src/main/scala/com/sksamuel/elastic4s/monix/TaskExecutor.scala
@@ -2,7 +2,6 @@ package com.sksamuel.elastic4s.monix
 
 import com.sksamuel.elastic4s.{ElasticRequest, Executor, HttpClient, HttpResponse}
 import monix.eval.Task
-import monix.execution.Cancelable
 
 class TaskExecutor extends Executor[Task] {
   override def exec(client: HttpClient, request: ElasticRequest): Task[HttpResponse] =

--- a/elastic4s-effect-zio/src/test/scala/com/sksamuel/elastic4s/zio/ZIOTaskTest.scala
+++ b/elastic4s-effect-zio/src/test/scala/com/sksamuel/elastic4s/zio/ZIOTaskTest.scala
@@ -1,8 +1,8 @@
 package com.sksamuel.elastic4s.zio
 
 import com.sksamuel.elastic4s.testkit.DockerTests
+import com.sksamuel.elastic4s.zio.instances._
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
-import instances._
 import zio.{DefaultRuntime, Task}
 
 class ZIOTaskTest extends FlatSpec with Matchers with DockerTests with BeforeAndAfterAll {

--- a/elastic4s-http-streams/src/main/scala/com/sksamuel/elastic4s/streams/BulkIndexingSubscriber.scala
+++ b/elastic4s-http-streams/src/main/scala/com/sksamuel/elastic4s/streams/BulkIndexingSubscriber.scala
@@ -1,9 +1,9 @@
 package com.sksamuel.elastic4s.streams
 
 import akka.actor._
-import com.sksamuel.elastic4s.{ElasticClient, RequestFailure, RequestSuccess}
-import com.sksamuel.elastic4s.requests.bulk.{BulkCompatibleRequest, BulkRequest, BulkResponse, BulkResponseItem}
+import com.sksamuel.elastic4s.requests.bulk.{BulkCompatibleRequest, BulkRequest, BulkResponseItem}
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
+import com.sksamuel.elastic4s.{ElasticClient, RequestFailure, RequestSuccess}
 import org.reactivestreams.{Subscriber, Subscription}
 
 import scala.collection.mutable.ArrayBuffer

--- a/elastic4s-http-streams/src/main/scala/com/sksamuel/elastic4s/streams/ReactiveElastic.scala
+++ b/elastic4s-http-streams/src/main/scala/com/sksamuel/elastic4s/streams/ReactiveElastic.scala
@@ -1,8 +1,8 @@
 package com.sksamuel.elastic4s.streams
 
 import akka.actor.ActorRefFactory
-import com.sksamuel.elastic4s.{ElasticClient, IndexesAndTypes}
 import com.sksamuel.elastic4s.requests.searches.SearchRequest
+import com.sksamuel.elastic4s.{ElasticClient, IndexesAndTypes}
 
 import scala.concurrent.duration._
 import scala.language.implicitConversions

--- a/elastic4s-http-streams/src/main/scala/com/sksamuel/elastic4s/streams/ScrollPublisher.scala
+++ b/elastic4s-http-streams/src/main/scala/com/sksamuel/elastic4s/streams/ScrollPublisher.scala
@@ -1,9 +1,9 @@
 package com.sksamuel.elastic4s.streams
 
 import akka.actor.{Actor, ActorRefFactory, PoisonPill, Props, Stash}
-import com.sksamuel.elastic4s.{ElasticClient, RequestFailure, RequestSuccess}
 import com.sksamuel.elastic4s.requests.searches.{SearchHit, SearchRequest, SearchResponse}
 import com.sksamuel.elastic4s.streams.PublishActor.Ready
+import com.sksamuel.elastic4s.{ElasticClient, RequestFailure, RequestSuccess}
 import com.sksamuel.exts.Logging
 import com.sksamuel.exts.OptionImplicits._
 import org.reactivestreams.{Publisher, Subscriber, Subscription}

--- a/elastic4s-http-streams/src/test/scala/com/sksamuel/elastic4s/streams/ScrollPublisherVerificationTest.scala
+++ b/elastic4s-http-streams/src/test/scala/com/sksamuel/elastic4s/streams/ScrollPublisherVerificationTest.scala
@@ -6,9 +6,9 @@ import com.sksamuel.elastic4s.requests.searches.SearchHit
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.reactivestreams.Publisher
 import org.reactivestreams.tck.{PublisherVerification, TestEnvironment}
+import org.scalatestplus.testng.TestNGSuiteLike
 
 import scala.util.Try
-import org.scalatestplus.testng.TestNGSuiteLike
 
 class ScrollPublisherVerificationTest
   extends PublisherVerification[SearchHit](

--- a/elastic4s-testkit/src/main/scala/com/sksamuel/elastic4s/testkit/IndexMatchers.scala
+++ b/elastic4s-testkit/src/main/scala/com/sksamuel/elastic4s/testkit/IndexMatchers.scala
@@ -1,8 +1,8 @@
 package com.sksamuel.elastic4s.testkit
 
 import com.sksamuel.elastic4s.ElasticClient
-import org.scalatest.matchers.{MatchResult, Matcher}
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.matchers.{MatchResult, Matcher}
 
 trait IndexMatchers extends Matchers {
 

--- a/elastic4s-testkit/src/main/scala/com/sksamuel/elastic4s/testkit/SearchMatchers.scala
+++ b/elastic4s-testkit/src/main/scala/com/sksamuel/elastic4s/testkit/SearchMatchers.scala
@@ -2,11 +2,11 @@ package com.sksamuel.elastic4s.testkit
 
 import com.sksamuel.elastic4s.ElasticClient
 import com.sksamuel.elastic4s.requests.searches.SearchRequest
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.matchers.{MatchResult, Matcher}
 
 import scala.concurrent.duration._
 import scala.language.higherKinds
-import org.scalatest.matchers.should.Matchers
 
 trait SearchMatchers extends Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/JsonSugar.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/JsonSugar.scala
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
 import org.scalatest.Matchers
-import org.scalatest.matchers.{Matcher, MatchResult}
+import org.scalatest.matchers.{MatchResult, Matcher}
 
 trait JsonSugar extends Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/cat/CatIndicesTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/cat/CatIndicesTest.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.elastic4s.cat
 
-import com.sksamuel.elastic4s.testkit.DockerTests
 import com.sksamuel.elastic4s.requests.common.{HealthStatus, RefreshPolicy}
+import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.{FlatSpec, Matchers}
 
 class CatIndicesTest extends FlatSpec with Matchers with DockerTests {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/cluster/ClusterInfoTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/cluster/ClusterInfoTest.scala
@@ -1,8 +1,8 @@
 package com.sksamuel.elastic4s.requests.cluster
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
 import org.scalatest.PartialFunctionValues._
+import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
 
 class ClusterInfoTest extends WordSpec with Matchers with DockerTests with BeforeAndAfterAll {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/MappingDefinitionDslTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/MappingDefinitionDslTest.scala
@@ -1,8 +1,8 @@
 package com.sksamuel.elastic4s.requests.mappings
 
-import com.sksamuel.elastic4s.{ElasticApi, JsonSugar}
 import com.sksamuel.elastic4s.requests.analyzers.{EnglishLanguageAnalyzer, SpanishLanguageAnalyzer}
 import com.sksamuel.elastic4s.requests.indexes.CreateIndexContentBuilder
+import com.sksamuel.elastic4s.{ElasticApi, JsonSugar}
 import org.scalatest.{Matchers, WordSpec}
 
 class MappingDefinitionDslTest extends WordSpec with Matchers with JsonSugar with ElasticApi {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/roles/ClearRolesCacheTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/roles/ClearRolesCacheTest.scala
@@ -1,6 +1,5 @@
 package com.sksamuel.elastic4s.requests.security.roles
 
-import com.sksamuel.elastic4s.ElasticDsl
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.{Matchers, WordSpec}
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/roles/CreateRoleTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/roles/CreateRoleTest.scala
@@ -2,10 +2,11 @@ package com.sksamuel.elastic4s.requests.security.roles
 
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.{Matchers, WordSpec}
+
 import scala.util.Try
 
 class CreateRoleTest extends WordSpec with Matchers with DockerTests {
-	
+
 	Try {
 		client.execute {
 			deleteRole("role1")

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/roles/DeleteRoleTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/roles/DeleteRoleTest.scala
@@ -1,6 +1,5 @@
 package com.sksamuel.elastic4s.requests.security.roles
 
-import com.sksamuel.elastic4s.ElasticDsl
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.{Matchers, WordSpec}
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/roles/GetRoleTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/roles/GetRoleTest.scala
@@ -2,6 +2,7 @@ package com.sksamuel.elastic4s.requests.security.roles
 
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.{Matchers, WordSpec}
+
 import scala.util.Try
 
 class GetRoleTest extends WordSpec with Matchers with DockerTests {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/roles/UpdateRoleTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/roles/UpdateRoleTest.scala
@@ -2,10 +2,11 @@ package com.sksamuel.elastic4s.requests.security.roles
 
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.{Matchers, WordSpec}
+
 import scala.util.Try
 
 class UpdateRoleTest extends WordSpec with Matchers with DockerTests {
-	
+
 	Try {
 		client.execute {
 			deleteRole("role1")

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/ChangePasswordTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/ChangePasswordTest.scala
@@ -1,8 +1,8 @@
 package com.sksamuel.elastic4s.requests.security.users
 
-import com.sksamuel.elastic4s.ElasticDsl
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.{Matchers, WordSpec}
+
 import scala.util.Try
 
 class ChangeUserPasswordTest extends WordSpec with Matchers with DockerTests {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/CreateUserTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/CreateUserTest.scala
@@ -2,10 +2,11 @@ package com.sksamuel.elastic4s.requests.security.users
 
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.{Matchers, WordSpec}
+
 import scala.util.Try
 
 class CreateUserTest extends WordSpec with Matchers with DockerTests {
-	
+
 	Try {
 		client.execute {
 			deleteUser("user1")

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/DeleteUserTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/DeleteUserTest.scala
@@ -1,6 +1,5 @@
 package com.sksamuel.elastic4s.requests.security.users
 
-import com.sksamuel.elastic4s.ElasticDsl
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.{Matchers, WordSpec}
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/DisableUserTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/DisableUserTest.scala
@@ -1,8 +1,8 @@
 package com.sksamuel.elastic4s.requests.security.users
 
-import com.sksamuel.elastic4s.ElasticDsl
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.{Matchers, WordSpec}
+
 import scala.util.Try
 
 class DisableUserTest extends WordSpec with Matchers with DockerTests {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/EnableUserTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/EnableUserTest.scala
@@ -1,8 +1,8 @@
 package com.sksamuel.elastic4s.requests.security.users
 
-import com.sksamuel.elastic4s.ElasticDsl
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.{Matchers, WordSpec}
+
 import scala.util.Try
 
 class EnnableUserTest extends WordSpec with Matchers with DockerTests {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/GetUserTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/GetUserTest.scala
@@ -2,6 +2,7 @@ package com.sksamuel.elastic4s.requests.security.users
 
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.{Matchers, WordSpec}
+
 import scala.util.Try
 
 class GetUserTest extends WordSpec with Matchers with DockerTests {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/InnerHitTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/InnerHitTest.scala
@@ -1,8 +1,8 @@
 package com.sksamuel.elastic4s.search
 
 import com.sksamuel.elastic4s.requests.mappings.Child
-import com.sksamuel.elastic4s.requests.searches.{InnerHits, Total}
 import com.sksamuel.elastic4s.requests.searches.queries.InnerHit
+import com.sksamuel.elastic4s.requests.searches.{InnerHits, Total}
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.{Matchers, WordSpec}
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
@@ -7,7 +7,7 @@ import com.sksamuel.elastic4s.requests.searches._
 import com.sksamuel.elastic4s.requests.searches.aggs.{SubAggCollectionMode, TermsOrder}
 import com.sksamuel.elastic4s.requests.searches.queries.funcscorer.MultiValueMode
 import com.sksamuel.elastic4s.requests.searches.queries.geo.GeoDistance
-import com.sksamuel.elastic4s.requests.searches.queries.matches.{MatchAllQuery, MultiMatchQueryBuilderType, ZeroTermsQuery}
+import com.sksamuel.elastic4s.requests.searches.queries.matches.{MultiMatchQueryBuilderType, ZeroTermsQuery}
 import com.sksamuel.elastic4s.requests.searches.queries.{RegexpFlag, SimpleQueryStringFlag}
 import com.sksamuel.elastic4s.requests.searches.sort.{SortMode, SortOrder}
 import com.sksamuel.elastic4s.requests.searches.suggestion.{DirectGenerator, Fuzziness, SuggestMode}

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchTest.scala
@@ -1,11 +1,11 @@
 package com.sksamuel.elastic4s.search
 
-import com.sksamuel.elastic4s.{ElasticDsl, HitReader}
 import com.sksamuel.elastic4s.jackson.ElasticJackson
 import com.sksamuel.elastic4s.requests.admin.IndicesOptionsRequest
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.queries.matches.MultiMatchQueryBuilderType.CROSS_FIELDS
 import com.sksamuel.elastic4s.testkit.DockerTests
+import com.sksamuel.elastic4s.{ElasticDsl, HitReader}
 import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/CommonTermsQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/CommonTermsQueryTest.scala
@@ -1,8 +1,8 @@
 package com.sksamuel.elastic4s.search.queries
 
 import com.sksamuel.elastic4s.requests.common.Preference
-import com.sksamuel.elastic4s.{ElasticDsl, Indexable}
 import com.sksamuel.elastic4s.testkit.DockerTests
+import com.sksamuel.elastic4s.{ElasticDsl, Indexable}
 import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/TermsLookupQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/TermsLookupQueryTest.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.elastic4s.search.queries
 
-import com.sksamuel.elastic4s.testkit.DockerTests
 import com.sksamuel.elastic4s.requests.common.{DocumentRef, RefreshPolicy}
+import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.{FlatSpec, Matchers}
 
 class TermsLookupQueryTest

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/TermsSetQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/TermsSetQueryTest.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.elastic4s.search.queries
 
+import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import com.sksamuel.elastic4s.requests.common.{DocumentRef, RefreshPolicy}
 import org.scalatest.{FlatSpec, Matchers}
 
 class TermsSetQueryTest
@@ -32,7 +32,7 @@ class TermsSetQueryTest
     }.await.result
     resp.hits.hits.map(_.sourceAsString).toSet shouldBe Set("""{"names":["nelson","edmure","john"],"required_matches":2}""")
   }
-  
+
   // Test: Satisfying the requirements only one 'minimum should match' field (second one)
   "a terms set query with minimum shoud match field" should "return any documents that match at least one term" in {
     val resp = client.execute {
@@ -57,12 +57,12 @@ class TermsSetQueryTest
     }.await.result
     resp.hits.hits.map(_.sourceAsString).toSet shouldBe Set("""{"names":["nelson","edmure","john"],"required_matches":2}""")
   }
-  
+
   // Test: Satisfying the requirements of the 'minimum should match' script for both documents
   "a terms set query with minimum shoud match script" should "return any documents that match at least one or more terms" in {
     val resp = client.execute {
       search("randompeople") query termsSetQuery("names", Set("nelson","edmure","byron","pete"), script("Math.min(params.num_terms,doc['required_matches'].value)"))
     }.await.result
     resp.hits.hits.map(_.sourceAsString).toSet shouldBe Set("""{"names":["nelson","edmure","john"],"required_matches":2}""", """{"names":["umber","rudolfus","byron"],"required_matches":1}""")
-  }  
-} 
+  }
+}

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/suggestions/TermSuggestionsTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/suggestions/TermSuggestionsTest.scala
@@ -1,9 +1,9 @@
 package com.sksamuel.elastic4s.search.suggestions
 
-import com.sksamuel.elastic4s.requests.searches.suggestion.SuggestMode
-import com.sksamuel.elastic4s.testkit.DockerTests
 import com.sksamuel.elastic4s.Indexable
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
+import com.sksamuel.elastic4s.requests.searches.suggestion.SuggestMode
+import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try


### PR DESCRIPTION
There are a large number of unused import warnings, this PR resolves all of them. This was done using IntelliJ's Optimize Imports, which also reorders imports. No specific imports were collapsed into `_`.

Draft PR for now, as this contains the build fixes in https://github.com/sksamuel/elastic4s/pull/2024 