### PR TITLE
 scala 2.13 cross compile support for the 5.6.x branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,9 @@ before_cache:
 before_script:
 - sudo chmod +x /usr/local/bin/sbt
 scala:
-- 2.11.11
-- 2.12.2
+- 2.11.12
+- 2.12.10
+- 2.13.1
 script:
 - sbt clean test
 jdk:

--- a/elastic4s-http-streams/src/main/scala/com/sksamuel/elastic4s/streams/BulkIndexingSubscriber.scala
+++ b/elastic4s-http-streams/src/main/scala/com/sksamuel/elastic4s/streams/BulkIndexingSubscriber.scala
@@ -253,7 +253,7 @@ class BulkActor[T](client: HttpClient,
   private def index(): Unit = {
 
     def bulkDef: BulkDefinition = {
-      val defs = buffer.map(t => builder.request(t))
+      val defs = buffer.map(t => builder.request(t)).toIndexedSeq
       val policy = if (config.refreshAfterOp) RefreshPolicy.IMMEDIATE else RefreshPolicy.NONE
       BulkDefinition(defs).refresh(policy.name)
     }

--- a/elastic4s-http-streams/src/main/scala/com/sksamuel/elastic4s/streams/ScrollPublisher.scala
+++ b/elastic4s-http-streams/src/main/scala/com/sksamuel/elastic4s/streams/ScrollPublisher.scala
@@ -150,7 +150,7 @@ class PublishActor(client: HttpClient,
     // more results and we can unleash the beast (stashed requests) and switch back to ready mode
     case Success(resp: SearchResponse) =>
       scrollId = resp.scrollId.getOrElse("Query didn't return a scroll id")
-      queue.enqueue(resp.hits.hits: _*)
+      resp.hits.hits.foreach(h => queue.enqueue(h))
       context become ready
       unstashAll()
   }

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/HttpExecutable.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/HttpExecutable.scala
@@ -35,7 +35,7 @@ trait HttpExecutable[T, U] extends Logging {
               params: Map[String, Any],
               handler: ResponseHandler[U]): Future[U] = {
       logger.debug(s"Executing elastic request $method:$endpoint?${params.map { case (k, v) => k + "=" + v }.mkString("&")}")
-      val callback = client.performRequestAsync(method, endpoint, params.mapValues(_.toString).asJava, _: ResponseListener)
+      val callback = client.performRequestAsync(method, endpoint, params.mapValues(_.toString).toMap.asJava, _: ResponseListener)
       future(callback, handler)
     }
 
@@ -53,7 +53,7 @@ trait HttpExecutable[T, U] extends Logging {
         logger.debug(bodyLogged)
       }
 
-      val callback = client.performRequestAsync(method, endpoint, params.mapValues(_.toString).asJava, entity, _: ResponseListener)
+      val callback = client.performRequestAsync(method, endpoint, params.mapValues(_.toString).toMap.asJava, entity, _: ResponseListener)
       future(callback, handler)
     }
   }

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/SearchIterator.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/SearchIterator.scala
@@ -26,15 +26,15 @@ object SearchIterator {
 
     import com.sksamuel.elastic4s.http.ElasticDsl._
 
-    private var iterator: Iterator[SearchHit] = Iterator.empty
+    private var _iterator: Iterator[SearchHit] = Iterator.empty
     private var scrollId: Option[String] = None
 
-    override def hasNext: Boolean = iterator.hasNext || {
-      iterator = fetchNext()
-      iterator.hasNext
+    override def hasNext: Boolean = _iterator.hasNext || {
+      _iterator = fetchNext()
+      _iterator.hasNext
     }
 
-    override def next(): SearchHit = iterator.next()
+    override def next(): SearchHit = _iterator.next()
 
     def fetchNext(): Iterator[SearchHit] = {
 
@@ -47,7 +47,7 @@ object SearchIterator {
       val response = Await.result(future, timeout)
       // in a search scroll we must always use the last returned scrollId
       scrollId = response.scrollId
-      response.hits.hits.iterator
+      response.hits.hits.toIndexedSeq.iterator
     }
   }
 

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/responses.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/search/responses.scala
@@ -6,6 +6,8 @@ import com.sksamuel.elastic4s.http.{Shards, SourceAsContentBuilder}
 import com.sksamuel.elastic4s.http.explain.Explanation
 import com.sksamuel.elastic4s.{Hit, HitReader}
 
+import scala.reflect.ClassTag
+
 case class SearchHit(@JsonProperty("_id") id: String,
                      @JsonProperty("_index") index: String,
                      @JsonProperty("_type") `type`: String,
@@ -52,7 +54,7 @@ case class SearchHit(@JsonProperty("_id") id: String,
           )
         }
       )
-  }
+  }.toMap
 }
 
 case class SearchHits(total: Long,
@@ -195,11 +197,11 @@ case class SearchResponse(took: Int,
 
   private def suggestion(name: String): Map[String, SuggestionResult] = suggest(name).map { result => result.text -> result }.toMap
 
-  def termSuggestion(name: String): Map[String, TermSuggestionResult] = suggestion(name).mapValues(_.toTerm)
-  def completionSuggestion(name: String): Map[String, CompletionSuggestionResult] = suggestion(name).mapValues(_.toCompletion)
-  def phraseSuggestion(name: String): Map[String, PhraseSuggestionResult] = suggestion(name).mapValues(_.toPhrase)
+  def termSuggestion(name: String): Map[String, TermSuggestionResult] = suggestion(name).mapValues(_.toTerm).toMap
+  def completionSuggestion(name: String): Map[String, CompletionSuggestionResult] = suggestion(name).mapValues(_.toCompletion).toMap
+  def phraseSuggestion(name: String): Map[String, PhraseSuggestionResult] = suggestion(name).mapValues(_.toPhrase).toMap
 
-  def to[T: HitReader]: IndexedSeq[T] = hits.hits.map(_.to[T]).toIndexedSeq
+  def to[T: HitReader](implicit c: ClassTag[T]): IndexedSeq[T] = hits.hits.map(_.to[T]).toIndexedSeq
   def safeTo[T: HitReader]: IndexedSeq[Either[Throwable, T]] = hits.hits.map(_.safeTo[T]).toIndexedSeq
 }
 case class AvgAggregationResult(name: String, value: Double)

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/span/SpanNearQueryBodyFnTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/span/SpanNearQueryBodyFnTest.scala
@@ -3,8 +3,6 @@ package com.sksamuel.elastic4s.http.search.queries.span
 import com.sksamuel.elastic4s.searches.queries.span.{SpanNearQueryDefinition, SpanTermQueryDefinition}
 import org.scalatest.FunSuite
 
-import scala.util.parsing.json.JSON
-
 class SpanNearQueryBodyFnTest extends FunSuite {
 
   test("SpanNearQueryBodyFn apply should return appropriate XContentBuilder") {
@@ -16,23 +14,8 @@ class SpanNearQueryBodyFnTest extends FunSuite {
       slop = 42, boost = Some(2.0), inOrder = Some(true), queryName = Some("rootName")
     ))
 
-    val actual = JSON.parseRaw(builder.string())
-    val expected = JSON.parseRaw(
-      """
-        |{
-        |   "span_near":{
-        |     "clauses":[
-        |         {"span_term":{"field1":"value1","boost":4.0,"_name":"name1"}},
-        |         {"span_term":{"field2":"value2","boost":7.0,"_name":"name2"}}
-        |      ],
-        |      "slop":42,
-        |      "in_order":true,
-        |      "boost":2.0,
-        |      "_name":"rootName"
-        |    }
-        |}""".stripMargin)
 
-    assert(actual === expected)
+    assert(builder.string() == """{"span_near":{"clauses":[{"span_term":{"field1":"value1","boost":4.0,"_name":"name1"}},{"span_term":{"field2":"value2","boost":7.0,"_name":"name2"}}],"slop":42,"in_order":true,"boost":2.0,"_name":"rootName"}}""")
   }
 
 }

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/span/SpanOrQueryBodyFnTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/span/SpanOrQueryBodyFnTest.scala
@@ -1,9 +1,7 @@
 package com.sksamuel.elastic4s.http.search.queries.span
 
