### PR TITLE
Update basic setup in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,24 +82,7 @@ The DSL methods are located in the `ElasticDsl` trait which needs to be imported
 import com.sksamuel.elastic4s.ElasticDsl._
 ```
 
-### Alternative Executors
-The default `Executor` uses scala `Future`s to execute requests, but there are alternate Executors that can be used by
-adding appropriate imports. The imports will create an implicit `Executor[F]` and a `Functor[F]`,
-where `F` is some effect type.
-
-#### Cats-Effect IO
-`import com.sksamuel.elastic4s.cats.effect.instances._` will provide implicit instances for `cats.effect.IO`
-
-#### Monix Task
-`import com.sksamuel.elastic4s.monix.instances._` will provide implicit instances for `monix.eval.Task`
-
-#### Scalaz Task
-`import com.sksamuel.elastic4s.scalaz.instances._` will provide implicit instances for `scalaz.concurrent.Task`
-
-#### ZIO Task
-`import com.sksamuel.elastic4s.zio.instances._` will provide implicit instances for `zio.Task`
-
-### Simple SBT Setup
+### SBT Setup
 
 ```scala
 // major.minor are in sync with the elasticsearch releases
@@ -112,7 +95,39 @@ libraryDependencies ++= Seq(
 )
 ```
 
-### Example Application
+## Connecting to a Cluster
+
+To connect to a standalone ElasticSearch cluster, pass a `JavaClient` to an `ElasticClient`. You can specify protocol,
+host, and port in a single string.
+
+```scala
+val client = ElasticClient(JavaClient(ElasticProperties("http://host1:9200")))
+```
+
+For multiple nodes you can pass a comma-separated list of endpoints in a single string:
+
+```scala
+val nodes ="http://host1:9200,http://host2:9200,http://host3:9200"
+val client = ElasticClient(JavaClient(ElasticProperties(nodes)))
+```
+
+### Using different clients
+
+It is possible to use Akka HTTP in place of the Java client in order to connect to a cluster:
+
+Add the following to your `built.sbt`, replace `x.x.x` with your version of ElasticSearch:
+
+```scala
+libraryDependencies += "com.sksamuel.elastic4s" % "elastic4s-client-akka_2.13" % "x.x.x"
+```
+
+And then you can use the `AkkaHttpClient` in your code:
+
+```scala
+val client = ElasticClient(AkkaHttpClient("http://host1:9200"))
+```
+
+## Example Application
 
 An example is worth 1000 characters so here is a quick example of how to connect to a node with a client, create an
 index and index a one field document. Then we will search for that document using a simple text query.
@@ -174,6 +189,26 @@ object ArtistIndex extends App {
 }
 ```
 
+
+## Alternative Executors
+
+The default `Executor` uses scala `Future`s to execute requests, but there are alternate Executors that can be used by
+adding appropriate imports. The imports will create an implicit `Executor[F]` and a `Functor[F]`,
+where `F` is some effect type.
+
+### Cats-Effect IO
+`import com.sksamuel.elastic4s.cats.effect.instances._` will provide implicit instances for `cats.effect.IO`
+
+### Monix Task
+`import com.sksamuel.elastic4s.monix.instances._` will provide implicit instances for `monix.eval.Task`
+
+### Scalaz Task
+`import com.sksamuel.elastic4s.scalaz.instances._` will provide implicit instances for `scalaz.concurrent.Task`
+
+### ZIO Task
+`import com.sksamuel.elastic4s.zio.instances._` will provide implicit instances for `zio.Task`
+
+
 ## Near Real-time search results
 
 When you index a document in Elasticsearch, it is not normally immediately available to be searched, as a refresh has to happen to make it available for the search API. By default a refresh occurs every second but this can be increased if needed. Note that this impacts only the visibility of newly indexed documents when using the search API and has nothing
@@ -183,37 +218,6 @@ You shouldn't use IMMEDIATE for heavy loads as you'll cause contention with Elas
 
 For more in depth examples keep reading.
 
