### PR TITLE
Support dense_vector field type in mappings

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/fields/fields.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/fields/fields.scala
@@ -367,4 +367,28 @@ case class IpField(name: String,
                    properties: Seq[ElasticField] = Nil,
                    store: Option[Boolean] = None) extends ElasticField
 
+case class DenseVectorField(name: String,
+                            dims: Int,
+                            analysis: Analysis = Analysis(),
+                            boost: Option[Double] = None,
+                            coerce: Option[Boolean] = None,
+                            copyTo: Seq[String] = Nil,
+                            docValues: Option[Boolean] = None,
+                            enabled: Option[Boolean] = None,
+                            fielddata: Option[Boolean] = None,
+                            fields: Seq[ElasticField] = Nil,
+                            format: Option[String] = None,
+                            includeInAll: Option[Boolean] = None,
+                            ignoreAbove: Option[Int] = None,
+                            ignoreMalformed: Option[Boolean] = None,
+                            index: Option[String] = None,
+                            indexOptions: Option[String] = None,
+                            norms: Option[Boolean] = None,
+                            nulls: Nulls = Nulls(),
+                            scalingFactor: Option[Double] = None,
+                            similarity: Option[String] = None,
+                            store: Option[Boolean] = None,
+                            termVector: Option[String] = None)
+  extends ElasticField
+
 case class IndexPrefixes(minChars: Int, maxChars: Int)

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/TypesApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/TypesApi.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.elastic4s.requests
 
-import com.sksamuel.elastic4s.requests.mappings.{BasicField, CompletionField, GeoshapeField, JoinField, KeywordField, NestedField, ObjectField, RangeField, SearchAsYouTypeField, TextField}
+import com.sksamuel.elastic4s.requests.mappings.{BasicField, CompletionField, DenseVectorField, GeoshapeField, JoinField, KeywordField, NestedField, ObjectField, RangeField, SearchAsYouTypeField, TextField}
 import com.sksamuel.elastic4s.requests.script.{Script, ScriptField}
 
 trait TypesApi {
@@ -53,6 +53,8 @@ trait TypesApi {
   def tokenCountField(name: String): BasicField      = BasicField(name, "token_count")
   def percolatorField(name: String): BasicField      = BasicField(name, "percolator")
   def joinField(name: String): JoinField             = JoinField(name)
+
+  def denseVectorField(name: String, dims: Int): DenseVectorField = DenseVectorField(name, dims)
 
   def scriptField(name: String, script: String): ScriptField = ScriptField(name, script)
   def scriptField(name: String, script: Script): ScriptField = ScriptField(name, script)

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/mappings/CommonFieldBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/mappings/CommonFieldBuilder.scala
@@ -145,6 +145,8 @@ object FieldBuilderFn {
         range.coerce.foreach(builder.field("coerce", _))
         range.format.foreach(builder.field("format", _))
         range.similarity.foreach(builder.field("similarity", _))
+      case denseVector: DenseVectorField =>
+        builder.field("dims", denseVector.dims)
     }
     builder.endObject()
     builder

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/mappings/DenseVectorField.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/mappings/DenseVectorField.scala
@@ -1,0 +1,69 @@
+package com.sksamuel.elastic4s.requests.mappings
+
+import com.sksamuel.exts.OptionImplicits._
+
+case class DenseVectorField(name: String,
+                            dims: Int,
+                            analysis: Analysis = Analysis(),
+                            boost: Option[Double] = None,
+                            coerce: Option[Boolean] = None,
+                            copyTo: Seq[String] = Nil,
+                            docValues: Option[Boolean] = None,
+                            enabled: Option[Boolean] = None,
+                            fielddata: Option[Boolean] = None,
+                            fields: Seq[FieldDefinition] = Nil,
+                            format: Option[String] = None,
+                            includeInAll: Option[Boolean] = None,
+                            ignoreAbove: Option[Int] = None,
+                            ignoreMalformed: Option[Boolean] = None,
+                            index: Option[String] = None,
+                            indexOptions: Option[String] = None,
+                            norms: Option[Boolean] = None,
+                            nulls: Nulls = Nulls(),
+                            scalingFactor: Option[Double] = None,
+                            similarity: Option[String] = None,
+                            store: Option[Boolean] = None,
+                            termVector: Option[String] = None)
+  extends FieldDefinition {
+
+  type T = DenseVectorField
+
+  override def `type` = "dense_vector"
+
+  override def analyzer(analyzer: String): T       = copy(analysis = analysis.copy(analyzer = analyzer.some))
+  override def normalizer(normalizer: String): T   = copy(analysis = analysis.copy(normalizer = normalizer.some))
+  override def searchAnalyzer(analyzer: String): T = copy(analysis = analysis.copy(searchAnalyzer = analyzer.some))
+
+  override def boost(boost: Double): T          = copy(boost = boost.some)
+  override def docValues(docValues: Boolean): T = copy(docValues = docValues.some)
+
+  override def fields(fields: Iterable[FieldDefinition]): T = copy(fields = fields.toSeq)
+
+  def coerce(coerce: Boolean): T                       = copy(coerce = coerce.some)
+  override def copyTo(first: String, rest: String*): T = copyTo(first +: rest)
+  override def copyTo(copyTo: Iterable[String]): T     = copy(copyTo = copyTo.toSeq)
+
+  override def enabled(enabled: Boolean): T = copy(enabled = enabled.some)
+
+  def format(format: String): T = copy(format = format.some)
+
+  def scalingFactor(scalingFactor: Double): T = copy(scalingFactor = scalingFactor.some)
+
+  def similarity(similarity: String): T = copy(similarity = similarity.some)
+
+  def ignoreAbove(ignoreAbove: Int): T                = copy(ignoreAbove = ignoreAbove.some)
+  def ignoreMalformed(ignoreMalformed: Boolean): T    = copy(ignoreMalformed = ignoreMalformed.some)
+  override def includeInAll(includeInAll: Boolean): T = copy(includeInAll = includeInAll.some)
+
+  def fielddata(fielddata: Boolean): T = copy(fielddata = fielddata.some)
+
+  override def index(index: Boolean): T = copy(index = index.toString.some)
+
+  override def norms(norms: Boolean): T       = copy(norms = norms.some)
+  override def nullable(nullable: Boolean): T = copy(nulls = nulls.copy(nullable = nullable.some))
+  override def nullValue(nullvalue: Any): T   = copy(nulls = nulls.copy(nullValue = nullvalue.some))
+
+  override def store(b: Boolean): T = copy(store = b.some)
+
+  override def termVector(t: String): T = copy(termVector = t.some)
+}

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/mappings/DenseVectorFieldTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/mappings/DenseVectorFieldTest.scala
@@ -1,0 +1,15 @@
+package com.sksamuel.elastic4s.requests.mappings
+
+import com.sksamuel.elastic4s.ElasticApi
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class DenseVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
+
+  private val field = DenseVectorField(name = "myfield", dims = 3)
+
+  "A DenseVectorField" should "support dims property" in {
+    FieldBuilderFn(field).string() shouldBe
+      """{"type":"dense_vector","dims":3}"""
+  }
+}


### PR DESCRIPTION
Hi,

We need support for a [dense_vector](https://www.elastic.co/guide/en/elasticsearch/reference/current/dense-vector.html) field type in our mapping definition. This is a pretty basic attempt at providing that.
My knowledge of both elastic4s and elasticsearch isn't great, so apologies if this doesn't make completely sense. I'm happy to change if need be.