-import com.sksamuel.elastic4s.searches.queries.span.{SpanNearQueryDefinition, SpanOrQueryDefinition, SpanTermQueryDefinition}
+import com.sksamuel.elastic4s.searches.queries.span.{SpanOrQueryDefinition, SpanTermQueryDefinition}
 import org.scalatest.FunSuite
-
-import scala.util.parsing.json.JSON
 
 class SpanOrQueryBodyFnTest extends FunSuite {
 
@@ -16,21 +14,7 @@ class SpanOrQueryBodyFnTest extends FunSuite {
       boost = Some(2.0), queryName = Some("rootName")
     ))
 
-    val actual = JSON.parseRaw(builder.string())
-    val expected = JSON.parseRaw(
-      """
-        |{
-        |   "span_or":{
-        |     "clauses":[
-        |         {"span_term":{"field1":"value1","boost":4.0,"_name":"name1"}},
-        |         {"span_term":{"field2":"value2","boost":7.0,"_name":"name2"}}
-        |      ],
-        |      "boost":2.0,
-        |      "_name":"rootName"
-        |    }
-        |}""".stripMargin)
-
-    assert(actual === expected)
+    assert(builder.string() == """{"span_or":{"clauses":[{"span_term":{"field1":"value1","boost":4.0,"_name":"name1"}},{"span_term":{"field2":"value2","boost":7.0,"_name":"name2"}}],"boost":2.0,"_name":"rootName"}}""")
   }
 
 }

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/span/XContentBuilderExtensionsTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/search/queries/span/XContentBuilderExtensionsTest.scala
@@ -5,8 +5,6 @@ import org.elasticsearch.common.xcontent.{XContentBuilder, XContentFactory}
 import org.scalatest.FunSuite
 import org.scalatest.Matchers._
 
