### PR TITLE
[backport] Support geo-location in completion suggester

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/queries/funcscorer/Origin.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/queries/funcscorer/Origin.scala
@@ -1,0 +1,13 @@
+package com.sksamuel.elastic4s.searches.queries.funcscorer
+
+import com.sksamuel.elastic4s.searches.GeoPoint
+
+sealed trait Origin
+case class GeoPointOrigin(origin: GeoPoint) extends Origin
+
+case class StringOrigin(origin: String) extends Origin
+
+object Origin {
+  implicit def fromString(origin: String): StringOrigin = StringOrigin(origin)
+  implicit def fromGeoPoint(origin: GeoPoint): GeoPointOrigin = GeoPointOrigin(origin)
+}

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/suggestion/CompletionSuggestion.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/searches/suggestion/CompletionSuggestion.scala
@@ -1,6 +1,7 @@
 package com.sksamuel.elastic4s.searches.suggestion
 
 import com.sksamuel.elastic4s.searches.queries.RegexpFlag
+import com.sksamuel.elastic4s.searches.GeoPoint
 import com.sksamuel.exts.OptionImplicits._
 
 sealed trait Fuzziness
@@ -34,7 +35,7 @@ case class CompletionSuggestion(name: String,
                                 unicodeAware: Option[Boolean] = None,
                                 skipDuplicates: Option[Boolean] = None,
                                 text: Option[String] = None,
-                                contexts: Map[String, Seq[CategoryContext]] = Map.empty)
+                                contexts: Map[String, Seq[CompletionContext]] = Map.empty)
     extends Suggestion {
 
   def regex(regex: String): CompletionSuggestion               = copy(regex = regex.some)
@@ -49,12 +50,12 @@ case class CompletionSuggestion(name: String,
   def skipDuplicates(skipDuplicates: Boolean): CompletionSuggestion =
     copy(skipDuplicates = skipDuplicates.some)
 
-  def context(name: String, context: CategoryContext): CompletionSuggestion = contexts(name, Seq(context))
-  def contexts(name: String, contexts: Seq[CategoryContext]): CompletionSuggestion =
+  def context(name: String, context: CompletionContext): CompletionSuggestion = contexts(name, Seq(context))
+  def contexts(name: String, contexts: Seq[CompletionContext]): CompletionSuggestion =
     copy(contexts = this.contexts + (name -> contexts))
 
   // adds more contexts to this query
-  def contexts(map: Map[String, Seq[CategoryContext]]): CompletionSuggestion =
+  def contexts(map: Map[String, Seq[CompletionContext]]): CompletionSuggestion =
     copy(contexts = this.contexts ++ map)
 
   def prefix(prefix: String): CompletionSuggestion = copy(prefix = prefix.some)
@@ -75,4 +76,6 @@ case class CompletionSuggestion(name: String,
       unicodeAware.isDefined
 }
 
-case class CategoryContext(name: String, boost: Double = 1, prefix: Boolean = false)
+sealed trait CompletionContext
+case class CategoryContext(name: String, boost: Double = 1, prefix: Boolean = false) extends CompletionContext
+case class GeoContext(geoPoint: GeoPoint, precision: String, boost: Double = 1) extends CompletionContext

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/suggs/CompletionSuggestionBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/suggs/CompletionSuggestionBuilderFn.scala
@@ -3,6 +3,8 @@ package com.sksamuel.elastic4s.http.search.suggs
 import com.sksamuel.elastic4s.http.EnumConversions
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 import com.sksamuel.elastic4s.searches.suggestion.CompletionSuggestion
+import com.sksamuel.elastic4s.searches.suggestion.GeoContext
+import com.sksamuel.elastic4s.searches.suggestion.CategoryContext
 
 object CompletionSuggestionBuilderFn {
 
@@ -49,9 +51,19 @@ object CompletionSuggestionBuilderFn {
           builder.startArray(key)
           value.foreach { context =>
             builder.startObject()
-            builder.field("context", context.name)
-            builder.field("boost", context.boost)
-            builder.field("prefix", context.prefix)
+            context match {
+              case CategoryContext(name, boost, prefix) =>
+                builder.field("context", name)
+                builder.field("boost", boost)
+                builder.field("prefix", prefix)
+              case GeoContext(geoPoint, precision, boost) =>
+                builder.startObject("context")
+                builder.field("lat", geoPoint.lat)
+                builder.field("lon", geoPoint.long)
+                builder.endObject()
+                builder.field("boost", boost)
+                builder.field("precision", precision)
+            }
             builder.endObject()
           }
           builder.endArray()


### PR DESCRIPTION
Elasitcsearch support "geo" and "category" contexts, but elatic4s supports only the latter.
This patch adds geo support.
A similar pull request https://github.com/sksamuel/elastic4s/pull/1610 was merged into the 7.x branches, but the feature is not available for v6.7.