### PR TITLE
use non-default elastic ports for tests and docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,7 +723,7 @@ And to test
 sbt test
 ```
 
-For the tests to work you will need to run a local elastic instance on port 9200, _with security enabled_. One easy way of doing this is to use docker (via docker-compose):
+For the tests to work you will need to run a local elastic instance on port 39227, _with security enabled_. One easy way of doing this is to use docker (via docker-compose):
 `docker-compose up`
 
 ## Used By

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,8 @@ services:
       network.host: 0.0.0.0
       path.repo: /tmp/elastic4s
     ports:
-      - 9200:9200
-      - 9300:9300
+      # use obscure ports for the tests to reduce the risk of interfering with existing elastic installations/containers
+      - 39227:9200
+      - 39337:9300
     volumes:
       - "./elastic4s-tests/src/test/resources/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml"

--- a/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientTest.scala
+++ b/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientTest.scala
@@ -33,7 +33,7 @@ class AkkaHttpClientTest extends AnyFlatSpec with Matchers with DockerTests with
     }
   }
 
-  private lazy val akkaClient = AkkaHttpClient(AkkaHttpClientSettings(List("localhost:9200")))
+  private lazy val akkaClient = AkkaHttpClient(AkkaHttpClientSettings(List(s"$elasticHost:$elasticPort")))
 
   override val client = ElasticClient(akkaClient)
 

--- a/elastic4s-testkit/src/main/scala/com/sksamuel/elastic4s/testkit/DockerTests.scala
+++ b/elastic4s-testkit/src/main/scala/com/sksamuel/elastic4s/testkit/DockerTests.scala
@@ -7,7 +7,12 @@ import scala.util.Try
 
 trait DockerTests extends ElasticDsl with ClientProvider {
 
-  val client = ElasticClient(JavaClient(ElasticProperties(s"http://${sys.env.getOrElse("ES_HOST", "127.0.0.1")}:${sys.env.getOrElse("ES_PORT", "9200")}")))
+  val elasticHost = sys.env.getOrElse("ES_HOST", "127.0.0.1")
+  val elasticPort = sys.env.getOrElse("ES_PORT",
+      // use obscure ports for the tests to reduce the risk of interfering with existing elastic installations/containers
+      "39227"
+    )
+  val client = ElasticClient(JavaClient(ElasticProperties(s"http://$elasticHost:$elasticPort")))
 
   protected def deleteIdx(indexName: String): Unit = {
     Try {

--- a/elastic4s-testkit/src/main/scala/com/sksamuel/elastic4s/testkit/providers.scala
+++ b/elastic4s-testkit/src/main/scala/com/sksamuel/elastic4s/testkit/providers.scala
@@ -45,8 +45,8 @@
 //  override def getNode: LocalNode =
 //    try {
 //
-//      // assume the local node is running on 9200
-//      val client = ElasticClient("elasticsearch://localhost:9200")
+//      // assume the local node is running on 39227
+//      val client = ElasticClient("elasticsearch://localhost:39227")
 //      import com.sksamuel.elastic4s.http.ElasticDsl._
 //      val nodeinfo   = client.execute(nodeInfo()).await.result
 //      val (id, node) = nodeinfo.nodes.head


### PR DESCRIPTION
fixes https://github.com/sksamuel/elastic4s/issues/2081

I've changed the ports to 
```
      - 39227:9200
      - 39337:9300
```
which are free according to IANA