-import scala.util.parsing.json.JSON
-
 class XContentBuilderExtensionsTest extends FunSuite {
 
   test("RichXContentBuilder.addArray should not write bytes for empty array") {
@@ -15,9 +13,7 @@ class XContentBuilderExtensionsTest extends FunSuite {
     builder.addArray("arrayField", Seq())
     builder.endObject()
 
-    val actual = JSON.parseRaw(builder.string())
-    val expected = JSON.parseRaw("""{"arrayField": []}""")
-    assert(actual === expected)
+    assert(builder.string() === """{"arrayField":[]}""")
   }
 
   test("RichXContentBuilder.addArray should write bytes array with one element") {
@@ -26,9 +22,7 @@ class XContentBuilderExtensionsTest extends FunSuite {
     builder.addArray("arrayField", Seq(buildSimpleObject("f1", "v1")))
     builder.endObject()
 
-    val actual = JSON.parseRaw(builder.string())
-    val expected = JSON.parseRaw("""{"arrayField": [{"f1": "v1"}]}""")
-    assert(actual === expected)
+    assert(builder.string === """{"arrayField":[{"f1":"v1"}]}""")
   }
 
   test("RichXContentBuilder.addArray should write bytes array with many elements") {
@@ -41,15 +35,8 @@ class XContentBuilderExtensionsTest extends FunSuite {
     ))
     builder.endObject()
 
-    val actual = JSON.parseRaw(builder.string())
-    val expected = JSON.parseRaw(
-      """{
-        |  "arrayField": [
-        |    {"f1": "v1"},
-        |    {"f2": "v2"},
-        |    {"f3": "v3"}
-        |  ]
-        |}""".stripMargin)
+    val actual = builder.string()
+    val expected ="""{"arrayField":[{"f1":"v1"},{"f2":"v2"},{"f3":"v3"}]}"""
     assert(actual === expected)
   }
 

--- a/elastic4s-streams/src/main/scala/com/sksamuel/elastic4s/streams/BulkIndexingSubscriber.scala
+++ b/elastic4s-streams/src/main/scala/com/sksamuel/elastic4s/streams/BulkIndexingSubscriber.scala
@@ -255,7 +255,7 @@ class BulkActor[T](client: TcpClient,
   private def index(): Unit = {
 
     def bulkDef: BulkDefinition = {
-      val defs = buffer.map(t => builder.request(t))
+      val defs = buffer.map(t => builder.request(t)).toIndexedSeq
       val policy = if (config.refreshAfterOp) RefreshPolicy.IMMEDIATE else RefreshPolicy.NONE
       BulkDefinition(defs).refresh(policy.name)
     }

--- a/elastic4s-streams/src/main/scala/com/sksamuel/elastic4s/streams/ScrollPublisher.scala
+++ b/elastic4s-streams/src/main/scala/com/sksamuel/elastic4s/streams/ScrollPublisher.scala
@@ -149,7 +149,7 @@ class PublishActor(client: TcpClient,
     // more results and we can unleash the beast (stashed requests) and switch back to ready mode
     case Success(resp: RichSearchResponse) =>
       scrollId = resp.scrollId
-      queue.enqueue(resp.hits: _*)
+      resp.hits.foreach(h=>queue.enqueue(h))
       context become ready
       unstashAll()
   }

--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/admin/ShardSegments.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/admin/ShardSegments.scala
@@ -8,6 +8,6 @@ case class ShardSegments(original: org.elasticsearch.action.admin.indices.segmen
 
   def numberOfCommitted: Integer = original.getNumberOfCommitted
   def numberOfSearch: Integer = original.getNumberOfSearch
-  def segments: Seq[Segment] = Option(original.getSegments).map(_.asScala).getOrElse(Nil)
+  def segments: Seq[Segment] = Option(original.getSegments).map(_.asScala).getOrElse(Nil).toIndexedSeq
   def shardRouting = original.getShardRouting
 }

--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/alias/GetAliasResult.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/alias/GetAliasResult.scala
@@ -8,6 +8,6 @@ import scala.collection.JavaConverters._
 case class GetAliasResult(response: GetAliasesResponse) {
 
   def aliases: Map[String, Seq[AliasMetaData]] = {
-    response.getAliases.keysIt().asScala.map(key => key -> response.getAliases.get(key).asScala).toMap
+    response.getAliases.keysIt().asScala.map(key => key -> response.getAliases.get(key).asScala.toIndexedSeq).toMap
   }
 }

--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/get/RichGetField.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/get/RichGetField.scala
@@ -8,7 +8,7 @@ case class RichGetField(original: GetField) extends HitField {
 
   override def name: String = original.getName
   override def value: AnyRef = original.getValue
-  override def values: Seq[AnyRef] = original.getValues.asScala
+  override def values: Seq[AnyRef] = original.getValues.asScala.toIndexedSeq
   override def isMetadataField: Boolean = original.isMetadataField
 
   def iterator: Iterator[AnyRef] = original.iterator.asScala

--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/get/RichGetResponse.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/get/RichGetResponse.scala
@@ -42,7 +42,7 @@ case class RichGetResponse(original: GetResponse) extends Hit {
   private def getFieldToHitField(f: GetField) = new HitField {
     override def name: String = f.getName
     override def value: AnyRef = f.getValue
-    override def values: Seq[AnyRef] = Option(f.getValues).map(_.asScala).getOrElse(Nil)
+    override def values: Seq[AnyRef] = Option(f.getValues).map(_.asScala).getOrElse(Nil).toIndexedSeq
     override def isMetadataField: Boolean = f.isMetadataField
   }
 
@@ -54,7 +54,7 @@ case class RichGetResponse(original: GetResponse) extends Hit {
 
   @deprecated("use sourceAsMap instead", "5.0.0")
   def fields: Map[String, HitField] = {
-    Option(original.getFields).fold(Map.empty[String, HitField])(_.asScala.toMap.mapValues(getFieldToHitField))
+    Option(original.getFields).fold(Map.empty[String, HitField])(_.asScala.toMap.mapValues(getFieldToHitField).toMap)
   }
 
   @deprecated("use .sourceAsMap", "5.0.0")

--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/RichMultiSearchResponse.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/RichMultiSearchResponse.scala
@@ -3,6 +3,8 @@ package com.sksamuel.elastic4s.searches
 import com.sksamuel.elastic4s.HitReader
 import org.elasticsearch.action.search.MultiSearchResponse
 
+import scala.reflect.ClassTag
+
 case class RichMultiSearchResponse(original: MultiSearchResponse) {
 
   def size: Int = responses.size
@@ -12,7 +14,7 @@ case class RichMultiSearchResponse(original: MultiSearchResponse) {
   // returns all the matches as a single sequence, dropping errors.
   // if you wish to retain errors use safeTo
   // if you wish to return the seq of seq, then use responses and map individually
-  def to[T: HitReader]: Seq[T] = responses.flatMap(_.to[T])
+  def to[T: HitReader](implicit c: ClassTag[T]): Seq[T] = responses.flatMap(_.to[T])
 
   // returns all the matches as a single sequence
   // if you wish to return the seq of seq, then use responses and map individually

--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/RichMultiSearchResponseItem.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/RichMultiSearchResponseItem.scala
@@ -3,6 +3,8 @@ package com.sksamuel.elastic4s.searches
 import com.sksamuel.elastic4s.HitReader
 import org.elasticsearch.action.search.MultiSearchResponse
 
+import scala.reflect.ClassTag
+
 case class RichMultiSearchResponseItem(item: MultiSearchResponse.Item) {
 
   def isFailure: Boolean = item.isFailure
@@ -17,6 +19,6 @@ case class RichMultiSearchResponseItem(item: MultiSearchResponse.Item) {
   def response: RichSearchResponse = RichSearchResponse(item.getResponse)
   def responseOpt: Option[RichSearchResponse] = Option(item.getResponse).map(RichSearchResponse.apply)
 
-  def to[T: HitReader]: IndexedSeq[T] = response.to[T]
+  def to[T: HitReader](implicit c: ClassTag[T]): IndexedSeq[T] = response.to[T]
   def safeTo[T: HitReader]: IndexedSeq[Either[Throwable, T]] = response.safeTo[T]
 }

--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/RichSearchHit.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/RichSearchHit.scala
@@ -27,7 +27,7 @@ case class RichSearchHit(java: SearchHit) extends Hit {
   def explanation: Option[Explanation] = Option(java.getExplanation)
 
   def fields: Map[String, RichSearchHitField] =
-    Option(java.getFields).map(_.asScala.toMap).getOrElse(Map.empty).mapValues(RichSearchHitField)
+    Option(java.getFields).map(_.asScala.toMap).getOrElse(Map.empty).mapValues(RichSearchHitField).toMap
 
   def stringValue(fieldName: String): String = field(fieldName).value.toString
 

--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/RichSearchResponse.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/RichSearchResponse.scala
@@ -12,6 +12,7 @@ import org.elasticsearch.search.aggregations.InternalAggregations
 import org.elasticsearch.search.suggest.Suggest
 
 import scala.concurrent.duration._
+import scala.reflect.ClassTag
 
 case class RichSearchResponse(original: SearchResponse) {
 
@@ -22,7 +23,9 @@ case class RichSearchResponse(original: SearchResponse) {
 
   def hits: Array[RichSearchHit] = original.getHits.getHits.map(RichSearchHit.apply)
 
-  def to[T: HitReader]: IndexedSeq[T] = hits.map(_.to[T]).toIndexedSeq
+  def to[T: HitReader](implicit c: ClassTag[T]): IndexedSeq[T] = {
+    hits.map(_.to[T]).toIndexedSeq
+  }
   def safeTo[T: HitReader]: IndexedSeq[Either[Throwable, T]] = hits.map(_.safeTo[T]).toIndexedSeq
 
   def scrollId: String = original.getScrollId

--- a/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/suggestions/suggestions.scala
+++ b/elastic4s-tcp/src/main/scala/com/sksamuel/elastic4s/searches/suggestions/suggestions.scala
@@ -44,19 +44,19 @@ object SuggestionResult {
 case class TermSuggestionResult(suggestion: TermSuggestion) extends SuggestionResult {
   type R = TermSuggestion
   type E = TermSuggestionEntry
-  def entries: Seq[TermSuggestionEntry] = suggestion.getEntries.asScala.map(TermSuggestionEntry)
+  def entries: Seq[TermSuggestionEntry] = suggestion.getEntries.asScala.map(TermSuggestionEntry).toIndexedSeq
 }
 
 case class PhraseSuggestionResult(suggestion: PhraseSuggestion) extends SuggestionResult {
   type R = PhraseSuggestion
   type E = PhraseSuggestionEntry
-  def entries: Seq[PhraseSuggestionEntry] = suggestion.getEntries.asScala.map(PhraseSuggestionEntry)
+  def entries: Seq[PhraseSuggestionEntry] = suggestion.getEntries.asScala.map(PhraseSuggestionEntry).toIndexedSeq
 }
 
 case class CompletionSuggestionResult(suggestion: CompletionSuggestion) extends SuggestionResult {
   type R = CompletionSuggestion
   type E = CompletionSuggestionEntry
-  def entries: Seq[CompletionSuggestionEntry] = suggestion.getEntries.asScala.map(CompletionSuggestionEntry)
+  def entries: Seq[CompletionSuggestionEntry] = suggestion.getEntries.asScala.map(CompletionSuggestionEntry).toIndexedSeq
 }
 
 // scala version of Suggest.Suggestion.Entry
@@ -72,7 +72,7 @@ trait SuggestionEntry {
   def options: Seq[SuggestionOption] = entry
     .getOptions
     .asScala
-    .map(arg => SuggestionOption.apply(arg.asInstanceOf[Suggestion.Entry.Option]))
+    .map(arg => SuggestionOption.apply(arg.asInstanceOf[Suggestion.Entry.Option])).toIndexedSeq
 }
 
 case class TermSuggestionEntry(entry: TermSuggestion.Entry) extends SuggestionEntry {

--- a/elastic4s-testkit/src/main/scala/com/sksamuel/elastic4s/testkit/ResponseConverter.scala
+++ b/elastic4s-testkit/src/main/scala/com/sksamuel/elastic4s/testkit/ResponseConverter.scala
@@ -126,8 +126,8 @@ object ResponseConverterImplicits {
             None,
             None, // TODO
             x.sourceAsMap.asScalaNested,
-            x.fields.mapValues(_.value),
-            x.highlightFields.mapValues(_.fragments.map(_.string)),
+            x.fields.mapValues(_.value).toMap,
+            x.highlightFields.mapValues(_.fragments.map(_.string).toIndexedSeq).toMap,
             inner_hits = Map.empty,// TODO: Set properly
             x.version
           )
@@ -236,7 +236,7 @@ object ResponseConverterImplicits {
       response.`type`,
       response.version,
       response.exists,
-      response.original.getFields.asScala.toMap.mapValues(_.getValues.asScala),
+      response.original.getFields.asScala.toMap.mapValues(_.getValues.asScala).toMap,
       response.sourceAsMap.asScalaNested
     )
   }
@@ -273,7 +273,7 @@ object ResponseConverterImplicits {
         response.getFailedShards,
         response.getSuccessfulShards
       ),
-      response.getQueryExplanation.asScala.map(x => Explanation(x.getIndex, x.isValid, x.getError))
+      response.getQueryExplanation.asScala.map(x => Explanation(x.getIndex, x.isValid, x.getError)).toIndexedSeq
     )
   }
 
@@ -331,7 +331,7 @@ object ResponseConverterImplicits {
         case other => other
       }
 
-      self.mapValues(toScala)
+      self.mapValues(toScala).toMap
     }
   }
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -11,22 +11,22 @@ object Build extends AutoPlugin {
 
   object autoImport {
     val org = "com.sksamuel.elastic4s"
-    val AkkaVersion = "2.4.17"
-    val CatsVersion = "0.9.0"
-    val CirceVersion = "0.7.1"
+    val AkkaVersion = "2.5.27"
+    val CatsVersion = "2.0.0"
+    val CirceVersion = "0.12.0-M3"
     val CommonsIoVersion = "2.4"
     val ElasticsearchVersion = "5.6.2"
-    val ExtsVersion = "1.44.0"
-    val JacksonVersion = "2.8.8"
-    val Json4sVersion = "3.5.1"
-    val SprayJsonVersion = "1.3.3"
+    val ExtsVersion = "1.61.1"
+    val JacksonVersion = "2.10.0"
+    val Json4sVersion = "3.5.5"
+    val SprayJsonVersion = "1.3.5"
     val Log4jVersion = "2.6.2"
     val LuceneVersion = "6.6.1"
     val MockitoVersion = "1.9.5"
-    val PlayJsonVersion = "2.6.0-M6"
+    val PlayJsonVersion = "2.7.4"
     val ReactiveStreamsVersion = "1.0.0"
-    val ScalaVersion = "2.12.2"
-    val ScalatestVersion = "3.0.1"
+    val ScalaVersion = "2.13.1"
+    val ScalatestVersion = "3.0.8"
     val Slf4jVersion = "1.7.12"
   }
 
@@ -39,7 +39,7 @@ object Build extends AutoPlugin {
     // appending everything from 'compileonly' to unmanagedClasspath
     unmanagedClasspath in Compile ++= update.value.select(configurationFilter("compileonly")),
     scalaVersion := ScalaVersion,
-    crossScalaVersions := Seq("2.11.8", scalaVersion.value),
+    crossScalaVersions := Seq("2.11.12", "2.12.10", scalaVersion.value),
     publishMavenStyle := true,
     resolvers += Resolver.mavenLocal,
     fork in Test := true,
@@ -55,7 +55,7 @@ object Build extends AutoPlugin {
     javacOptions := Seq("-source", "1.7", "-target", "1.7"),
     libraryDependencies ++= Seq(
       "com.sksamuel.exts"                     %% "exts"                     % ExtsVersion,
-      "org.typelevel"                         %% "cats"                     % CatsVersion,
+      "org.typelevel"                         %% "cats-core"                % CatsVersion,
       "org.slf4j"                             % "slf4j-api"                 % Slf4jVersion,
       "org.elasticsearch"                     % "elasticsearch"             % ElasticsearchVersion,
       "org.mockito"                           % "mockito-all"               % MockitoVersion        % "test",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.18


### PR DESCRIPTION
added support for scala 2.13 for the 5.6.x release.

did:

- started from release/5.6.x
- Build.scala 
  - added 2.13.1 to crossScalaVersions
  - update dependencies to ones that support 2.11 till 2.13
- compiled and fixed errors where needed
- ran tests on all cross scala versions

