### PR TITLE
Replace deprecated unicode arrows

### DIFF
--- a/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClient.scala
+++ b/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClient.scala
@@ -7,7 +7,7 @@ import akka.stream.scaladsl.{FileIO, Keep, Sink, Source, StreamConverters}
 import akka.stream.{ActorMaterializer, OverflowStrategy, QueueOfferResult}
 import akka.util.ByteString
 import com.sksamuel.elastic4s.HttpEntity.StringEntity
-import com.sksamuel.elastic4s.{ElasticRequest, HttpClient ⇒ ElasticHttpClient, HttpEntity ⇒ ElasticHttpEntity, HttpResponse ⇒ ElasticHttpResponse}
+import com.sksamuel.elastic4s.{ElasticRequest, HttpClient => ElasticHttpClient, HttpEntity => ElasticHttpEntity, HttpResponse => ElasticHttpResponse}
 
 import scala.concurrent.{Future, Promise}
 import scala.util.{Failure, Success, Try}

--- a/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientMockTest.scala
+++ b/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientMockTest.scala
@@ -2,7 +2,7 @@ package com.sksamuel.elastic4s.akka
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse, StatusCodes, Uri}
-import com.sksamuel.elastic4s.{ElasticRequest, HttpEntity ⇒ ElasticEntity, HttpResponse ⇒ ElasticResponse}
+import com.sksamuel.elastic4s.{ElasticRequest, HttpEntity => ElasticEntity, HttpResponse => ElasticResponse}
 import org.scalamock.function.MockFunction1
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.BeforeAndAfterAll

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/bulk/BulkBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/bulk/BulkBuilderFn.scala
@@ -21,7 +21,7 @@ object BulkBuilderFn {
         index.version.foreach(builder.field("version", _))
         index.ifPrimaryTerm.foreach(builder.field("if_primary_term", _))
         index.ifSeqNo.foreach(builder.field("if_seq_no", _))
-        index.versionType.foreach(versionType ⇒ builder.field("version_type", VersionTypeHttpString(versionType)))
+        index.versionType.foreach(versionType => builder.field("version_type", VersionTypeHttpString(versionType)))
         index.pipeline.foreach(builder.field("pipeline", _))
         builder.endObject()
         builder.endObject()
@@ -39,7 +39,7 @@ object BulkBuilderFn {
         delete.version.foreach(builder.field("version", _))
         delete.ifPrimaryTerm.foreach(builder.field("if_primary_term", _))
         delete.ifSeqNo.foreach(builder.field("if_seq_no", _))
-        delete.versionType.foreach(versionType ⇒ builder.field("version_type", VersionTypeHttpString(versionType)))
+        delete.versionType.foreach(versionType => builder.field("version_type", VersionTypeHttpString(versionType)))
         builder.endObject()
         builder.endObject()
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/cluster/ClusterHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/cluster/ClusterHandlers.scala
@@ -28,7 +28,7 @@ trait ClusterHandlers {
     override def build(request: ClusterSettingsRequest): ElasticRequest = {
       val builder = ClusterSettingsBodyBuilderFn(request)
       val entity = HttpEntity(builder.string, "application/json")
-      ElasticRequest("PUT", "/_cluster/settings", Map("flat_settings" → true), entity)
+      ElasticRequest("PUT", "/_cluster/settings", Map("flat_settings" -> true), entity)
     }
   }
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/cluster/settings.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/cluster/settings.scala
@@ -21,13 +21,13 @@ object ClusterSettingsBodyBuilderFn {
     val builder = XContentFactory.jsonBuilder()
     if(request.persistentSettings.nonEmpty) {
       builder.startObject("persistent")
-      request.persistentSettings.foreach(t ⇒ builder.field(t._1, t._2))
+      request.persistentSettings.foreach(t => builder.field(t._1, t._2))
       builder.endObject()
     }
 
     if(request.transientSettings.nonEmpty) {
       builder.startObject("transient")
-      request.transientSettings.foreach(t ⇒ builder.field(t._1, t._2))
+      request.transientSettings.foreach(t => builder.field(t._1, t._2))
       builder.endObject()
     }
     builder

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/MoreLikeThisQueryBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/MoreLikeThisQueryBuilderFn.scala
@@ -17,7 +17,7 @@ object MoreLikeThisQueryBuilderFn {
       builder.startObject()
       builder.field("_index", doc.ref.index.name)
       builder.field("_id", doc.ref.id)
-      doc.routing.foreach { r ⇒
+      doc.routing.foreach { r =>
         builder.field("routing", r)
       }
       builder.endObject()
@@ -26,7 +26,7 @@ object MoreLikeThisQueryBuilderFn {
       builder.startObject()
       builder.field("_index", doc.index)
       builder.rawField("doc", doc.doc)
-      doc.routing.foreach { r ⇒
+      doc.routing.foreach { r =>
         builder.field("routing", r)
       }
       builder.endObject()
@@ -40,7 +40,7 @@ object MoreLikeThisQueryBuilderFn {
         builder.startObject()
         builder.field("_index", doc.ref.index.name)
         builder.field("_id", doc.ref.id)
-        doc.routing.foreach { r ⇒
+        doc.routing.foreach { r =>
           builder.field("routing", r)
         }
         builder.endObject()

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/ElasticErrorTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/ElasticErrorTest.scala
@@ -28,7 +28,7 @@ class ElasticErrorTest extends AnyFlatSpec with Matchers with ElasticDsl {
     assert(error.failedShards.size == 7)
     assert(error.rootCause.size == 7)
 
-    val failedShard = error.failedShards.find(p ⇒ p.node.contains("X6_5FwQsQOSTMc-4wEjLCA")).get
+    val failedShard = error.failedShards.find(p => p.node.contains("X6_5FwQsQOSTMc-4wEjLCA")).get
     assert(failedShard.shard == 0)
     assert(failedShard.index contains "items_landsat_20190129_0")
     assert(failedShard.node.contains("X6_5FwQsQOSTMc-4wEjLCA"))

--- a/elastic4s-effect-cats/src/main/scala/com/sksamuel/elastic4s/cats/effect/instances/CatsEffectInstances.scala
+++ b/elastic4s-effect-cats/src/main/scala/com/sksamuel/elastic4s/cats/effect/instances/CatsEffectInstances.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.elastic4s.cats.effect.instances
 
 import cats.effect.Async
-import cats.{Functor ⇒ CatsFunctor}
+import cats.{Functor => CatsFunctor}
 import com.sksamuel.elastic4s.cats.effect.CatsEffectExecutor
 import com.sksamuel.elastic4s.{Executor, Functor}
 

--- a/elastic4s-testkit/src/main/scala/com/sksamuel/elastic4s/testkit/ElasticSugar.scala
+++ b/elastic4s-testkit/src/main/scala/com/sksamuel/elastic4s/testkit/ElasticSugar.scala
@@ -140,12 +140,12 @@ trait ElasticSugar extends ElasticDsl {
     }
 
   def blockUntilIndexExists(index: String): Unit =
-    blockUntil(s"Expected exists index $index") { () ⇒
+    blockUntil(s"Expected exists index $index") { () =>
       doesIndexExists(index)
     }
 
   def blockUntilIndexNotExists(index: String): Unit =
-    blockUntil(s"Expected not exists index $index") { () ⇒
+    blockUntil(s"Expected not exists index $index") { () =>
       !doesIndexExists(index)
     }
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/cluster/ClusterInfoTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/cluster/ClusterInfoTest.scala
@@ -10,7 +10,7 @@ class ClusterInfoTest extends AnyWordSpec with Matchers with DockerTests with Be
 
   override protected def afterAll(): Unit = {
     client.execute {
-      addRemoteClusterRequest(Map("search.remote.cluster_one.seeds" → null, "search.remote.cluster_two.seeds" → null))
+      addRemoteClusterRequest(Map("search.remote.cluster_one.seeds" -> null, "search.remote.cluster_two.seeds" -> null))
     }.await
   }
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/cluster/ClusterSettingsTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/cluster/ClusterSettingsTest.scala
@@ -27,12 +27,12 @@ class ClusterSettingsTest extends AnyWordSpec with Matchers with DockerTests {
     "return cluster settings updated" in {
 
       val settings = client.execute {
-        clusterPersistentSettings(Map("indices.recovery.max_bytes_per_sec" → "50mb"))
-          .transientSettings(Map("search.max_buckets" → "30000"))
+        clusterPersistentSettings(Map("indices.recovery.max_bytes_per_sec" -> "50mb"))
+          .transientSettings(Map("search.max_buckets" -> "30000"))
       }.await.result
 
-      settings.transient shouldBe Map("search.max_buckets" → "30000")
-      settings.persistent shouldBe Map("indices.recovery.max_bytes_per_sec" → "50mb")
+      settings.transient shouldBe Map("search.max_buckets" -> "30000")
+      settings.persistent shouldBe Map("indices.recovery.max_bytes_per_sec" -> "50mb")
     }
   }
 }


### PR DESCRIPTION
Unicode arrows are deprecated in 2.13.

This PR replaces them with their two-character versions.

See https://github.com/scala/scala/pull/7540