### PR TITLE
Fix test warnings caused by upgrade to ScalaTest 3.1

### DIFF
--- a/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientMockTest.scala
+++ b/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientMockTest.scala
@@ -6,13 +6,15 @@ import com.sksamuel.elastic4s.{ElasticRequest, HttpEntity ⇒ ElasticEntity, Htt
 import org.scalamock.function.MockFunction1
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.concurrent._
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 class AkkaHttpClientMockTest
-  extends WordSpec
+  extends AnyWordSpec
     with Matchers
     with MockFactory
     with ScalaFutures

--- a/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientMockTest.scala
+++ b/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientMockTest.scala
@@ -5,13 +5,13 @@ import akka.http.scaladsl.model.{HttpRequest, HttpResponse, StatusCodes, Uri}
 import com.sksamuel.elastic4s.{ElasticRequest, HttpEntity ⇒ ElasticEntity, HttpResponse ⇒ ElasticResponse}
 import org.scalamock.function.MockFunction1
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.concurrent._
 import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
 
 class AkkaHttpClientMockTest
   extends AnyWordSpec

--- a/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientTest.scala
+++ b/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientTest.scala
@@ -4,11 +4,13 @@ import akka.actor.ActorSystem
 import com.sksamuel.elastic4s.ElasticClient
 import com.sksamuel.elastic4s.requests.common.HealthStatus
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.util.Try
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class AkkaHttpClientTest extends FlatSpec with Matchers with DockerTests with BeforeAndAfterAll {
+class AkkaHttpClientTest extends AnyFlatSpec with Matchers with DockerTests with BeforeAndAfterAll {
 
   private implicit lazy val system: ActorSystem = ActorSystem()
 

--- a/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientTest.scala
+++ b/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientTest.scala
@@ -5,10 +5,10 @@ import com.sksamuel.elastic4s.ElasticClient
 import com.sksamuel.elastic4s.requests.common.HealthStatus
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.BeforeAndAfterAll
-
-import scala.util.Try
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class AkkaHttpClientTest extends AnyFlatSpec with Matchers with DockerTests with BeforeAndAfterAll {
 

--- a/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/DefaultBlacklistTest.scala
+++ b/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/DefaultBlacklistTest.scala
@@ -1,11 +1,12 @@
 package com.sksamuel.elastic4s.akka
 
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.concurrent.duration._
 import scala.language.postfixOps
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class DefaultBlacklistTest extends WordSpec with Matchers {
+class DefaultBlacklistTest extends AnyWordSpec with Matchers {
 
   val minDuration = 1 second
   val maxDuration = 10 seconds

--- a/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/DefaultBlacklistTest.scala
+++ b/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/DefaultBlacklistTest.scala
@@ -1,10 +1,11 @@
 package com.sksamuel.elastic4s.akka
 
 
-import scala.concurrent.duration._
-import scala.language.postfixOps
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.concurrent.duration._
+import scala.language.postfixOps
 
 class DefaultBlacklistTest extends AnyWordSpec with Matchers {
 

--- a/elastic4s-effect-zio/src/test/scala/com/sksamuel/elastic4s/zio/ZIOTaskTest.scala
+++ b/elastic4s-effect-zio/src/test/scala/com/sksamuel/elastic4s/zio/ZIOTaskTest.scala
@@ -2,10 +2,12 @@ package com.sksamuel.elastic4s.zio
 
 import com.sksamuel.elastic4s.testkit.DockerTests
 import com.sksamuel.elastic4s.zio.instances._
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
 import zio.{DefaultRuntime, Task}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ZIOTaskTest extends FlatSpec with Matchers with DockerTests with BeforeAndAfterAll {
+class ZIOTaskTest extends AnyFlatSpec with Matchers with DockerTests with BeforeAndAfterAll {
 
   implicit class RichZIO[A](zio: Task[A]) {
     def unsafeRun: Either[Throwable, A] =

--- a/elastic4s-effect-zio/src/test/scala/com/sksamuel/elastic4s/zio/ZIOTaskTest.scala
+++ b/elastic4s-effect-zio/src/test/scala/com/sksamuel/elastic4s/zio/ZIOTaskTest.scala
@@ -3,9 +3,9 @@ package com.sksamuel.elastic4s.zio
 import com.sksamuel.elastic4s.testkit.DockerTests
 import com.sksamuel.elastic4s.zio.instances._
 import org.scalatest.BeforeAndAfterAll
-import zio.{DefaultRuntime, Task}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import zio.{DefaultRuntime, Task}
 
 class ZIOTaskTest extends AnyFlatSpec with Matchers with DockerTests with BeforeAndAfterAll {
 

--- a/elastic4s-http-streams/src/test/scala/com/sksamuel/elastic4s/streams/ScrollPublisherIntegrationTest.scala
+++ b/elastic4s-http-streams/src/test/scala/com/sksamuel/elastic4s/streams/ScrollPublisherIntegrationTest.scala
@@ -7,10 +7,10 @@ import com.sksamuel.elastic4s.requests.indexes.IndexRequest
 import com.sksamuel.elastic4s.requests.searches.SearchHit
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.reactivestreams.{Subscriber, Subscription}
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class ScrollPublisherIntegrationTest extends AnyWordSpec with DockerTests with Matchers  {
 

--- a/elastic4s-http-streams/src/test/scala/com/sksamuel/elastic4s/streams/ScrollPublisherIntegrationTest.scala
+++ b/elastic4s-http-streams/src/test/scala/com/sksamuel/elastic4s/streams/ScrollPublisherIntegrationTest.scala
@@ -7,11 +7,12 @@ import com.sksamuel.elastic4s.requests.indexes.IndexRequest
 import com.sksamuel.elastic4s.requests.searches.SearchHit
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.reactivestreams.{Subscriber, Subscription}
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ScrollPublisherIntegrationTest extends WordSpec with DockerTests with Matchers  {
+class ScrollPublisherIntegrationTest extends AnyWordSpec with DockerTests with Matchers  {
 
   import ReactiveElastic._
   import com.sksamuel.elastic4s.jackson.ElasticJackson.Implicits._

--- a/elastic4s-http-streams/src/test/scala/com/sksamuel/elastic4s/streams/ScrollPublisherUnitTest.scala
+++ b/elastic4s-http-streams/src/test/scala/com/sksamuel/elastic4s/streams/ScrollPublisherUnitTest.scala
@@ -2,9 +2,10 @@ package com.sksamuel.elastic4s.streams
 
 import akka.actor.ActorSystem
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ScrollPublisherUnitTest extends WordSpec with Matchers with DockerTests {
+class ScrollPublisherUnitTest extends AnyWordSpec with Matchers with DockerTests {
 
   import ReactiveElastic._
 

--- a/elastic4s-http-streams/src/test/scala/com/sksamuel/elastic4s/streams/SubscriberListenerTest.scala
+++ b/elastic4s-http-streams/src/test/scala/com/sksamuel/elastic4s/streams/SubscriberListenerTest.scala
@@ -5,10 +5,10 @@ import java.util.concurrent.{CountDownLatch, TimeUnit}
 import akka.actor.ActorSystem
 import com.sksamuel.elastic4s.requests.bulk.BulkResponseItem
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class SubscriberListenerTest extends AnyWordSpec with Matchers with DockerTests {
 

--- a/elastic4s-http-streams/src/test/scala/com/sksamuel/elastic4s/streams/SubscriberListenerTest.scala
+++ b/elastic4s-http-streams/src/test/scala/com/sksamuel/elastic4s/streams/SubscriberListenerTest.scala
@@ -5,11 +5,12 @@ import java.util.concurrent.{CountDownLatch, TimeUnit}
 import akka.actor.ActorSystem
 import com.sksamuel.elastic4s.requests.bulk.BulkResponseItem
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class SubscriberListenerTest extends WordSpec with Matchers with DockerTests {
+class SubscriberListenerTest extends AnyWordSpec with Matchers with DockerTests {
 
   import ReactiveElastic._
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/ElasticPropertiesTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/ElasticPropertiesTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ElasticPropertiesTest extends FlatSpec with Matchers {
+class ElasticPropertiesTest extends AnyFlatSpec with Matchers {
 
   "elasticsearch properties" should "parse multiple host/ports" in {
     ElasticProperties("http://host1:1234,host2:2345") shouldBe

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/ElasticsearchClientUriTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/ElasticsearchClientUriTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ElasticsearchClientUriTest extends FlatSpec with Matchers {
+class ElasticsearchClientUriTest extends AnyFlatSpec with Matchers {
 
   private def testString(connectionString: String,
                          hosts: List[(String, Int)],

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/HitReaderTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/HitReaderTest.scala
@@ -6,12 +6,13 @@ import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.indexes.IndexRequest
 import com.sksamuel.elastic4s.testkit.DockerTests
 import com.sksamuel.exts.OptionImplicits._
-import org.scalatest.{FlatSpec, Matchers}
 import org.scalatestplus.mockito.MockitoSugar
 
 import scala.util.{Success, Try}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class HitReaderTest extends FlatSpec with MockitoSugar with DockerTests with Matchers {
+class HitReaderTest extends AnyFlatSpec with MockitoSugar with DockerTests with Matchers {
 
   private val IndexName = "football"
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/HitReaderTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/HitReaderTest.scala
@@ -6,11 +6,11 @@ import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.indexes.IndexRequest
 import com.sksamuel.elastic4s.testkit.DockerTests
 import com.sksamuel.exts.OptionImplicits._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 
 import scala.util.{Success, Try}
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
 
 class HitReaderTest extends AnyFlatSpec with MockitoSugar with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/IndexAndTypesTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/IndexAndTypesTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class IndexAndTypesTest extends WordSpec with Matchers {
+class IndexAndTypesTest extends AnyWordSpec with Matchers {
 
   "IndexAndTypes" should {
     "parse /" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/JsonSugar.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/JsonSugar.scala
@@ -3,8 +3,8 @@ package com.sksamuel.elastic4s
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
-import org.scalatest.Matchers
 import org.scalatest.matchers.{MatchResult, Matcher}
+import org.scalatest.matchers.should.Matchers
 
 trait JsonSugar extends Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/JsonSugar.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/JsonSugar.scala
@@ -3,8 +3,8 @@ package com.sksamuel.elastic4s
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
-import org.scalatest.matchers.{MatchResult, Matcher}
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.matchers.{MatchResult, Matcher}
 
 trait JsonSugar extends Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/TermVectorTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/TermVectorTest.scala
@@ -3,10 +3,11 @@ package com.sksamuel.elastic4s
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.SpanSugar._
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 class TermVectorTest
-  extends WordSpec
+  extends AnyWordSpec
     with DockerTests
     with Matchers
     with ScalaFutures {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/TermVectorTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/TermVectorTest.scala
@@ -2,8 +2,8 @@ package com.sksamuel.elastic4s
 
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.SpanSugar._
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.SpanSugar._
 import org.scalatest.wordspec.AnyWordSpec
 
 class TermVectorTest

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/cat/CatAliasTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/cat/CatAliasTest.scala
@@ -2,9 +2,10 @@ package com.sksamuel.elastic4s.cat
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class CatAliasTest extends FlatSpec with Matchers with DockerTests {
+class CatAliasTest extends AnyFlatSpec with Matchers with DockerTests {
 
   client.execute {
     indexInto("catalias").fields("name" -> "hampton court palace").refresh(RefreshPolicy.Immediate)

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/cat/CatAllocationTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/cat/CatAllocationTest.scala
@@ -2,9 +2,10 @@ package com.sksamuel.elastic4s.cat
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class CatAllocationTest extends FlatSpec with Matchers with DockerTests {
+class CatAllocationTest extends AnyFlatSpec with Matchers with DockerTests {
 
   client.execute {
     bulk(

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/cat/CatCountTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/cat/CatCountTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.cat
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FlatSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class CatCountTest extends FlatSpec with Matchers with DockerTests {
+class CatCountTest extends AnyFlatSpec with Matchers with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/cat/CatCountTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/cat/CatCountTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.cat
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class CatCountTest extends AnyFlatSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/cat/CatIndicesTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/cat/CatIndicesTest.scala
@@ -2,9 +2,10 @@ package com.sksamuel.elastic4s.cat
 
 import com.sksamuel.elastic4s.requests.common.{HealthStatus, RefreshPolicy}
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class CatIndicesTest extends FlatSpec with Matchers with DockerTests {
+class CatIndicesTest extends AnyFlatSpec with Matchers with DockerTests {
 
   client.execute {
     bulk(

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/cat/CatMasterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/cat/CatMasterTest.scala
@@ -2,9 +2,10 @@ package com.sksamuel.elastic4s.cat
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class CatMasterTest extends FlatSpec with Matchers with DockerTests {
+class CatMasterTest extends AnyFlatSpec with Matchers with DockerTests {
 
   client.execute {
     bulk(

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/cat/CatNodesTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/cat/CatNodesTest.scala
@@ -2,9 +2,10 @@ package com.sksamuel.elastic4s.cat
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class CatNodesTest extends FlatSpec with Matchers with DockerTests {
+class CatNodesTest extends AnyFlatSpec with Matchers with DockerTests {
 
   client.execute {
     bulk(

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/cat/CatSegmentsTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/cat/CatSegmentsTest.scala
@@ -2,10 +2,12 @@ package com.sksamuel.elastic4s.cat
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FlatSpec, Inspectors, Matchers}
+import org.scalatest.Inspectors
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class CatSegmentsTest
-  extends FlatSpec
+  extends AnyFlatSpec
     with Matchers
     with DockerTests
     with Inspectors {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/http/ElasticClientTests.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/http/ElasticClientTests.scala
@@ -1,10 +1,10 @@
 package com.sksamuel.elastic4s.http
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class ElasticClientTests extends AnyFlatSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/http/ElasticClientTests.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/http/ElasticClientTests.scala
@@ -1,11 +1,12 @@
 package com.sksamuel.elastic4s.http
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FlatSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ElasticClientTests extends FlatSpec with Matchers with DockerTests {
+class ElasticClientTests extends AnyFlatSpec with Matchers with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/jackson/ElasticJacksonIndexableTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/jackson/ElasticJacksonIndexableTest.scala
@@ -6,10 +6,10 @@ import com.fasterxml.jackson.databind.{DeserializationContext, JsonDeserializer,
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Success
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Success
 
 class ElasticJacksonIndexableTest extends AnyWordSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/jackson/ElasticJacksonIndexableTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/jackson/ElasticJacksonIndexableTest.scala
@@ -6,11 +6,12 @@ import com.fasterxml.jackson.databind.{DeserializationContext, JsonDeserializer,
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Success
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ElasticJacksonIndexableTest extends WordSpec with Matchers with DockerTests {
+class ElasticJacksonIndexableTest extends AnyWordSpec with Matchers with DockerTests {
 
   import ElasticJackson.Implicits._
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/json/XContentBuilderTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/json/XContentBuilderTest.scala
@@ -3,9 +3,10 @@ package com.sksamuel.elastic4s.json
 import java.math.BigInteger
 
 import com.sksamuel.elastic4s.XContentFactory
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class XContentBuilderTest extends FunSuite with Matchers {
+class XContentBuilderTest extends AnyFunSuite with Matchers {
 
   test("simple object") {
     XContentFactory.obj().field("test", true).field("name", "foo").string() shouldBe

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/admin/GetSegmentTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/admin/GetSegmentTest.scala
@@ -2,9 +2,10 @@ package com.sksamuel.elastic4s.requests.admin
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class GetSegmentTest extends FlatSpec with Matchers with DockerTests {
+class GetSegmentTest extends AnyFlatSpec with Matchers with DockerTests {
 
   client.execute {
     bulk(

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/admin/IndexTemplateHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/admin/IndexTemplateHttpTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.requests.admin
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 class IndexTemplateHttpTest
-  extends WordSpec
+  extends AnyWordSpec
     with MockitoSugar
     with Matchers
     with DockerTests {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/admin/IndexTemplateHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/admin/IndexTemplateHttpTest.scala
@@ -2,9 +2,9 @@ package com.sksamuel.elastic4s.requests.admin
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.mockito.MockitoSugar
 
 class IndexTemplateHttpTest
   extends AnyWordSpec

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/aliases/AliasesHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/aliases/AliasesHttpTest.scala
@@ -4,10 +4,10 @@ import com.sksamuel.elastic4s.Index
 import com.sksamuel.elastic4s.requests.indexes.admin.{AliasActionResponse, AliasExistsResponse}
 import com.sksamuel.elastic4s.requests.indexes.alias.{Alias, IndexAliases}
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class AliasesHttpTest extends AnyWordSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/aliases/AliasesHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/aliases/AliasesHttpTest.scala
@@ -4,11 +4,12 @@ import com.sksamuel.elastic4s.Index
 import com.sksamuel.elastic4s.requests.indexes.admin.{AliasActionResponse, AliasExistsResponse}
 import com.sksamuel.elastic4s.requests.indexes.alias.{Alias, IndexAliases}
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class AliasesHttpTest extends WordSpec with Matchers with DockerTests {
+class AliasesHttpTest extends AnyWordSpec with Matchers with DockerTests {
 
   removeIndex("beaches")
   removeIndex("mountains")

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/aliases/GetAliasesTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/aliases/GetAliasesTest.scala
@@ -4,9 +4,10 @@ import com.sksamuel.elastic4s.Index
 import com.sksamuel.elastic4s.requests.indexes.alias
 import com.sksamuel.elastic4s.requests.indexes.alias.Alias
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FunSuite, Matchers}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class GetAliasesTest extends FunSuite with Matchers with DockerTests {
+class GetAliasesTest extends AnyFunSuite with Matchers with DockerTests {
 
   test("get all aliases") {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/CommonGramsTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/CommonGramsTokenFilterTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s.requests.analyzers
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class CommonGramsTokenFilterTest extends WordSpec with TokenFilterApi with Matchers {
+class CommonGramsTokenFilterTest extends AnyWordSpec with TokenFilterApi with Matchers {
 
   "CommonGramsTokenFilter builder" should {
     "not set any defaults" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/CompoundWordTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/CompoundWordTokenFilterTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s.requests.analyzers
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class CompoundWordTokenFilterTest extends WordSpec with TokenFilterApi with Matchers {
+class CompoundWordTokenFilterTest extends AnyWordSpec with TokenFilterApi with Matchers {
 
   "CompoundWordTokenFilter builder" should {
     "set type" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/CustomAnalyzerDefinitionTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/CustomAnalyzerDefinitionTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s.requests.analyzers
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class CustomAnalyzerDefinitionTest extends FlatSpec with Matchers {
+class CustomAnalyzerDefinitionTest extends AnyFlatSpec with Matchers {
 
   "CustomAnalyzerDefinition" should "build correct json" in {
     CustomAnalyzerDefinition("mycustom", KeywordTokenizer, KStemTokenFilter, ApostropheTokenFilter)

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/CustomAnalyzerTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/CustomAnalyzerTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s.requests.analyzers
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class CustomAnalyzerTest extends FlatSpec with Matchers {
+class CustomAnalyzerTest extends AnyFlatSpec with Matchers {
 
   "CustomAnalyzer" should "support predefined tokenizers and filters" in {
     CustomAnalyzerDefinition(

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/CustomNormalizerTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/CustomNormalizerTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s.requests.analyzers
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class CustomNormalizerTest extends FlatSpec with Matchers {
+class CustomNormalizerTest extends AnyFlatSpec with Matchers {
 
   "CustomNormalizer" should "support predefined filters" in {
     CustomNormalizerDefinition(

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/EdgeNGramTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/EdgeNGramTokenFilterTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s.requests.analyzers
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class EdgeNGramTokenFilterTest extends WordSpec with TokenFilterApi with Matchers {
+class EdgeNGramTokenFilterTest extends AnyWordSpec with TokenFilterApi with Matchers {
 
   "EdgeNGramTokenFilter builder" should {
     "not set any defaults" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/EdgeNGramTokenizerTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/EdgeNGramTokenizerTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s.requests.analyzers
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class EdgeNGramTokenizerTest extends WordSpec with TokenizerApi with Matchers {
+class EdgeNGramTokenizerTest extends AnyWordSpec with TokenizerApi with Matchers {
 
   "EdgeNGramTokenizer builder" should {
     "set min and max ngrams" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/ElisionTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/ElisionTokenFilterTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s.requests.analyzers
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ElisionTokenFilterTest extends WordSpec with TokenFilterApi with Matchers {
+class ElisionTokenFilterTest extends AnyWordSpec with TokenFilterApi with Matchers {
 
   "ElisionTokenFilter builder" should {
     "set articles" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/KeywordMarkerTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/KeywordMarkerTokenFilterTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s.requests.analyzers
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class KeywordMarkerTokenFilterTest extends WordSpec with TokenFilterApi with Matchers {
+class KeywordMarkerTokenFilterTest extends AnyWordSpec with TokenFilterApi with Matchers {
 
   "KeywordMarkerTokenFilter builder" should {
     "not set any defaults" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/KeywordTokenizerTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/KeywordTokenizerTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s.requests.analyzers
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class KeywordTokenizerTest extends WordSpec with TokenizerApi with Matchers {
+class KeywordTokenizerTest extends AnyWordSpec with TokenizerApi with Matchers {
 
   "KeywordTokenizer builder" should {
     "set buffer size" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/LengthTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/LengthTokenFilterTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s.requests.analyzers
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class LengthTokenFilterTest extends WordSpec with TokenFilterApi with Matchers {
+class LengthTokenFilterTest extends AnyWordSpec with TokenFilterApi with Matchers {
 
   "LengthTokenFilter builder" should {
     "not set defaults" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/LimitTokenCountTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/LimitTokenCountTokenFilterTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s.requests.analyzers
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class LimitTokenCountTokenFilterTest extends WordSpec with TokenFilterApi with Matchers {
+class LimitTokenCountTokenFilterTest extends AnyWordSpec with TokenFilterApi with Matchers {
 
   "LimitTokenCountTokenFilter builder" should {
     "not set any defaults" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/NGramTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/NGramTokenFilterTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s.requests.analyzers
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class NGramTokenFilterTest extends WordSpec with TokenFilterApi with Matchers {
+class NGramTokenFilterTest extends AnyWordSpec with TokenFilterApi with Matchers {
 
   "NGramTokenFilter builder" should {
     "not set any defaults" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/NGramTokenizerTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/NGramTokenizerTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s.requests.analyzers
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class NGramTokenizerTest extends WordSpec with TokenizerApi with Matchers {
+class NGramTokenizerTest extends AnyWordSpec with TokenizerApi with Matchers {
 
   "NGramTokenizer builder" should {
     "set min and max ngrams" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/PatternAnalyzerTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/PatternAnalyzerTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s.requests.analyzers
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class PatternAnalyzerTest extends WordSpec with AnalyzerApi with Matchers {
+class PatternAnalyzerTest extends AnyWordSpec with AnalyzerApi with Matchers {
 
   "PatternAnalyzer builder" should {
     "set language" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/PatternCaptureTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/PatternCaptureTokenFilterTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s.requests.analyzers
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class PatternCaptureTokenFilterTest extends WordSpec with TokenFilterApi with Matchers {
+class PatternCaptureTokenFilterTest extends AnyWordSpec with TokenFilterApi with Matchers {
 
   "PatternAnalyzer builder" should {
     "set patterns" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/PatternTokenizerTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/PatternTokenizerTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s.requests.analyzers
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class PatternTokenizerTest extends WordSpec with TokenizerApi with Matchers {
+class PatternTokenizerTest extends AnyWordSpec with TokenizerApi with Matchers {
 
   "PatternTokenizer builder" should {
     "set flags" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/ShingleTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/ShingleTokenFilterTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s.requests.analyzers
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ShingleTokenFilterTest extends WordSpec with TokenFilterApi with Matchers {
+class ShingleTokenFilterTest extends AnyWordSpec with TokenFilterApi with Matchers {
 
   "ShingleTokenFilter builder" should {
     "not set any defaults" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/SnowballAnalyzerTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/SnowballAnalyzerTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s.requests.analyzers
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class SnowballAnalyzerTest extends WordSpec with AnalyzerApi with Matchers {
+class SnowballAnalyzerTest extends AnyWordSpec with AnalyzerApi with Matchers {
 
   "SnowballAnalyzer builder" should {
     "set stopwords" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/SnowballTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/SnowballTokenFilterTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s.requests.analyzers
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class SnowballTokenFilterTest extends WordSpec with TokenFilterApi with Matchers {
+class SnowballTokenFilterTest extends AnyWordSpec with TokenFilterApi with Matchers {
 
   "SnowballTokenFilter builder" should {
     "set language" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/StandardAnalyzerTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/StandardAnalyzerTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s.requests.analyzers
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class StandardAnalyzerTest extends WordSpec with AnalyzerApi with Matchers {
+class StandardAnalyzerTest extends AnyWordSpec with AnalyzerApi with Matchers {
 
   "StandardAnalyzer builder" should {
     "set stopwords" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/StandardTokenizerTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/StandardTokenizerTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s.requests.analyzers
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class StandardTokenizerTest extends WordSpec with TokenizerApi with Matchers {
+class StandardTokenizerTest extends AnyWordSpec with TokenizerApi with Matchers {
 
   "StandardTokenizer builder" should {
     "set max token length" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/StemmerTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/StemmerTokenFilterTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s.requests.analyzers
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class StemmerTokenFilterTest extends WordSpec with TokenFilterApi with Matchers {
+class StemmerTokenFilterTest extends AnyWordSpec with TokenFilterApi with Matchers {
 
   "StemmerTokenFilter builder" should {
     "set language" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/StopAnalyzerTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/StopAnalyzerTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s.requests.analyzers
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class StopAnalyzerTest extends WordSpec with AnalyzerApi with Matchers {
+class StopAnalyzerTest extends AnyWordSpec with AnalyzerApi with Matchers {
 
   "StopAnalyzer builder" should {
     "set stopwords" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/StopTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/StopTokenFilterTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s.requests.analyzers
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class StopTokenFilterTest extends WordSpec with TokenFilterApi with Matchers {
+class StopTokenFilterTest extends AnyWordSpec with TokenFilterApi with Matchers {
 
   "StopTokenFilter builder" should {
     "set stop words" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/TruncateTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/TruncateTokenFilterTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s.requests.analyzers
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class TruncateTokenFilterTest extends WordSpec with TokenFilterApi with Matchers {
+class TruncateTokenFilterTest extends AnyWordSpec with TokenFilterApi with Matchers {
 
   "TruncateTokenFilter builder" should {
     "not set any defaults" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/UaxUrlEmailTokenizerTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/UaxUrlEmailTokenizerTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s.requests.analyzers
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class UaxUrlEmailTokenizerTest extends WordSpec with TokenizerApi with Matchers {
+class UaxUrlEmailTokenizerTest extends AnyWordSpec with TokenizerApi with Matchers {
 
   "UaxUrlEmailTokenizer builder" should {
     "set max token length" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/UniqueTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/UniqueTokenFilterTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s.requests.analyzers
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class UniqueTokenFilterTest extends WordSpec with AnalyzerApi with Matchers with TokenFilterApi {
+class UniqueTokenFilterTest extends AnyWordSpec with AnalyzerApi with Matchers with TokenFilterApi {
 
   "UniqueTokenFilter builder" should {
     "not set any defaults" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/WordDelimiterTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/WordDelimiterTokenFilterTest.scala
@@ -1,8 +1,9 @@
 package com.sksamuel.elastic4s.requests.analyzers
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class WordDelimiterTokenFilterTest extends WordSpec with TokenFilterApi with Matchers {
+class WordDelimiterTokenFilterTest extends AnyWordSpec with TokenFilterApi with Matchers {
 
   "WordDelimiterTokenFilter builder" should {
     "set generateNumberParts" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/bulk/BulkTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/bulk/BulkTest.scala
@@ -3,10 +3,10 @@ package com.sksamuel.elastic4s.requests.bulk
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.common.VersionType.Internal
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class BulkTest extends AnyFlatSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/bulk/BulkTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/bulk/BulkTest.scala
@@ -3,11 +3,12 @@ package com.sksamuel.elastic4s.requests.bulk
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.common.VersionType.Internal
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FlatSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class BulkTest extends FlatSpec with Matchers with DockerTests {
+class BulkTest extends AnyFlatSpec with Matchers with DockerTests {
 
   private val indexname = "bulkytest"
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/cat/CatHealthTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/cat/CatHealthTest.scala
@@ -2,9 +2,10 @@ package com.sksamuel.elastic4s.requests.cat
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class CatHealthTest extends FlatSpec with Matchers with DockerTests {
+class CatHealthTest extends AnyFlatSpec with Matchers with DockerTests {
 
   client.execute {
     bulk(

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/cat/CatShardsTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/cat/CatShardsTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.requests.cat
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class CatShardsTest extends AnyFlatSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/cat/CatShardsTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/cat/CatShardsTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.requests.cat
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FlatSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class CatShardsTest extends FlatSpec with Matchers with DockerTests {
+class CatShardsTest extends AnyFlatSpec with Matchers with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/cat/CatThreadPoolTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/cat/CatThreadPoolTest.scala
@@ -2,9 +2,10 @@ package com.sksamuel.elastic4s.requests.cat
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class CatThreadPoolTest extends FlatSpec with Matchers with DockerTests {
+class CatThreadPoolTest extends AnyFlatSpec with Matchers with DockerTests {
 
   client.execute {
     bulk(

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/cluster/ClusterInfoTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/cluster/ClusterInfoTest.scala
@@ -2,9 +2,11 @@ package com.sksamuel.elastic4s.requests.cluster
 
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.PartialFunctionValues._
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ClusterInfoTest extends WordSpec with Matchers with DockerTests with BeforeAndAfterAll {
+class ClusterInfoTest extends AnyWordSpec with Matchers with DockerTests with BeforeAndAfterAll {
 
   override protected def afterAll(): Unit = {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/cluster/ClusterInfoTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/cluster/ClusterInfoTest.scala
@@ -1,8 +1,8 @@
 package com.sksamuel.elastic4s.requests.cluster
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.PartialFunctionValues._
 import org.scalatest.BeforeAndAfterAll
+import org.scalatest.PartialFunctionValues._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/cluster/ClusterSettingsTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/cluster/ClusterSettingsTest.scala
@@ -1,11 +1,12 @@
 package com.sksamuel.elastic4s.requests.cluster
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ClusterSettingsTest extends WordSpec with Matchers with DockerTests {
+class ClusterSettingsTest extends AnyWordSpec with Matchers with DockerTests {
 
   private val indexname = "clustersettingstest"
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/cluster/ClusterSettingsTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/cluster/ClusterSettingsTest.scala
@@ -1,10 +1,10 @@
 package com.sksamuel.elastic4s.requests.cluster
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class ClusterSettingsTest extends AnyWordSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/cluster/ClusterStateTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/cluster/ClusterStateTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.requests.cluster
 
 import com.sksamuel.elastic4s.requests.cluster.ClusterStateResponse.Index
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ClusterStateTest extends WordSpec with Matchers with DockerTests {
+class ClusterStateTest extends AnyWordSpec with Matchers with DockerTests {
 
   private val indexname = "clusterstatetest"
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/cluster/ClusterStateTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/cluster/ClusterStateTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.requests.cluster
 
 import com.sksamuel.elastic4s.requests.cluster.ClusterStateResponse.Index
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class ClusterStateTest extends AnyWordSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/cluster/ClusterStatsTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/cluster/ClusterStatsTest.scala
@@ -1,10 +1,10 @@
 package com.sksamuel.elastic4s.requests.cluster
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class ClusterStatsTest extends AnyFunSuite with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/cluster/ClusterStatsTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/cluster/ClusterStatsTest.scala
@@ -1,11 +1,12 @@
 package com.sksamuel.elastic4s.requests.cluster
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FunSuite, Matchers}
 
 import scala.util.Try
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class ClusterStatsTest extends FunSuite with Matchers with DockerTests {
+class ClusterStatsTest extends AnyFunSuite with Matchers with DockerTests {
 
   private val indexname = "clusterstatstest"
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/count/CountTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/count/CountTest.scala
@@ -1,11 +1,12 @@
 package com.sksamuel.elastic4s.requests.count
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class CountTest extends WordSpec with DockerTests with Matchers {
+class CountTest extends AnyWordSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/count/CountTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/count/CountTest.scala
@@ -1,10 +1,10 @@
 package com.sksamuel.elastic4s.requests.count
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class CountTest extends AnyWordSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/delete/DeleteApiTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/delete/DeleteApiTest.scala
@@ -2,9 +2,10 @@ package com.sksamuel.elastic4s.requests.delete
 
 import com.sksamuel.elastic4s.requests.common.{RefreshPolicy, VersionType}
 import org.scalactic.TypeCheckedTripleEquals
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class DeleteApiTest extends FlatSpec with Matchers with TypeCheckedTripleEquals {
+class DeleteApiTest extends AnyFlatSpec with Matchers with TypeCheckedTripleEquals {
 
   import com.sksamuel.elastic4s.ElasticApi._
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/delete/DeleteByIdTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/delete/DeleteByIdTest.scala
@@ -5,11 +5,12 @@ import java.util.UUID
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.common.VersionType.Internal
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class DeleteByIdTest extends WordSpec with Matchers with DockerTests {
+class DeleteByIdTest extends AnyWordSpec with Matchers with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/delete/DeleteByIdTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/delete/DeleteByIdTest.scala
@@ -5,10 +5,10 @@ import java.util.UUID
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.common.VersionType.Internal
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class DeleteByIdTest extends AnyWordSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/delete/DeleteByQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/delete/DeleteByQueryTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.requests.delete
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class DeleteByQueryTest extends WordSpec with Matchers with DockerTests {
+class DeleteByQueryTest extends AnyWordSpec with Matchers with DockerTests {
 
   private val indexname = "charles_dickens"
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/delete/DeleteByQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/delete/DeleteByQueryTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.requests.delete
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class DeleteByQueryTest extends AnyWordSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/delete/DeleteTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/delete/DeleteTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.requests.delete
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FlatSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class DeleteTest extends FlatSpec with DockerTests with Matchers {
+class DeleteTest extends AnyFlatSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/delete/DeleteTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/delete/DeleteTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.requests.delete
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class DeleteTest extends AnyFlatSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/explain/ExplainTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/explain/ExplainTest.scala
@@ -3,11 +3,12 @@ package com.sksamuel.elastic4s.requests.explain
 import com.sksamuel.elastic4s.ElasticDsl
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FlatSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ExplainTest extends FlatSpec with Matchers with ElasticDsl with DockerTests {
+class ExplainTest extends AnyFlatSpec with Matchers with ElasticDsl with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/explain/ExplainTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/explain/ExplainTest.scala
@@ -3,10 +3,10 @@ package com.sksamuel.elastic4s.requests.explain
 import com.sksamuel.elastic4s.ElasticDsl
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class ExplainTest extends AnyFlatSpec with Matchers with ElasticDsl with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/get/GetTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/get/GetTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.requests.get
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class GetTest extends AnyFlatSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/get/GetTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/get/GetTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.requests.get
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FlatSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class GetTest extends FlatSpec with Matchers with DockerTests {
+class GetTest extends AnyFlatSpec with Matchers with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/get/MultiGetTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/get/MultiGetTest.scala
@@ -2,13 +2,13 @@ package com.sksamuel.elastic4s.requests.get
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers._
+import org.scalatest.matchers.should.Matchers._
 import org.scalatestplus.mockito.MockitoSugar
 
 import scala.util.Try
+import org.scalatest.flatspec.AnyFlatSpec
 
-class MultiGetTest extends FlatSpec with MockitoSugar with DockerTests {
+class MultiGetTest extends AnyFlatSpec with MockitoSugar with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/get/MultiGetTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/get/MultiGetTest.scala
@@ -2,11 +2,11 @@ package com.sksamuel.elastic4s.requests.get
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 import org.scalatestplus.mockito.MockitoSugar
 
 import scala.util.Try
-import org.scalatest.flatspec.AnyFlatSpec
 
 class MultiGetTest extends AnyFlatSpec with MockitoSugar with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/ClearCacheRequestTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/ClearCacheRequestTest.scala
@@ -1,10 +1,10 @@
 package com.sksamuel.elastic4s.requests.indexes
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class ClearCacheRequestTest extends AnyWordSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/ClearCacheRequestTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/ClearCacheRequestTest.scala
@@ -1,11 +1,12 @@
 package com.sksamuel.elastic4s.requests.indexes
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ClearCacheRequestTest extends WordSpec with Matchers with DockerTests {
+class ClearCacheRequestTest extends AnyWordSpec with Matchers with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/CreateIndexApiTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/CreateIndexApiTest.scala
@@ -5,13 +5,15 @@ import com.sksamuel.elastic4s.JsonSugar
 import com.sksamuel.elastic4s.requests.analyzers._
 import com.sksamuel.elastic4s.requests.mappings.PrefixTree
 import com.sksamuel.elastic4s.requests.mappings.dynamictemplate.DynamicMapping
-import org.scalatest.{FlatSpec, Matchers, OneInstancePerTest}
+import org.scalatest.OneInstancePerTest
 import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.duration._
 import scala.io.Source
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class CreateIndexApiTest extends FlatSpec with MockitoSugar with JsonSugar with Matchers with OneInstancePerTest {
+class CreateIndexApiTest extends AnyFlatSpec with MockitoSugar with JsonSugar with Matchers with OneInstancePerTest {
 
   "the index dsl" should "generate json to include mapping properties" in {
     val req = createIndex("users").mapping(

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/CreateIndexApiTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/CreateIndexApiTest.scala
@@ -6,12 +6,12 @@ import com.sksamuel.elastic4s.requests.analyzers._
 import com.sksamuel.elastic4s.requests.mappings.PrefixTree
 import com.sksamuel.elastic4s.requests.mappings.dynamictemplate.DynamicMapping
 import org.scalatest.OneInstancePerTest
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.duration._
 import scala.io.Source
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
 
 class CreateIndexApiTest extends AnyFlatSpec with MockitoSugar with JsonSugar with Matchers with OneInstancePerTest {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/CreateIndexTemplateRequestTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/CreateIndexTemplateRequestTest.scala
@@ -1,12 +1,14 @@
 package com.sksamuel.elastic4s.requests.indexes
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{BeforeAndAfter, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfter
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 class CreateIndexTemplateRequestTest
-  extends WordSpec
+  extends AnyWordSpec
     with Matchers
     with BeforeAndAfter
     with DockerTests {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/CreateIndexTemplateRequestTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/CreateIndexTemplateRequestTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.requests.indexes
 
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.BeforeAndAfter
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class CreateIndexTemplateRequestTest
   extends AnyWordSpec

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/CreateIndexTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/CreateIndexTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.requests.indexes
 
 import com.sksamuel.elastic4s.requests.analyzers.PatternAnalyzer
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class CreateIndexTest extends AnyWordSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/CreateIndexTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/CreateIndexTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.requests.indexes
 
 import com.sksamuel.elastic4s.requests.analyzers.PatternAnalyzer
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class CreateIndexTest extends WordSpec with Matchers with DockerTests {
+class CreateIndexTest extends AnyWordSpec with Matchers with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/DeleteIndexTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/DeleteIndexTest.scala
@@ -2,9 +2,10 @@ package com.sksamuel.elastic4s.requests.indexes
 
 import com.sksamuel.elastic4s.ElasticDsl
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class DeleteIndexTest extends WordSpec with Matchers with DockerTests {
+class DeleteIndexTest extends AnyWordSpec with Matchers with DockerTests {
 
   "delete index request" should {
     "delete index" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/ExistsTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/ExistsTest.scala
@@ -1,10 +1,10 @@
 package com.sksamuel.elastic4s.requests.indexes
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class ExistsTest extends AnyWordSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/ExistsTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/ExistsTest.scala
@@ -1,11 +1,12 @@
 package com.sksamuel.elastic4s.requests.indexes
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ExistsTest extends WordSpec with Matchers with DockerTests {
+class ExistsTest extends AnyWordSpec with Matchers with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/FlushIndexRequestTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/FlushIndexRequestTest.scala
@@ -1,11 +1,12 @@
 package com.sksamuel.elastic4s.requests.indexes
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class FlushIndexRequestTest extends WordSpec with Matchers with DockerTests {
+class FlushIndexRequestTest extends AnyWordSpec with Matchers with DockerTests {
 
   private val indexname = "flushindextest"
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/FlushIndexRequestTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/FlushIndexRequestTest.scala
@@ -1,10 +1,10 @@
 package com.sksamuel.elastic4s.requests.indexes
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class FlushIndexRequestTest extends AnyWordSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/GetIndexRequestTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/GetIndexRequestTest.scala
@@ -1,10 +1,10 @@
 package com.sksamuel.elastic4s.requests.indexes
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class GetIndexRequestTest extends AnyWordSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/GetIndexRequestTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/GetIndexRequestTest.scala
@@ -1,11 +1,12 @@
 package com.sksamuel.elastic4s.requests.indexes
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class GetIndexRequestTest extends WordSpec with Matchers with DockerTests {
+class GetIndexRequestTest extends AnyWordSpec with Matchers with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/IndexExistsTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/IndexExistsTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.requests.indexes
 
 import com.sksamuel.elastic4s.requests.admin.{IndicesExistsRequest, IndicesOptionsRequest}
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class IndexExistsTest extends AnyWordSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/IndexExistsTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/IndexExistsTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.requests.indexes
 
 import com.sksamuel.elastic4s.requests.admin.{IndicesExistsRequest, IndicesOptionsRequest}
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class IndexExistsTest extends WordSpec with Matchers with DockerTests {
+class IndexExistsTest extends AnyWordSpec with Matchers with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/IndexStatsRequestTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/IndexStatsRequestTest.scala
@@ -2,10 +2,12 @@ package com.sksamuel.elastic4s.requests.indexes
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FlatSpec, Inspectors, Matchers}
+import org.scalatest.Inspectors
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class IndexStatsRequestTest
-  extends FlatSpec
+  extends AnyFlatSpec
     with Matchers
     with DockerTests
     with Inspectors {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/IndexTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/IndexTest.scala
@@ -6,11 +6,12 @@ import com.sksamuel.elastic4s.Indexable
 import com.sksamuel.elastic4s.requests.common.VersionType.{External, Internal}
 import com.sksamuel.elastic4s.requests.common.{RefreshPolicy, Shards, VersionType}
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class IndexTest extends WordSpec with Matchers with DockerTests {
+class IndexTest extends AnyWordSpec with Matchers with DockerTests {
 
   case class Phone(name: String, speed: String)
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/IndexTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/IndexTest.scala
@@ -6,10 +6,10 @@ import com.sksamuel.elastic4s.Indexable
 import com.sksamuel.elastic4s.requests.common.VersionType.{External, Internal}
 import com.sksamuel.elastic4s.requests.common.{RefreshPolicy, Shards, VersionType}
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class IndexTest extends AnyWordSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/OpenCloseIndexRequestTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/OpenCloseIndexRequestTest.scala
@@ -3,13 +3,13 @@ package com.sksamuel.elastic4s.requests.indexes
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.concurrent.TimeLimits
 import org.scalatest.exceptions.TestFailedDueToTimeoutException
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.time.{Seconds, Span}
+import org.scalatest.wordspec.AnyWordSpec
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.Try
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
 
 class OpenCloseIndexRequestTest extends AnyWordSpec with Matchers with DockerTests with TimeLimits {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/OpenCloseIndexRequestTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/OpenCloseIndexRequestTest.scala
@@ -4,13 +4,14 @@ import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.concurrent.TimeLimits
 import org.scalatest.exceptions.TestFailedDueToTimeoutException
 import org.scalatest.time.{Seconds, Span}
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class OpenCloseIndexRequestTest extends WordSpec with Matchers with DockerTests with TimeLimits {
+class OpenCloseIndexRequestTest extends AnyWordSpec with Matchers with DockerTests with TimeLimits {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/RefreshIndexRequestTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/RefreshIndexRequestTest.scala
@@ -1,11 +1,11 @@
 package com.sksamuel.elastic4s.requests.indexes
 
 import com.sksamuel.elastic4s.testkit.DockerTests
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 import scala.concurrent.duration._
 import scala.util.Try
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
 
 class RefreshIndexRequestTest extends AnyWordSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/RefreshIndexRequestTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/RefreshIndexRequestTest.scala
@@ -1,12 +1,13 @@
 package com.sksamuel.elastic4s.requests.indexes
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.concurrent.duration._
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class RefreshIndexRequestTest extends WordSpec with Matchers with DockerTests {
+class RefreshIndexRequestTest extends AnyWordSpec with Matchers with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/RolloverIndexRequestTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/RolloverIndexRequestTest.scala
@@ -1,10 +1,10 @@
 package com.sksamuel.elastic4s.requests.indexes
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class RolloverIndexRequestTest extends AnyWordSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/RolloverIndexRequestTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/RolloverIndexRequestTest.scala
@@ -1,11 +1,12 @@
 package com.sksamuel.elastic4s.requests.indexes
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class RolloverIndexRequestTest extends WordSpec with Matchers with DockerTests {
+class RolloverIndexRequestTest extends AnyWordSpec with Matchers with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/ShardStoreHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/ShardStoreHttpTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.requests.indexes
 
 import com.sksamuel.elastic4s.requests.indexes.admin.IndexShardStoreResponse.{IndexStoreStatus, ShardStoreStatus}
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ShardStoreHttpTest extends WordSpec with Matchers with DockerTests {
+class ShardStoreHttpTest extends AnyWordSpec with Matchers with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/ShardStoreHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/ShardStoreHttpTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.requests.indexes
 
 import com.sksamuel.elastic4s.requests.indexes.admin.IndexShardStoreResponse.{IndexStoreStatus, ShardStoreStatus}
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class ShardStoreHttpTest extends AnyWordSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/DynamicTemplateApiTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/DynamicTemplateApiTest.scala
@@ -3,9 +3,10 @@ package com.sksamuel.elastic4s.requests.mappings
 import com.sksamuel.elastic4s.requests.analyzers.SpanishLanguageAnalyzer
 import com.sksamuel.elastic4s.requests.mappings.dynamictemplate.DynamicTemplateBodyFn
 import com.sksamuel.elastic4s.{ElasticApi, JsonSugar}
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class DynamicTemplateApiTest extends WordSpec with Matchers with JsonSugar with ElasticApi {
+class DynamicTemplateApiTest extends AnyWordSpec with Matchers with JsonSugar with ElasticApi {
 
   "dynamic templates" should {
     "support match" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/MappingDefinitionDslTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/MappingDefinitionDslTest.scala
@@ -3,9 +3,10 @@ package com.sksamuel.elastic4s.requests.mappings
 import com.sksamuel.elastic4s.requests.analyzers.{EnglishLanguageAnalyzer, SpanishLanguageAnalyzer}
 import com.sksamuel.elastic4s.requests.indexes.CreateIndexContentBuilder
 import com.sksamuel.elastic4s.{ElasticApi, JsonSugar}
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class MappingDefinitionDslTest extends WordSpec with Matchers with JsonSugar with ElasticApi {
+class MappingDefinitionDslTest extends AnyWordSpec with Matchers with JsonSugar with ElasticApi {
 
   "mapping definition" should {
     "insert source exclusion directives when set" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/MappingHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/MappingHttpTest.scala
@@ -3,11 +3,13 @@ package com.sksamuel.elastic4s.requests.mappings
 import com.sksamuel.elastic4s.requests.analyzers._
 import com.sksamuel.elastic4s.requests.mappings.dynamictemplate.DynamicMapping
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class MappingHttpTest extends WordSpec with DockerTests with Matchers with BeforeAndAfterAll {
+class MappingHttpTest extends AnyWordSpec with DockerTests with Matchers with BeforeAndAfterAll {
 
   override protected def beforeAll(): Unit = {
     Try {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/MappingHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/MappingHttpTest.scala
@@ -4,10 +4,10 @@ import com.sksamuel.elastic4s.requests.analyzers._
 import com.sksamuel.elastic4s.requests.mappings.dynamictemplate.DynamicMapping
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.BeforeAndAfterAll
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class MappingHttpTest extends AnyWordSpec with DockerTests with Matchers with BeforeAndAfterAll {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/PutMappingApiTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/PutMappingApiTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.requests.mappings
 
 import com.sksamuel.elastic4s.requests.mappings.dynamictemplate.DynamicMapping
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FlatSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class PutMappingApiTest extends FlatSpec with Matchers with DockerTests {
+class PutMappingApiTest extends AnyFlatSpec with Matchers with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/PutMappingApiTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/PutMappingApiTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.requests.mappings
 
 import com.sksamuel.elastic4s.requests.mappings.dynamictemplate.DynamicMapping
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class PutMappingApiTest extends AnyFlatSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/PutMappingHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/PutMappingHttpTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.requests.mappings
 
 import com.sksamuel.elastic4s.requests.indexes.IndexMappings
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FunSuite, Matchers}
 
 import scala.util.Try
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class PutMappingHttpTest extends FunSuite with Matchers with DockerTests {
+class PutMappingHttpTest extends AnyFunSuite with Matchers with DockerTests {
 
   test("put mapping should add new field to an existing type") {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/PutMappingHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/PutMappingHttpTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.requests.mappings
 
 import com.sksamuel.elastic4s.requests.indexes.IndexMappings
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class PutMappingHttpTest extends AnyFunSuite with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/SearchAsYouTypeFieldTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/SearchAsYouTypeFieldTest.scala
@@ -2,9 +2,10 @@ package com.sksamuel.elastic4s.requests.mappings
 
 import com.sksamuel.elastic4s.ElasticApi
 import com.sksamuel.elastic4s.requests.analyzers.{ArmenianLanguageAnalyzer, EnglishLanguageAnalyzer}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class SearchAsYouTypeFieldTest extends FlatSpec with Matchers with ElasticApi {
+class SearchAsYouTypeFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
 
   "search as you type def" should "support additional text properties" in {
     val field = searchAsYouType("myfield")

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/TextFieldTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/TextFieldTest.scala
@@ -2,9 +2,10 @@ package com.sksamuel.elastic4s.requests.mappings
 
 import com.sksamuel.elastic4s.ElasticApi
 import com.sksamuel.elastic4s.requests.analyzers.{ArmenianLanguageAnalyzer, EnglishLanguageAnalyzer}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class TextFieldTest extends FlatSpec with Matchers with ElasticApi {
+class TextFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
 
   "text field def" should "support text properties" in {
     val field = textField("myfield")

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/nodes/NodesInfoHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/nodes/NodesInfoHttpTest.scala
@@ -1,9 +1,10 @@
 package com.sksamuel.elastic4s.requests.nodes
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class NodesInfoHttpTest extends WordSpec with Matchers with DockerTests {
+class NodesInfoHttpTest extends AnyWordSpec with Matchers with DockerTests {
 
   "node info request" should {
     "return node information" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/nodes/NodesStatsHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/nodes/NodesStatsHttpTest.scala
@@ -1,9 +1,10 @@
 package com.sksamuel.elastic4s.requests.nodes
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class NodesStatsHttpTest extends WordSpec with Matchers with DockerTests {
+class NodesStatsHttpTest extends AnyWordSpec with Matchers with DockerTests {
 
   "node stats request" should {
     "return os information" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/reindex/ReindexTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/reindex/ReindexTest.scala
@@ -2,9 +2,10 @@ package com.sksamuel.elastic4s.requests.reindex
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ReindexTest extends WordSpec with Matchers with DockerTests {
+class ReindexTest extends AnyWordSpec with Matchers with DockerTests {
 
   deleteIdx("reindex")
   deleteIdx("reindex2")

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/script/ScriptTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/script/ScriptTest.scala
@@ -1,11 +1,11 @@
 package com.sksamuel.elastic4s.requests.script
 
 import com.sksamuel.elastic4s.testkit.{DockerTests, ElasticMatchers}
-import org.scalatest.FreeSpec
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
 
-class ScriptTest extends FreeSpec with ElasticMatchers with DockerTests {
+class ScriptTest extends AnyFreeSpec with ElasticMatchers with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/script/ScriptTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/script/ScriptTest.scala
@@ -1,9 +1,9 @@
 package com.sksamuel.elastic4s.requests.script
 
 import com.sksamuel.elastic4s.testkit.{DockerTests, ElasticMatchers}
+import org.scalatest.freespec.AnyFreeSpec
 
 import scala.util.Try
-import org.scalatest.freespec.AnyFreeSpec
 
 class ScriptTest extends AnyFreeSpec with ElasticMatchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/AggregationAsStringTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/AggregationAsStringTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FunSuite, Matchers}
 
 import scala.util.Try
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-class AggregationAsStringTest extends FunSuite with DockerTests with Matchers {
+class AggregationAsStringTest extends AnyFunSuite with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/AggregationAsStringTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/AggregationAsStringTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class AggregationAsStringTest extends AnyFunSuite with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/AvgAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/AvgAggregationHttpTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class AvgAggregationHttpTest extends FreeSpec with DockerTests with Matchers {
+class AvgAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/AvgAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/AvgAggregationHttpTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class AvgAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/AvgBucketPipelineAggHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/AvgBucketPipelineAggHttpTest.scala
@@ -3,11 +3,12 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.DateHistogramInterval
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class AvgBucketPipelineAggHttpTest extends FreeSpec with DockerTests with Matchers {
+class AvgBucketPipelineAggHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/AvgBucketPipelineAggHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/AvgBucketPipelineAggHttpTest.scala
@@ -3,10 +3,10 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.DateHistogramInterval
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class AvgBucketPipelineAggHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/BucketSortPipelineAggHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/BucketSortPipelineAggHttpTest.scala
@@ -4,11 +4,12 @@ import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.sort.{FieldSort, SortOrder}
 import com.sksamuel.elastic4s.requests.searches.{Aggregations, DateHistogramInterval}
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class BucketSortPipelineAggHttpTest extends FreeSpec with DockerTests with Matchers {
+class BucketSortPipelineAggHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/BucketSortPipelineAggHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/BucketSortPipelineAggHttpTest.scala
@@ -4,10 +4,10 @@ import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.sort.{FieldSort, SortOrder}
 import com.sksamuel.elastic4s.requests.searches.{Aggregations, DateHistogramInterval}
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class BucketSortPipelineAggHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/CardinalityAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/CardinalityAggregationHttpTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class CardinalityAggregationHttpTest extends FreeSpec with DockerTests with Matchers {
+class CardinalityAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/CardinalityAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/CardinalityAggregationHttpTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class CardinalityAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/CompositeDateAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/CompositeDateAggregationHttpTest.scala
@@ -4,11 +4,12 @@ import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.DateHistogramInterval
 import com.sksamuel.elastic4s.requests.searches.aggs.CompositeAggregation._
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class CompositeDateAggregationHttpTest extends FreeSpec with DockerTests with Matchers {
+class CompositeDateAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/CompositeDateAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/CompositeDateAggregationHttpTest.scala
@@ -4,10 +4,10 @@ import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.DateHistogramInterval
 import com.sksamuel.elastic4s.requests.searches.aggs.CompositeAggregation._
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class CompositeDateAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/DateHistogramAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/DateHistogramAggregationHttpTest.scala
@@ -3,11 +3,12 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.{DateHistogramBucket, DateHistogramInterval}
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class DateHistogramAggregationHttpTest extends FreeSpec with DockerTests with Matchers {
+class DateHistogramAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/DateHistogramAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/DateHistogramAggregationHttpTest.scala
@@ -3,10 +3,10 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.{DateHistogramBucket, DateHistogramInterval}
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class DateHistogramAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/DateRangeAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/DateRangeAggregationHttpTest.scala
@@ -3,11 +3,12 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 import com.sksamuel.elastic4s.requests.searches.DateRangeBucket
 import com.sksamuel.elastic4s.testkit.DockerTests
 import com.sksamuel.elastic4s.{ElasticDate, ElasticDateMath, Years}
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class DateRangeAggregationHttpTest extends FreeSpec with DockerTests with Matchers {
+class DateRangeAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/DateRangeAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/DateRangeAggregationHttpTest.scala
@@ -3,10 +3,10 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 import com.sksamuel.elastic4s.requests.searches.DateRangeBucket
 import com.sksamuel.elastic4s.testkit.DockerTests
 import com.sksamuel.elastic4s.{ElasticDate, ElasticDateMath, Years}
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class DateRangeAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/ExtendedStatsAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/ExtendedStatsAggregationHttpTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class ExtendedStatsAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/ExtendedStatsAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/ExtendedStatsAggregationHttpTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class ExtendedStatsAggregationHttpTest extends FreeSpec with DockerTests with Matchers {
+class ExtendedStatsAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/ExtendedStatsBucketPipelineAggHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/ExtendedStatsBucketPipelineAggHttpTest.scala
@@ -3,11 +3,12 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.DateHistogramInterval
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class ExtendedStatsBucketPipelineAggHttpTest extends FreeSpec with DockerTests with Matchers {
+class ExtendedStatsBucketPipelineAggHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/ExtendedStatsBucketPipelineAggHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/ExtendedStatsBucketPipelineAggHttpTest.scala
@@ -3,10 +3,10 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.DateHistogramInterval
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class ExtendedStatsBucketPipelineAggHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/FilterAggregationDslTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/FilterAggregationDslTest.scala
@@ -2,9 +2,10 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.ElasticApi
 import com.sksamuel.elastic4s.requests.searches.DateHistogramInterval
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class FilterAggregationDslTest extends FlatSpec with Matchers with ElasticApi {
+class FilterAggregationDslTest extends AnyFlatSpec with Matchers with ElasticApi {
 
   "filter agg" should "support sub aggs" in {
     filterAggregation("filtered").query(

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/FilterAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/FilterAggregationHttpTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class FilterAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/FilterAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/FilterAggregationHttpTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class FilterAggregationHttpTest extends FreeSpec with DockerTests with Matchers {
+class FilterAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/FiltersAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/FiltersAggregationHttpTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class FiltersAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/FiltersAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/FiltersAggregationHttpTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class FiltersAggregationHttpTest extends FreeSpec with DockerTests with Matchers {
+class FiltersAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/GeoBoundsAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/GeoBoundsAggregationHttpTest.scala
@@ -1,11 +1,12 @@
 package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class GeoBoundsAggregationHttpTest extends FreeSpec with DockerTests with Matchers {
+class GeoBoundsAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/GeoBoundsAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/GeoBoundsAggregationHttpTest.scala
@@ -1,10 +1,10 @@
 package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class GeoBoundsAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/GeoCentroidAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/GeoCentroidAggregationHttpTest.scala
@@ -1,11 +1,12 @@
 package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class GeoCentroidAggregationHttpTest extends FreeSpec with DockerTests with Matchers {
+class GeoCentroidAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/GeoCentroidAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/GeoCentroidAggregationHttpTest.scala
@@ -1,10 +1,10 @@
 package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class GeoCentroidAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/GeoDistanceAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/GeoDistanceAggregationHttpTest.scala
@@ -3,11 +3,12 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 import com.sksamuel.elastic4s.requests.common.DistanceUnit
 import com.sksamuel.elastic4s.requests.searches.{GeoDistanceBucket, GeoPoint}
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class GeoDistanceAggregationHttpTest extends FreeSpec with DockerTests with Matchers {
+class GeoDistanceAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/GeoDistanceAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/GeoDistanceAggregationHttpTest.scala
@@ -3,10 +3,10 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 import com.sksamuel.elastic4s.requests.common.DistanceUnit
 import com.sksamuel.elastic4s.requests.searches.{GeoDistanceBucket, GeoPoint}
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class GeoDistanceAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/GeoHashGridAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/GeoHashGridAggregationHttpTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.requests.searches.GeoHashGridBucket
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class GeoHashGridAggregationHttpTest extends FreeSpec with DockerTests with Matchers {
+class GeoHashGridAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/GeoHashGridAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/GeoHashGridAggregationHttpTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.requests.searches.GeoHashGridBucket
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class GeoHashGridAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/GlobalAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/GlobalAggregationHttpTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class GlobalAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/GlobalAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/GlobalAggregationHttpTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class GlobalAggregationHttpTest extends FreeSpec with DockerTests with Matchers {
+class GlobalAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/HistogramAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/HistogramAggregationHttpTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.requests.searches.HistogramBucket
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class HistogramAggregationHttpTest extends AnyFreeSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/HistogramAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/HistogramAggregationHttpTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.requests.searches.HistogramBucket
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class HistogramAggregationHttpTest extends FreeSpec with Matchers with DockerTests {
+class HistogramAggregationHttpTest extends AnyFreeSpec with Matchers with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/IpRangeAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/IpRangeAggregationHttpTest.scala
@@ -3,10 +3,10 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 import com.sksamuel.elastic4s.ElasticDsl
 import com.sksamuel.elastic4s.requests.searches.IpRangeBucket
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class IpRangeAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers with ElasticDsl {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/IpRangeAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/IpRangeAggregationHttpTest.scala
@@ -3,11 +3,12 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 import com.sksamuel.elastic4s.ElasticDsl
 import com.sksamuel.elastic4s.requests.searches.IpRangeBucket
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class IpRangeAggregationHttpTest extends FreeSpec with DockerTests with Matchers with ElasticDsl {
+class IpRangeAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers with ElasticDsl {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/KeyedDateRangeAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/KeyedDateRangeAggregationHttpTest.scala
@@ -5,11 +5,12 @@ import com.sksamuel.elastic4s.testkit.DockerTests
 import com.sksamuel.elastic4s.{ElasticDate, ElasticDateMath, Years}
 import org.joda.time.DateTime
 import org.joda.time.format.{DateTimeFormat, DateTimeFormatter}
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class KeyedDateRangeAggregationHttpTest extends FreeSpec with DockerTests with Matchers {
+class KeyedDateRangeAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/KeyedDateRangeAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/KeyedDateRangeAggregationHttpTest.scala
@@ -5,10 +5,10 @@ import com.sksamuel.elastic4s.testkit.DockerTests
 import com.sksamuel.elastic4s.{ElasticDate, ElasticDateMath, Years}
 import org.joda.time.DateTime
 import org.joda.time.format.{DateTimeFormat, DateTimeFormatter}
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class KeyedDateRangeAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/KeyedFiltersAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/KeyedFiltersAggregationHttpTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class KeyedFiltersAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/KeyedFiltersAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/KeyedFiltersAggregationHttpTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class KeyedFiltersAggregationHttpTest extends FreeSpec with DockerTests with Matchers {
+class KeyedFiltersAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/KeyedRangeAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/KeyedRangeAggregationHttpTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.requests.searches.RangeBucket
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class KeyedRangeAggregationHttpTest extends FreeSpec with DockerTests with Matchers {
+class KeyedRangeAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/KeyedRangeAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/KeyedRangeAggregationHttpTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.requests.searches.RangeBucket
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class KeyedRangeAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/MinBucketPipelineAggPipelineAggHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/MinBucketPipelineAggPipelineAggHttpTest.scala
@@ -3,10 +3,10 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.DateHistogramInterval
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class MinBucketPipelineAggPipelineAggHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/MinBucketPipelineAggPipelineAggHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/MinBucketPipelineAggPipelineAggHttpTest.scala
@@ -3,11 +3,12 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.DateHistogramInterval
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class MinBucketPipelineAggPipelineAggHttpTest extends FreeSpec with DockerTests with Matchers {
+class MinBucketPipelineAggPipelineAggHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/MinMaxAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/MinMaxAggregationHttpTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class MinMaxAggregationHttpTest extends FreeSpec with DockerTests with Matchers {
+class MinMaxAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/MinMaxAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/MinMaxAggregationHttpTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class MinMaxAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/MissingAggregationTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/MissingAggregationTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class MissingAggregationTest extends FreeSpec with DockerTests with Matchers {
+class MissingAggregationTest extends AnyFreeSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/MissingAggregationTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/MissingAggregationTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class MissingAggregationTest extends AnyFreeSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/MovAvgPipelineAggHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/MovAvgPipelineAggHttpTest.scala
@@ -3,10 +3,10 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.{Aggregations, DateHistogramInterval}
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class MovAvgPipelineAggHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/MovAvgPipelineAggHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/MovAvgPipelineAggHttpTest.scala
@@ -3,11 +3,12 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.{Aggregations, DateHistogramInterval}
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class MovAvgPipelineAggHttpTest extends FreeSpec with DockerTests with Matchers {
+class MovAvgPipelineAggHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/PercentilesAggregationTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/PercentilesAggregationTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class PercentilesAggregationTest extends FreeSpec with DockerTests with Matchers {
+class PercentilesAggregationTest extends AnyFreeSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/PercentilesAggregationTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/PercentilesAggregationTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class PercentilesAggregationTest extends AnyFreeSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/PercentilesBucketPipelineAggHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/PercentilesBucketPipelineAggHttpTest.scala
@@ -3,11 +3,12 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.DateHistogramInterval
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class PercentilesBucketPipelineAggHttpTest extends FreeSpec with DockerTests with Matchers {
+class PercentilesBucketPipelineAggHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/PercentilesBucketPipelineAggHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/PercentilesBucketPipelineAggHttpTest.scala
@@ -3,10 +3,10 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.DateHistogramInterval
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class PercentilesBucketPipelineAggHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/RangeAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/RangeAggregationHttpTest.scala
@@ -2,9 +2,11 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.requests.searches.RangeBucket
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class RangeAggregationHttpTest extends FreeSpec with DockerTests with Matchers with BeforeAndAfterAll {
+class RangeAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers with BeforeAndAfterAll {
 
   deleteIdx("rangeaggs")
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/SerialDiffPipelineAggHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/SerialDiffPipelineAggHttpTest.scala
@@ -3,10 +3,10 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.{Aggregations, DateHistogramInterval}
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class SerialDiffPipelineAggHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/SerialDiffPipelineAggHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/SerialDiffPipelineAggHttpTest.scala
@@ -3,11 +3,12 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.{Aggregations, DateHistogramInterval}
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class SerialDiffPipelineAggHttpTest extends FreeSpec with DockerTests with Matchers {
+class SerialDiffPipelineAggHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/StatsBucketPipelineAggHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/StatsBucketPipelineAggHttpTest.scala
@@ -3,11 +3,12 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.DateHistogramInterval
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class StatsBucketPipelineAggHttpTest extends FreeSpec with DockerTests with Matchers {
+class StatsBucketPipelineAggHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/StatsBucketPipelineAggHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/StatsBucketPipelineAggHttpTest.scala
@@ -3,10 +3,10 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.DateHistogramInterval
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class StatsBucketPipelineAggHttpTest extends AnyFreeSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/SumAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/SumAggregationHttpTest.scala
@@ -1,11 +1,13 @@
 package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class SumAggregationHttpTest extends FreeSpec with DockerTests with Matchers with BeforeAndAfterAll {
+class SumAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers with BeforeAndAfterAll {
 
   override protected def beforeAll(): Unit = {
     deleteIdx("sumagg")

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/SumAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/SumAggregationHttpTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.BeforeAndAfterAll
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class SumAggregationHttpTest extends AnyFreeSpec with DockerTests with Matchers with BeforeAndAfterAll {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/TermsAggregationTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/TermsAggregationTest.scala
@@ -3,10 +3,10 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.TermBucket
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class TermsAggregationTest extends AnyFreeSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/TermsAggregationTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/TermsAggregationTest.scala
@@ -3,11 +3,12 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.TermBucket
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class TermsAggregationTest extends FreeSpec with DockerTests with Matchers {
+class TermsAggregationTest extends AnyFreeSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/TopHitsAggregationTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/TopHitsAggregationTest.scala
@@ -4,10 +4,10 @@ import com.sksamuel.elastic4s.AggReader
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.Total
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class TopHitsAggregationTest extends AnyFreeSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/TopHitsAggregationTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/TopHitsAggregationTest.scala
@@ -4,11 +4,12 @@ import com.sksamuel.elastic4s.AggReader
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.Total
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class TopHitsAggregationTest extends FreeSpec with DockerTests with Matchers {
+class TopHitsAggregationTest extends AnyFreeSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/ValueCountAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/ValueCountAggregationHttpTest.scala
@@ -3,11 +3,12 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 import com.sksamuel.elastic4s.ElasticDsl
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FreeSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class ValueCountAggregationHttpTest extends FreeSpec with Matchers with DockerTests {
+class ValueCountAggregationHttpTest extends AnyFreeSpec with Matchers with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/ValueCountAggregationHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/ValueCountAggregationHttpTest.scala
@@ -3,10 +3,10 @@ package com.sksamuel.elastic4s.requests.searches.aggs
 import com.sksamuel.elastic4s.ElasticDsl
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class ValueCountAggregationHttpTest extends AnyFreeSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/roles/ClearRolesCacheTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/roles/ClearRolesCacheTest.scala
@@ -1,9 +1,10 @@
 package com.sksamuel.elastic4s.requests.security.roles
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ClearRolesCacheTest extends WordSpec with Matchers with DockerTests {
+class ClearRolesCacheTest extends AnyWordSpec with Matchers with DockerTests {
 
   "clear roles cache request" should {
     "return ack" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/roles/CreateRoleApiTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/roles/CreateRoleApiTest.scala
@@ -2,9 +2,11 @@ package com.sksamuel.elastic4s.requests.security.roles
 
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.JsonSugar
-import org.scalatest.{FlatSpec, Matchers, OneInstancePerTest}
+import org.scalatest.OneInstancePerTest
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class CreateRoleApiTest extends FlatSpec with JsonSugar with Matchers with OneInstancePerTest {
+class CreateRoleApiTest extends AnyFlatSpec with JsonSugar with Matchers with OneInstancePerTest {
 
 	"the role dsl" should "generate valid json" in {
 		val req = createRole(

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/roles/CreateRoleTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/roles/CreateRoleTest.scala
@@ -1,10 +1,10 @@
 package com.sksamuel.elastic4s.requests.security.roles
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class CreateRoleTest extends AnyWordSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/roles/CreateRoleTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/roles/CreateRoleTest.scala
@@ -1,11 +1,12 @@
 package com.sksamuel.elastic4s.requests.security.roles
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class CreateRoleTest extends WordSpec with Matchers with DockerTests {
+class CreateRoleTest extends AnyWordSpec with Matchers with DockerTests {
 
 	Try {
 		client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/roles/DeleteRoleTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/roles/DeleteRoleTest.scala
@@ -1,9 +1,10 @@
 package com.sksamuel.elastic4s.requests.security.roles
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class DeleteRoleTest extends WordSpec with Matchers with DockerTests {
+class DeleteRoleTest extends AnyWordSpec with Matchers with DockerTests {
 
   "delete role request" should {
     "delete role" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/roles/GetRoleTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/roles/GetRoleTest.scala
@@ -1,10 +1,10 @@
 package com.sksamuel.elastic4s.requests.security.roles
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class GetRoleTest extends AnyWordSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/roles/GetRoleTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/roles/GetRoleTest.scala
@@ -1,11 +1,12 @@
 package com.sksamuel.elastic4s.requests.security.roles
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class GetRoleTest extends WordSpec with Matchers with DockerTests {
+class GetRoleTest extends AnyWordSpec with Matchers with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/roles/UpdateRoleTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/roles/UpdateRoleTest.scala
@@ -1,11 +1,12 @@
 package com.sksamuel.elastic4s.requests.security.roles
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class UpdateRoleTest extends WordSpec with Matchers with DockerTests {
+class UpdateRoleTest extends AnyWordSpec with Matchers with DockerTests {
 
 	Try {
 		client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/roles/UpdateRoleTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/roles/UpdateRoleTest.scala
@@ -1,10 +1,10 @@
 package com.sksamuel.elastic4s.requests.security.roles
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class UpdateRoleTest extends AnyWordSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/ChangePasswordTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/ChangePasswordTest.scala
@@ -1,11 +1,12 @@
 package com.sksamuel.elastic4s.requests.security.users
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ChangeUserPasswordTest extends WordSpec with Matchers with DockerTests {
+class ChangeUserPasswordTest extends AnyWordSpec with Matchers with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/ChangePasswordTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/ChangePasswordTest.scala
@@ -1,10 +1,10 @@
 package com.sksamuel.elastic4s.requests.security.users
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class ChangeUserPasswordTest extends AnyWordSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/CreateUserApiTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/CreateUserApiTest.scala
@@ -2,9 +2,11 @@ package com.sksamuel.elastic4s.requests.security.users
 
 import com.sksamuel.elastic4s.ElasticDsl._
 import com.sksamuel.elastic4s.JsonSugar
-import org.scalatest.{FlatSpec, Matchers, OneInstancePerTest}
+import org.scalatest.OneInstancePerTest
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class CreateUserApiTest extends FlatSpec with JsonSugar with Matchers with OneInstancePerTest {
+class CreateUserApiTest extends AnyFlatSpec with JsonSugar with Matchers with OneInstancePerTest {
 
 	"the user dsl" should "generate valid json" in {
 		val req = createUser(

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/CreateUserTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/CreateUserTest.scala
@@ -1,10 +1,10 @@
 package com.sksamuel.elastic4s.requests.security.users
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class CreateUserTest extends AnyWordSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/CreateUserTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/CreateUserTest.scala
@@ -1,11 +1,12 @@
 package com.sksamuel.elastic4s.requests.security.users
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class CreateUserTest extends WordSpec with Matchers with DockerTests {
+class CreateUserTest extends AnyWordSpec with Matchers with DockerTests {
 
 	Try {
 		client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/DeleteUserTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/DeleteUserTest.scala
@@ -1,9 +1,10 @@
 package com.sksamuel.elastic4s.requests.security.users
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class DeleteUserTest extends WordSpec with Matchers with DockerTests {
+class DeleteUserTest extends AnyWordSpec with Matchers with DockerTests {
 
   "delete user request" should {
     "delete user" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/DisableUserTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/DisableUserTest.scala
@@ -1,11 +1,12 @@
 package com.sksamuel.elastic4s.requests.security.users
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class DisableUserTest extends WordSpec with Matchers with DockerTests {
+class DisableUserTest extends AnyWordSpec with Matchers with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/DisableUserTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/DisableUserTest.scala
@@ -1,10 +1,10 @@
 package com.sksamuel.elastic4s.requests.security.users
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class DisableUserTest extends AnyWordSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/EnableUserTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/EnableUserTest.scala
@@ -1,10 +1,10 @@
 package com.sksamuel.elastic4s.requests.security.users
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class EnnableUserTest extends AnyWordSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/EnableUserTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/EnableUserTest.scala
@@ -1,11 +1,12 @@
 package com.sksamuel.elastic4s.requests.security.users
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class EnnableUserTest extends WordSpec with Matchers with DockerTests {
+class EnnableUserTest extends AnyWordSpec with Matchers with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/GetUserTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/GetUserTest.scala
@@ -1,10 +1,10 @@
 package com.sksamuel.elastic4s.requests.security.users
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class GetUserTest extends AnyWordSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/GetUserTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/security/users/GetUserTest.scala
@@ -1,11 +1,12 @@
 package com.sksamuel.elastic4s.requests.security.users
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class GetUserTest extends WordSpec with Matchers with DockerTests {
+class GetUserTest extends AnyWordSpec with Matchers with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/settings/SettingsTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/settings/SettingsTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.requests.settings
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class SettingsTest extends AnyWordSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/settings/SettingsTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/settings/SettingsTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.requests.settings
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class SettingsTest extends WordSpec with Matchers with DockerTests {
+class SettingsTest extends AnyWordSpec with Matchers with DockerTests {
 
   deleteIdx("settingsa")
   deleteIdx("settingsb")

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/snapshots/SnapshotTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/snapshots/SnapshotTest.scala
@@ -3,9 +3,10 @@ package com.sksamuel.elastic4s.requests.snapshots
 import java.util.UUID
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class SnapshotTest extends FlatSpec with Matchers with DockerTests {
+class SnapshotTest extends AnyFlatSpec with Matchers with DockerTests {
 
   private val repoName = "repotest_" + UUID.randomUUID().toString
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/termvectors/TermVectorsTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/termvectors/TermVectorsTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.requests.termvectors
 
 import com.sksamuel.elastic4s.Indexes
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class TermVectorsTest extends AnyFlatSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/termvectors/TermVectorsTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/termvectors/TermVectorsTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.requests.termvectors
 
 import com.sksamuel.elastic4s.Indexes
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FlatSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class TermVectorsTest extends FlatSpec with Matchers with DockerTests {
+class TermVectorsTest extends AnyFlatSpec with Matchers with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryTest.scala
@@ -2,13 +2,15 @@ package com.sksamuel.elastic4s.requests.update
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import org.scalatest.OptionValues
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.Try
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class UpdateByQueryTest
-  extends FlatSpec
+  extends AnyFlatSpec
     with Matchers
     with DockerTests
     with OptionValues {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryTest.scala
@@ -3,11 +3,11 @@ package com.sksamuel.elastic4s.requests.update
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.OptionValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.Try
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
 
 class UpdateByQueryTest
   extends AnyFlatSpec

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/update/UpdateTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/update/UpdateTest.scala
@@ -5,12 +5,14 @@ import java.util.UUID
 import com.sksamuel.elastic4s.ElasticApi
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FlatSpec, Matchers, OptionValues}
+import org.scalatest.OptionValues
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class UpdateTest
-  extends FlatSpec
+  extends AnyFlatSpec
     with Matchers
     with DockerTests
     with OptionValues {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/update/UpdateTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/update/UpdateTest.scala
@@ -6,10 +6,10 @@ import com.sksamuel.elastic4s.ElasticApi
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.OptionValues
-
-import scala.concurrent.ExecutionContext.Implicits.global
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class UpdateTest
   extends AnyFlatSpec

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/validate/ValidateDslTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/validate/ValidateDslTest.scala
@@ -1,9 +1,9 @@
 package com.sksamuel.elastic4s.requests.validate
 
-import org.scalatest.FlatSpec
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.flatspec.AnyFlatSpec
 
-class ValidateDslTest extends FlatSpec with MockitoSugar {
+class ValidateDslTest extends AnyFlatSpec with MockitoSugar {
 
   import com.sksamuel.elastic4s.ElasticDsl._
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/validate/ValidateDslTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/validate/ValidateDslTest.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.elastic4s.requests.validate
 
-import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatestplus.mockito.MockitoSugar
 
 class ValidateDslTest extends AnyFlatSpec with MockitoSugar {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/validate/ValidateTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/validate/ValidateTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.requests.validate
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class ValidateTest extends AnyWordSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/validate/ValidateTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/validate/ValidateTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.requests.validate
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ValidateTest extends WordSpec with Matchers with DockerTests {
+class ValidateTest extends AnyWordSpec with Matchers with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/InnerHitTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/InnerHitTest.scala
@@ -4,9 +4,10 @@ import com.sksamuel.elastic4s.requests.mappings.Child
 import com.sksamuel.elastic4s.requests.searches.queries.InnerHit
 import com.sksamuel.elastic4s.requests.searches.{InnerHits, Total}
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class InnerHitTest extends WordSpec with Matchers with DockerTests {
+class InnerHitTest extends AnyWordSpec with Matchers with DockerTests {
 
   val indexName = "inner_hit_test"
   deleteIdx(indexName)

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/MultiSearchHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/MultiSearchHttpTest.scala
@@ -3,12 +3,13 @@ package com.sksamuel.elastic4s.search
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.SearchType
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FlatSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class MultiSearchHttpTest
-  extends FlatSpec
+  extends AnyFlatSpec
     with DockerTests
     with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/MultiSearchHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/MultiSearchHttpTest.scala
@@ -3,10 +3,10 @@ package com.sksamuel.elastic4s.search
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.SearchType
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class MultiSearchHttpTest
   extends AnyFlatSpec

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/ScrollTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/ScrollTest.scala
@@ -2,11 +2,11 @@ package com.sksamuel.elastic4s.search
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 import scala.concurrent.duration._
 import scala.util.Try
-import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
 
 class ScrollTest extends AnyWordSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/ScrollTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/ScrollTest.scala
@@ -2,12 +2,13 @@ package com.sksamuel.elastic4s.search
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.concurrent.duration._
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ScrollTest extends WordSpec with Matchers with DockerTests {
+class ScrollTest extends AnyWordSpec with Matchers with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
@@ -12,10 +12,11 @@ import com.sksamuel.elastic4s.requests.searches.queries.{RegexpFlag, SimpleQuery
 import com.sksamuel.elastic4s.requests.searches.sort.{SortMode, SortOrder}
 import com.sksamuel.elastic4s.requests.searches.suggestion.{DirectGenerator, Fuzziness, SuggestMode}
 import org.joda.time.DateTimeZone
-import org.scalatest.{FlatSpec, OneInstancePerTest}
+import org.scalatest.OneInstancePerTest
 import org.scalatestplus.mockito.MockitoSugar
+import org.scalatest.flatspec.AnyFlatSpec
 
-class SearchDslTest extends FlatSpec with MockitoSugar with JsonSugar with OneInstancePerTest {
+class SearchDslTest extends AnyFlatSpec with MockitoSugar with JsonSugar with OneInstancePerTest {
 
   import ElasticDsl._
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
@@ -13,8 +13,8 @@ import com.sksamuel.elastic4s.requests.searches.sort.{SortMode, SortOrder}
 import com.sksamuel.elastic4s.requests.searches.suggestion.{DirectGenerator, Fuzziness, SuggestMode}
 import org.joda.time.DateTimeZone
 import org.scalatest.OneInstancePerTest
-import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatestplus.mockito.MockitoSugar
 
 class SearchDslTest extends AnyFlatSpec with MockitoSugar with JsonSugar with OneInstancePerTest {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchHitReaderTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchHitReaderTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.search
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FlatSpec, Matchers}
 
 import scala.util.Success
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class SearchHitReaderTest extends FlatSpec with Matchers with DockerTests {
+class SearchHitReaderTest extends AnyFlatSpec with Matchers with DockerTests {
 
   import com.sksamuel.elastic4s.jackson.ElasticJackson.Implicits._
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchHitReaderTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchHitReaderTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.search
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Success
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Success
 
 class SearchHitReaderTest extends AnyFlatSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchIteratorTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchIteratorTest.scala
@@ -4,10 +4,10 @@ import com.sksamuel.elastic4s.ElasticDsl
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.SearchIterator
 import com.sksamuel.elastic4s.testkit.{DockerTests, ElasticMatchers}
+import org.scalatest.wordspec.AnyWordSpec
 
 import scala.concurrent.duration._
 import scala.util.Try
-import org.scalatest.wordspec.AnyWordSpec
 
 class SearchIteratorTest
   extends AnyWordSpec

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchIteratorTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchIteratorTest.scala
@@ -4,13 +4,13 @@ import com.sksamuel.elastic4s.ElasticDsl
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.SearchIterator
 import com.sksamuel.elastic4s.testkit.{DockerTests, ElasticMatchers}
-import org.scalatest.WordSpec
 
 import scala.concurrent.duration._
 import scala.util.Try
+import org.scalatest.wordspec.AnyWordSpec
 
 class SearchIteratorTest
-  extends WordSpec
+  extends AnyWordSpec
     with ElasticMatchers
     with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchTest.scala
@@ -6,10 +6,10 @@ import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.queries.matches.MultiMatchQueryBuilderType.CROSS_FIELDS
 import com.sksamuel.elastic4s.testkit.DockerTests
 import com.sksamuel.elastic4s.{ElasticDsl, HitReader}
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class SearchTest extends AnyWordSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchTest.scala
@@ -6,11 +6,12 @@ import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.queries.matches.MultiMatchQueryBuilderType.CROSS_FIELDS
 import com.sksamuel.elastic4s.testkit.DockerTests
 import com.sksamuel.elastic4s.{ElasticDsl, HitReader}
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class SearchTest extends WordSpec with DockerTests with Matchers {
+class SearchTest extends AnyWordSpec with DockerTests with Matchers {
 
   import com.sksamuel.elastic4s.jackson.ElasticJackson.Implicits._
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/collapse/CollapseHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/collapse/CollapseHttpTest.scala
@@ -2,11 +2,13 @@ package com.sksamuel.elastic4s.search.collapse
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{BeforeAndAfterAll, FreeSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
 
-class CollapseHttpTest extends FreeSpec with Matchers with DockerTests with BeforeAndAfterAll {
+class CollapseHttpTest extends AnyFreeSpec with Matchers with DockerTests with BeforeAndAfterAll {
 
   override protected def beforeAll(): Unit = {
     Try {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/collapse/CollapseHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/collapse/CollapseHttpTest.scala
@@ -3,10 +3,10 @@ package com.sksamuel.elastic4s.search.collapse
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.BeforeAndAfterAll
-
-import scala.util.Try
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class CollapseHttpTest extends AnyFreeSpec with Matchers with DockerTests with BeforeAndAfterAll {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/highlight/HighlightTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/highlight/HighlightTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.search.highlight
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class HighlightTest extends AnyWordSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/highlight/HighlightTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/highlight/HighlightTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.search.highlight
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class HighlightTest extends WordSpec with Matchers with DockerTests {
+class HighlightTest extends AnyWordSpec with Matchers with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/BoolQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/BoolQueryTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.search.queries
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class BoolQueryTest extends AnyFlatSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/BoolQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/BoolQueryTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.search.queries
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FlatSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class BoolQueryTest extends FlatSpec with Matchers with DockerTests {
+class BoolQueryTest extends AnyFlatSpec with Matchers with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/CommonTermsQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/CommonTermsQueryTest.scala
@@ -3,10 +3,10 @@ package com.sksamuel.elastic4s.search.queries
 import com.sksamuel.elastic4s.requests.common.Preference
 import com.sksamuel.elastic4s.testkit.DockerTests
 import com.sksamuel.elastic4s.{ElasticDsl, Indexable}
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class CommonTermsQueryTest extends AnyWordSpec with Matchers with DockerTests with ElasticDsl {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/CommonTermsQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/CommonTermsQueryTest.scala
@@ -3,11 +3,12 @@ package com.sksamuel.elastic4s.search.queries
 import com.sksamuel.elastic4s.requests.common.Preference
 import com.sksamuel.elastic4s.testkit.DockerTests
 import com.sksamuel.elastic4s.{ElasticDsl, Indexable}
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class CommonTermsQueryTest extends WordSpec with Matchers with DockerTests with ElasticDsl {
+class CommonTermsQueryTest extends AnyWordSpec with Matchers with DockerTests with ElasticDsl {
 
   case class Condiment(name: String, desc: String)
   implicit object CondimentIndexable extends Indexable[Condiment] {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/CountTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/CountTest.scala
@@ -1,9 +1,9 @@
 package com.sksamuel.elastic4s.search.queries
 
 import com.sksamuel.elastic4s.testkit.DockerTests
+import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.util.Try
-import org.scalatest.flatspec.AnyFlatSpec
 
 class CountTest extends AnyFlatSpec with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/CountTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/CountTest.scala
@@ -1,11 +1,11 @@
 package com.sksamuel.elastic4s.search.queries
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.FlatSpec
 
 import scala.util.Try
+import org.scalatest.flatspec.AnyFlatSpec
 
-class CountTest extends FlatSpec with DockerTests {
+class CountTest extends AnyFlatSpec with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/DateRangeQueryHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/DateRangeQueryHttpTest.scala
@@ -2,9 +2,9 @@ package com.sksamuel.elastic4s.search.queries
 
 import com.sksamuel.elastic4s.testkit.{DockerTests, ElasticMatchers}
 import com.sksamuel.elastic4s.{ElasticDateMath, ElasticDsl, Years}
+import org.scalatest.wordspec.AnyWordSpec
 
 import scala.util.Try
-import org.scalatest.wordspec.AnyWordSpec
 
 class DateRangeQueryHttpTest
   extends AnyWordSpec

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/DateRangeQueryHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/DateRangeQueryHttpTest.scala
@@ -2,12 +2,12 @@ package com.sksamuel.elastic4s.search.queries
 
 import com.sksamuel.elastic4s.testkit.{DockerTests, ElasticMatchers}
 import com.sksamuel.elastic4s.{ElasticDateMath, ElasticDsl, Years}
-import org.scalatest.WordSpec
 
 import scala.util.Try
+import org.scalatest.wordspec.AnyWordSpec
 
 class DateRangeQueryHttpTest
-  extends WordSpec
+  extends AnyWordSpec
     with DockerTests
     with ElasticMatchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/ExistsQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/ExistsQueryTest.scala
@@ -1,10 +1,10 @@
 package com.sksamuel.elastic4s.search.queries
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class ExistsQueryTest extends AnyWordSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/ExistsQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/ExistsQueryTest.scala
@@ -1,11 +1,12 @@
 package com.sksamuel.elastic4s.search.queries
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ExistsQueryTest extends WordSpec with DockerTests with Matchers {
+class ExistsQueryTest extends AnyWordSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/FieldNamesFieldTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/FieldNamesFieldTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.search.queries
 
 import com.sksamuel.elastic4s.ElasticDsl
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class FieldNamesFieldTest extends AnyFlatSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/FieldNamesFieldTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/FieldNamesFieldTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.search.queries
 
 import com.sksamuel.elastic4s.ElasticDsl
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FlatSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class FieldNamesFieldTest extends FlatSpec with Matchers with DockerTests {
+class FieldNamesFieldTest extends AnyFlatSpec with Matchers with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/IdQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/IdQueryTest.scala
@@ -2,9 +2,10 @@ package com.sksamuel.elastic4s.search.queries
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class IdQueryTest extends FlatSpec with Matchers with DockerTests {
+class IdQueryTest extends AnyFlatSpec with Matchers with DockerTests {
 
   client.execute {
     createIndex("sodas")

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/MatchQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/MatchQueryTest.scala
@@ -2,12 +2,13 @@ package com.sksamuel.elastic4s.search
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FlatSpec, Matchers}
 
 import scala.util.Try
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class MatchQueryTest
-  extends FlatSpec
+  extends AnyFlatSpec
     with DockerTests
     with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/MatchQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/MatchQueryTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.search
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
 
 class MatchQueryTest
   extends AnyFlatSpec

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/MoreLikeThisQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/MoreLikeThisQueryTest.scala
@@ -5,10 +5,10 @@ import com.sksamuel.elastic4s.requests.analyzers.StandardAnalyzer
 import com.sksamuel.elastic4s.requests.common.{DocumentRef, RefreshPolicy}
 import com.sksamuel.elastic4s.requests.searches.queries.{ArtificialDocument, MoreLikeThisItem}
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class MoreLikeThisQueryTest extends AnyWordSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/MoreLikeThisQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/MoreLikeThisQueryTest.scala
@@ -5,11 +5,12 @@ import com.sksamuel.elastic4s.requests.analyzers.StandardAnalyzer
 import com.sksamuel.elastic4s.requests.common.{DocumentRef, RefreshPolicy}
 import com.sksamuel.elastic4s.requests.searches.queries.{ArtificialDocument, MoreLikeThisItem}
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class MoreLikeThisQueryTest extends WordSpec with Matchers with DockerTests {
+class MoreLikeThisQueryTest extends AnyWordSpec with Matchers with DockerTests {
 
   Try {
     client.execute(

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/NestedQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/NestedQueryTest.scala
@@ -2,10 +2,10 @@ package com.sksamuel.elastic4s.search.queries
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class NestedQueryTest extends AnyWordSpec with DockerTests with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/NestedQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/NestedQueryTest.scala
@@ -2,11 +2,12 @@ package com.sksamuel.elastic4s.search.queries
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class NestedQueryTest extends WordSpec with DockerTests with Matchers {
+class NestedQueryTest extends AnyWordSpec with DockerTests with Matchers {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/RangeQueryHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/RangeQueryHttpTest.scala
@@ -3,9 +3,9 @@ package com.sksamuel.elastic4s.search.queries
 import com.sksamuel.elastic4s.ElasticDsl
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.{DockerTests, ElasticMatchers}
+import org.scalatest.wordspec.AnyWordSpec
 
 import scala.util.Try
-import org.scalatest.wordspec.AnyWordSpec
 
 class RangeQueryHttpTest
   extends AnyWordSpec

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/RangeQueryHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/RangeQueryHttpTest.scala
@@ -3,12 +3,12 @@ package com.sksamuel.elastic4s.search.queries
 import com.sksamuel.elastic4s.ElasticDsl
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.{DockerTests, ElasticMatchers}
-import org.scalatest.WordSpec
 
 import scala.util.Try
+import org.scalatest.wordspec.AnyWordSpec
 
 class RangeQueryHttpTest
-  extends WordSpec
+  extends AnyWordSpec
     with DockerTests
     with ElasticMatchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/RawQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/RawQueryTest.scala
@@ -1,11 +1,12 @@
 package com.sksamuel.elastic4s.search.queries
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class RawQueryTest extends WordSpec with Matchers with DockerTests {
+class RawQueryTest extends AnyWordSpec with Matchers with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/RawQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/RawQueryTest.scala
@@ -1,10 +1,10 @@
 package com.sksamuel.elastic4s.search.queries
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class RawQueryTest extends AnyWordSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/TermsLookupQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/TermsLookupQueryTest.scala
@@ -2,10 +2,11 @@ package com.sksamuel.elastic4s.search.queries
 
 import com.sksamuel.elastic4s.requests.common.{DocumentRef, RefreshPolicy}
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class TermsLookupQueryTest
-  extends FlatSpec
+  extends AnyFlatSpec
     with DockerTests
     with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/TermsQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/TermsQueryTest.scala
@@ -2,10 +2,11 @@ package com.sksamuel.elastic4s.search.queries
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class TermsQueryTest
-  extends FlatSpec
+  extends AnyFlatSpec
     with DockerTests
     with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/TermsSetQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/TermsSetQueryTest.scala
@@ -2,10 +2,11 @@ package com.sksamuel.elastic4s.search.queries
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class TermsSetQueryTest
-  extends FlatSpec
+  extends AnyFlatSpec
     with DockerTests
     with Matchers {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/sort/ScriptSortTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/sort/ScriptSortTest.scala
@@ -2,9 +2,9 @@ package com.sksamuel.elastic4s.search.sort
 
 import com.sksamuel.elastic4s.requests.searches.sort.ScriptSortType
 import com.sksamuel.elastic4s.testkit.{DockerTests, ElasticMatchers}
+import org.scalatest.freespec.AnyFreeSpec
 
 import scala.util.Try
-import org.scalatest.freespec.AnyFreeSpec
 
 class ScriptSortTest extends AnyFreeSpec with ElasticMatchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/sort/ScriptSortTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/sort/ScriptSortTest.scala
@@ -2,11 +2,11 @@ package com.sksamuel.elastic4s.search.sort
 
 import com.sksamuel.elastic4s.requests.searches.sort.ScriptSortType
 import com.sksamuel.elastic4s.testkit.{DockerTests, ElasticMatchers}
-import org.scalatest.FreeSpec
 
 import scala.util.Try
+import org.scalatest.freespec.AnyFreeSpec
 
-class ScriptSortTest extends FreeSpec with ElasticMatchers with DockerTests {
+class ScriptSortTest extends AnyFreeSpec with ElasticMatchers with DockerTests {
 
   Try {
     client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/suggestions/TermSuggestionsTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/suggestions/TermSuggestionsTest.scala
@@ -4,10 +4,10 @@ import com.sksamuel.elastic4s.Indexable
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.suggestion.SuggestMode
 import com.sksamuel.elastic4s.testkit.DockerTests
-
-import scala.util.Try
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Try
 
 class TermSuggestionsTest extends AnyWordSpec with Matchers with DockerTests {
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/suggestions/TermSuggestionsTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/suggestions/TermSuggestionsTest.scala
@@ -4,11 +4,12 @@ import com.sksamuel.elastic4s.Indexable
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.requests.searches.suggestion.SuggestMode
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Try
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class TermSuggestionsTest extends WordSpec with Matchers with DockerTests {
+class TermSuggestionsTest extends AnyWordSpec with Matchers with DockerTests {
 
   implicit object SongIndexable extends Indexable[Song] {
     override def json(t: Song): String = s"""{"name":"${t.name}", "artist":"${t.artist}"}"""

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/tasks/GetTaskTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/tasks/GetTaskTest.scala
@@ -2,9 +2,10 @@ package com.sksamuel.elastic4s.tasks
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class GetTaskTest extends WordSpec with Matchers with DockerTests {
+class GetTaskTest extends AnyWordSpec with Matchers with DockerTests {
 
   cleanIndex("get_task_a")
   cleanIndex("get_task_b")

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/tasks/TasksTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/tasks/TasksTest.scala
@@ -1,9 +1,10 @@
 package com.sksamuel.elastic4s.tasks
 
 import com.sksamuel.elastic4s.testkit.DockerTests
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class TasksTest extends FlatSpec with DockerTests with Matchers {
+class TasksTest extends AnyFlatSpec with DockerTests with Matchers {
 
   "list tasks" should "include all fields" in {
 


### PR DESCRIPTION
Depends on changes in several other PRs.