-## Connecting to a Cluster
-
-To connect to a standalone ElasticSearch cluster, pass a `JavaClient` to an `ElasticClient`. You can specify protocol,
-host, and port in a single string.
-
-```scala
-val client = ElasticClient(JavaClient(ElasticProperties("http://host1:9200")))
-```
-
-For multiple nodes you can pass a comma-separated list of endpoints in a single string:
-
-```scala
-val nodes ="http://host1:9200,http://host2:9200,http://host3:9200"
-val client = ElasticClient(JavaClient(ElasticProperties(nodes)))
-```
-
-### Using different clients
-
-It is possible to use Akka HTTP in place of the Java client in order to connect to a cluster:
-
-Add the following to your `built.sbt`, replace `x.x.x` with your version of ElasticSearch:
-
-```scala
-libraryDependencies += "com.sksamuel.elastic4s" % "elastic4s-client-akka_2.13" % "x.x.x"
-```
-
-And then you can use the `AkkaHttpClient` in your code:
-
-```scala
-val client = ElasticClient(AkkaHttpClient("http://host1:9200"))
-```
 
 ## Create Index
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ To get started you will need to add a dependency:
 
 * [elastic4s-client-esjava](https://mvnrepository.com/artifact/com.sksamuel.elastic4s/a:elastic4s-client-esjava)
 
+```scala
+// major.minor are in sync with the elasticsearch releases
+val elastic4sVersion = "x.x.x"
+libraryDependencies ++= Seq(
+  // recommended client for beginners
+  "com.sksamuel.elastic4s" %% "elastic4s-client-esjava" % elastic4sVersion,
+  // test kit
+  "com.sksamuel.elastic4s" %% "elastic4s-testkit" % elastic4sVersion % "test"
+)
+```
+
 The basic usage is that you create an instance of a client and then invoke the `execute` method with the requests you
 want to perform. The execute method is asynchronous and will return a standard Scala `Future[T]`
 (or use one of the [Alternative executors](#alternative-executors)) where T is the response
@@ -82,20 +93,8 @@ The DSL methods are located in the `ElasticDsl` trait which needs to be imported
 import com.sksamuel.elastic4s.ElasticDsl._
 ```
 
-### SBT Setup
 
-```scala
-// major.minor are in sync with the elasticsearch releases
-val elastic4sVersion = "x.x.x"
-libraryDependencies ++= Seq(
-  // recommended client for beginners
-  "com.sksamuel.elastic4s" %% "elastic4s-client-esjava" % elastic4sVersion,
-  // testing
-  "com.sksamuel.elastic4s" %% "elastic4s-testkit" % elastic4sVersion % "test"
-)
-```
-
-## Connecting to a Cluster
+### Connecting to a Cluster
 
 To connect to a standalone ElasticSearch cluster, pass a `JavaClient` to an `ElasticClient`. You can specify protocol,
 host, and port in a single string.
@@ -113,7 +112,8 @@ val client = ElasticClient(JavaClient(ElasticProperties(nodes)))
 
 ### Using different clients
 
-It is possible to use Akka HTTP in place of the Java client in order to connect to a cluster:
+It is possible to use [alternative clients](https://search.maven.org/search?q=g:com.sksamuel.elastic4s%20elastic4s-client)
+in order to connect to a cluster, such as Akka HTTP:
 
 Add the following to your `built.sbt`, replace `x.x.x` with your version of ElasticSearch:
 
@@ -121,7 +121,7 @@ Add the following to your `built.sbt`, replace `x.x.x` with your version of Elas
 libraryDependencies += "com.sksamuel.elastic4s" % "elastic4s-client-akka_2.13" % "x.x.x"
 ```
 
-And then you can use the `AkkaHttpClient` in your code:
+And then pass `AkkaHttpClient` to the object `ElasticClient.apply` method:
 
 ```scala
 val client = ElasticClient(AkkaHttpClient("http://host1:9200"))


### PR DESCRIPTION
PR to address https://github.com/sksamuel/elastic4s/issues/2053

Basic setup documentation fell behind with release of v7. This brings quickstart and relevant classes and dependencies up-to-date.