### PR TITLE
[6.1.x] Add support for include_in_root|parent settings for nested fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,4 @@ script:
 - sbt clean scalafmtCheck scalafmtSbtCheck test
 
 jdk:
-- oraclejdk8
+- openjdk8

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/delete/DeleteByQueryDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/delete/DeleteByQueryDefinition.scala
@@ -30,6 +30,7 @@ case class DeleteByQueryDefinition(indexesAndTypes: IndexesAndTypes,
   def routing(routing: String): DeleteByQueryDefinition = copy(routing = routing.some)
 
   def refresh(refresh: RefreshPolicy): DeleteByQueryDefinition = copy(refresh = refresh.some)
+
   def refreshImmediately: DeleteByQueryDefinition = refresh(RefreshPolicy.IMMEDIATE)
 
   def scrollSize(scrollSize: Int): DeleteByQueryDefinition = copy(scrollSize = scrollSize.some)

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/CommonFieldBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/CommonFieldBuilder.scala
@@ -108,6 +108,8 @@ object FieldBuilderFn {
 
       case nested: NestedFieldDefinition =>
         nested.dynamic.foreach(builder.field("dynamic", _))
+        nested.includeInParent.foreach(builder.field("include_in_parent", _))
+        nested.includeInRoot.foreach(builder.field("include_in_root", _))
 
       case text: TextFieldDefinition =>
         text.eagerGlobalOrdinals.foreach(builder.field("eager_global_ordinals", _))

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/NestedFieldDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/NestedFieldDefinition.scala
@@ -47,12 +47,14 @@ case class NestedFieldDefinition(name: String,
   override def includeInAll(includeInAll: Boolean): T = copy(includeInAll = includeInAll.some)
 
   @deprecated(
-    "This setting was removed from the Elasticsearch documentation in version 2.0. See the following discussion regarding removing support in a future version of elasticsearch: https://github.com/elastic/elasticsearch/issues/12461"
+    "This setting was removed from the Elasticsearch documentation in version 2.0. See the following discussion regarding removing support in a future version of elasticsearch: https://github.com/elastic/elasticsearch/issues/12461",
+    "2.0"
   )
   def includeInParent(includeInParent: Boolean): T = copy(includeInParent = includeInParent.some)
 
   @deprecated(
-    "This setting was removed from the Elasticsearch documentation in version 2.0. See the following discussion regarding removing support in a future version of elasticsearch: https://github.com/elastic/elasticsearch/issues/12461"
+    "This setting was removed from the Elasticsearch documentation in version 2.0. See the following discussion regarding removing support in a future version of elasticsearch: https://github.com/elastic/elasticsearch/issues/12461",
+    "2.0"
   )
   def includeInRoot(includeInRoot: Boolean): T = copy(includeInRoot = includeInRoot.some)
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/NestedFieldDefinition.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/mappings/NestedFieldDefinition.scala
@@ -10,6 +10,8 @@ case class NestedFieldDefinition(name: String,
                                  dynamic: Option[String] = None,
                                  enabled: Option[Boolean] = None,
                                  includeInAll: Option[Boolean] = None,
+                                 includeInParent: Option[Boolean] = None,
+                                 includeInRoot: Option[Boolean] = None,
                                  index: Option[String] = None,
                                  indexOptions: Option[String] = None,
                                  fields: Seq[FieldDefinition] = Nil,
@@ -43,6 +45,16 @@ case class NestedFieldDefinition(name: String,
   override def enabled(enabled: Boolean): T = copy(enabled = enabled.some)
 
   override def includeInAll(includeInAll: Boolean): T = copy(includeInAll = includeInAll.some)
+
+  @deprecated(
+    "This setting was removed from the Elasticsearch documentation in version 2.0. See the following discussion regarding removing support in a future version of elasticsearch: https://github.com/elastic/elasticsearch/issues/12461"
+  )
+  def includeInParent(includeInParent: Boolean): T = copy(includeInParent = includeInParent.some)
+
+  @deprecated(
+    "This setting was removed from the Elasticsearch documentation in version 2.0. See the following discussion regarding removing support in a future version of elasticsearch: https://github.com/elastic/elasticsearch/issues/12461"
+  )
+  def includeInRoot(includeInRoot: Boolean): T = copy(includeInRoot = includeInRoot.some)
 
   override def index(index: Boolean): T = copy(index = index.toString.some)
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/mappings/NestedFieldDefinitionTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/mappings/NestedFieldDefinitionTest.scala
@@ -1,0 +1,29 @@
+package com.sksamuel.elastic4s.mappings
+
+import com.sksamuel.elastic4s.ElasticApi
+import org.scalatest.{FlatSpec, Matchers}
+
+class NestedFieldDefinitionTest extends FlatSpec with Matchers with ElasticApi {
+
+  val field: NestedFieldDefinition = nestedField("myfield")
+
+  "A NestedField" should "support boolean dynamic property" in {
+    FieldBuilderFn(field.dynamic(true)).string() shouldBe
+      """{"type":"nested","dynamic":"true"}"""
+  }
+
+  it should "support string dynamic property" in {
+    FieldBuilderFn(field.dynamic("strict")).string() shouldBe
+      """{"type":"nested","dynamic":"strict"}"""
+  }
+
+  it should "support include_in_root property" in {
+    FieldBuilderFn(field.includeInRoot(true)).string() shouldBe
+      """{"type":"nested","include_in_root":true}"""
+  }
+
+  it should "support include_in_parent property" in {
+    FieldBuilderFn(field.includeInParent(true)).string() shouldBe
+      """{"type":"nested","include_in_parent":true}"""
+  }
+}

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/DateRangeQueryHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/DateRangeQueryHttpTest.scala
@@ -42,7 +42,7 @@ class DateRangeQueryHttpTest
     "support date math for gte" in {
       val resp = http.execute {
         search("daterange") query {
-          rangeQuery("premiere_date").gte(ElasticDateMath("now").minus(5, Years))
+          rangeQuery("premiere_date").gte(ElasticDateMath("16/12/2017").minus(5, Years))
         }
       }.await.right.get.result
       resp.totalHits shouldBe 3


### PR DESCRIPTION
Backport of https://github.com/sksamuel/elastic4s/pull/1994

Took the liberty to fix a failing (non related) test and build. Hope it's ok