### PR TITLE
[7.1.x] Add support for include_in_root|parent settings for nested fields

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/mappings/CommonFieldBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/mappings/CommonFieldBuilder.scala
@@ -109,6 +109,8 @@ object FieldBuilderFn {
 
       case nested: NestedField =>
         nested.dynamic.foreach(builder.field("dynamic", _))
+        nested.includeInParent.foreach(builder.field("include_in_parent", _))
+        nested.includeInRoot.foreach(builder.field("include_in_root", _))
 
       case text: TextField =>
         text.eagerGlobalOrdinals.foreach(builder.field("eager_global_ordinals", _))

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/mappings/NestedField.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/mappings/NestedField.scala
@@ -10,6 +10,8 @@ case class NestedField(name: String,
                        dynamic: Option[String] = None,
                        enabled: Option[Boolean] = None,
                        includeInAll: Option[Boolean] = None,
+                       includeInParent: Option[Boolean] = None,
+                       includeInRoot: Option[Boolean] = None,
                        index: Option[String] = None,
                        indexOptions: Option[String] = None,
                        fields: Seq[FieldDefinition] = Nil,
@@ -43,6 +45,18 @@ case class NestedField(name: String,
   override def enabled(enabled: Boolean): T = copy(enabled = enabled.some)
 
   override def includeInAll(includeInAll: Boolean): T = copy(includeInAll = includeInAll.some)
+
+  @deprecated(
+    "This setting was removed from the Elasticsearch documentation in version 2.0. See the following discussion regarding removing support in a future version of elasticsearch: https://github.com/elastic/elasticsearch/issues/12461",
+    "2.0"
+  )
+  def includeInParent(includeInParent: Boolean): T = copy(includeInParent = includeInParent.some)
+
+  @deprecated(
+    "This setting was removed from the Elasticsearch documentation in version 2.0. See the following discussion regarding removing support in a future version of elasticsearch: https://github.com/elastic/elasticsearch/issues/12461",
+    "2.0"
+  )
+  def includeInRoot(includeInRoot: Boolean): T = copy(includeInRoot = includeInRoot.some)
 
   override def index(index: Boolean): T = copy(index = index.toString.some)
 

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/mappings/NestedFieldTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/mappings/NestedFieldTest.scala
@@ -1,0 +1,29 @@
+package com.sksamuel.elastic4s.requests.mappings
+
+import com.sksamuel.elastic4s.ElasticApi
+import org.scalatest.{FlatSpec, Matchers}
+
+class NestedFieldTest extends FlatSpec with Matchers with ElasticApi {
+
+  val field: NestedField = nestedField("myfield")
+
+  "A NestedField" should "support boolean dynamic property" in {
+    FieldBuilderFn(field.dynamic(true)).string() shouldBe
+      """{"type":"nested","dynamic":"true"}"""
+  }
+
+  it should "support string dynamic property" in {
+    FieldBuilderFn(field.dynamic("strict")).string() shouldBe
+      """{"type":"nested","dynamic":"strict"}"""
+  }
+
+  it should "support include_in_root property" in {
+    FieldBuilderFn(field.includeInRoot(true)).string() shouldBe
+      """{"type":"nested","include_in_root":true}"""
+  }
+
+  it should "support include_in_parent property" in {
+    FieldBuilderFn(field.includeInParent(true)).string() shouldBe
+      """{"type":"nested","include_in_parent":true}"""
+  }
+}


### PR DESCRIPTION
Port of #1994

Build is failing here on unrelated tests for `aws` module.
They pass on 7.0.x, but I didn't manage to find when exactly they broke.