### PR TITLE
Add rank feature query

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/fields/builders/ElasticFieldBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/fields/builders/ElasticFieldBuilderFn.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.elastic4s.fields.builders
 
-import com.sksamuel.elastic4s.fields.{AliasField, BinaryField, BooleanField, CompletionField, DateField, DenseVectorField, ElasticField, FlattenedField, GeoPointField, GeoShapeField, JoinField, KeywordField, NestedField, NumberField, ObjectField, RangeField, SearchAsYouTypeField, TextField, TokenCountField}
+import com.sksamuel.elastic4s.fields.{AliasField, BinaryField, BooleanField, CompletionField, DateField, DenseVectorField, ElasticField, FlattenedField, GeoPointField, GeoShapeField, JoinField, KeywordField, NestedField, NumberField, ObjectField, RangeField, RankFeatureField, RankFeaturesField, SearchAsYouTypeField, TextField, TokenCountField}
 import com.sksamuel.elastic4s.json.XContentBuilder
 
 object ElasticFieldBuilderFn {
@@ -22,6 +22,8 @@ object ElasticFieldBuilderFn {
       case f: NumberField[_] => NumberFieldBuilderFn.build(f)
       case f: ObjectField => ObjectFieldBuilderFn.build(f)
       case f: RangeField => RangeFieldBuilderFn.build(f)
+      case f: RankFeatureField => RankFeatureFieldBuilderFn.build(f)
+      case f: RankFeaturesField => RankFeaturesFieldBuilderFn.build(f)
       case f: SearchAsYouTypeField => SearchAsYouTypeFieldBuilderFn.build(f)
       case f: TextField => TextFieldBuilderFn.build(f)
       case f: TokenCountField => TokenCountFieldBuilderFn.build(f)

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/fields/builders/RankFeatureFieldBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/fields/builders/RankFeatureFieldBuilderFn.scala
@@ -1,0 +1,14 @@
+package com.sksamuel.elastic4s.fields.builders
+
+import com.sksamuel.elastic4s.fields.RankFeatureField
+import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
+
+object RankFeatureFieldBuilderFn {
+  def build(field: RankFeatureField): XContentBuilder = {
+
+    val builder = XContentFactory.jsonBuilder()
+    builder.field("type", field.`type`)
+    field.positiveScoreImpact.foreach(builder.field("positive_score_impact", _))
+    builder.endObject()
+  }
+}

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/fields/builders/RankFeaturesFieldBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/fields/builders/RankFeaturesFieldBuilderFn.scala
@@ -1,0 +1,13 @@
+package com.sksamuel.elastic4s.fields.builders
+
+import com.sksamuel.elastic4s.fields.RankFeaturesField
+import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
+
+object RankFeaturesFieldBuilderFn {
+  def build(field: RankFeaturesField): XContentBuilder = {
+
+    val builder = XContentFactory.jsonBuilder()
+    builder.field("type", field.`type`)
+    builder.endObject()
+  }
+}

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/fields/fields.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/fields/fields.scala
@@ -419,3 +419,12 @@ case class IpField(name: String,
   override def `type`: String = "ip"
 }
 case class IndexPrefixes(minChars: Int, maxChars: Int)
+
+case class RankFeatureField(name: String,
+                            positiveScoreImpact: Option[Boolean] = None) extends ElasticField {
+  override def `type`: String = "rank_feature"
+}
+
+case class RankFeaturesField(name: String) extends ElasticField {
+  override def `type`: String = "rank_features"
+}

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/QueryApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/QueryApi.scala
@@ -180,6 +180,8 @@ trait QueryApi {
 
   def rangeQuery(field: String): RangeQuery = RangeQuery(field)
 
+  def rankFeatureQuery(field: String) = RankFeatureQuery(field)
+
   def rawQuery(json: String): RawQuery = RawQuery(json)
 
   def regexQuery(field: String, value: String): RegexQuery = RegexQuery(field, value)

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/QueryBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/QueryBuilderFn.scala
@@ -44,6 +44,7 @@ object QueryBuilderFn {
     case q: PrefixQuery         => PrefixQueryBodyFn(q)
     case q: QueryStringQuery    => QueryStringBodyFn(q)
     case r: RangeQuery          => RangeQueryBodyFn(r)
+    case r: RankFeatureQuery    => RankFeatureQueryBuilderFn(r)
     case q: RawQuery            => RawQueryBodyFn(q)
     case q: RegexQuery          => RegexQueryBodyFn(q)
     case q: ScriptQuery         => ScriptQueryBodyFn(q)

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/RankFeatureQuery.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/RankFeatureQuery.scala
@@ -1,0 +1,28 @@
+package com.sksamuel.elastic4s.requests.searches.queries
+
+import com.sksamuel.exts.OptionImplicits._
+import RankFeatureQuery._
+
+case class RankFeatureQuery(field: String,
+                            boost: Option[Double] = None,
+                            saturation: Option[Saturation] = None,
+                            log: Option[Log] = None,
+                            sigmoid: Option[Sigmoid] = None) extends Query {
+
+  def boost(boost: Double): RankFeatureQuery = copy(boost = boost.some)
+
+  def withSaturation(saturation: Saturation): RankFeatureQuery =
+    copy(saturation = saturation.some, log = None, sigmoid = None)
+
+  def withLog(log: Log): RankFeatureQuery =
+    copy(log = log.some, saturation = None, sigmoid = None)
+
+  def withSigmoid(sigmoid: Sigmoid): RankFeatureQuery =
+    copy(sigmoid = sigmoid.some, saturation = None, log = None)
+}
+
+object RankFeatureQuery {
+  case class Saturation(pivot: Option[Int])
+  case class Log(scalingFactor: Int)
+  case class Sigmoid(pivot: Int, exponent: Double)
+}

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/RankFeatureQueryBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/RankFeatureQueryBuilderFn.scala
@@ -1,0 +1,30 @@
+package com.sksamuel.elastic4s.requests.searches.queries
+
+import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
+
+object RankFeatureQueryBuilderFn {
+  def apply(q: RankFeatureQuery): XContentBuilder = {
+    val builder = XContentFactory.jsonBuilder()
+    builder.startObject("rank_feature")
+    builder.field("field", q.field)
+    q.boost.foreach(builder.field("boost", _))
+    q.saturation.foreach { s =>
+        builder.startObject("saturation")
+        s.pivot.foreach(builder.field("pivot", _))
+        builder.endObject()
+    }
+    q.log.foreach { l =>
+        builder.startObject("log")
+        builder.field("scaling_factor", l.scalingFactor)
+        builder.endObject()
+    }
+    q.sigmoid.foreach { s =>
+        builder.startObject("sigmoid")
+        builder.field("pivot", s.pivot)
+        builder.field("exponent", s.exponent)
+        builder.endObject()
+    }
+    builder.endObject()
+    builder
+  }
+}

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/queries/RankFeatureQueryBodyFnTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/queries/RankFeatureQueryBodyFnTest.scala
@@ -1,0 +1,102 @@
+package com.sksamuel.elastic4s.requests.searches.queries
+
+import com.sksamuel.elastic4s.requests.searches.queries.RankFeatureQuery.{Log, Saturation, Sigmoid}
+import org.scalatest.GivenWhenThen
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class RankFeatureQueryBodyFnTest extends AnyFunSuite with Matchers with GivenWhenThen {
+  test("Should correctly build rank feature query with a sigmoid function") {
+    Given("A rank feature query with a sigmoid function")
+    val query = RankFeatureQuery(field = "pagerank").boost(0.5).withSigmoid(Sigmoid(7, 0.6))
+
+    When("Rank feature query is built")
+    val queryBody = RankFeatureQueryBuilderFn(query)
+
+    Then("query should have right fields")
+    queryBody.string() shouldEqual rankFeatureQueryWithSigmoid
+  }
+
+  def rankFeatureQueryWithSigmoid: String =
+    """
+      |{
+      |   "rank_feature":{
+      |      "field": "pagerank",
+      |      "boost": 0.5,
+      |      "sigmoid": {
+      |         "pivot": 7,
+      |         "exponent": 0.6
+      |      }
+      |   }
+      |}
+    """.stripMargin.replaceAllLiterally(" ", "").replace("\n", "")
+
+  test("Should correctly build a rank feature query with a log function") {
+    {
+      Given("A rank feature query with a log function")
+      val query = RankFeatureQuery(field = "pagerank").withLog(Log(3))
+
+      When("Rank feature query is built")
+      val queryBody = RankFeatureQueryBuilderFn(query)
+
+      Then("query should have right fields")
+      queryBody.string() shouldEqual rankFeatureQueryWithLog
+    }
+
+    def rankFeatureQueryWithLog: String =
+      """
+        |{
+        |   "rank_feature":{
+        |      "field": "pagerank",
+        |      "log": {
+        |          "scaling_factor": 3
+        |      }
+        |   }
+        |}
+    """.stripMargin.replaceAllLiterally(" ", "").replace("\n", "")
+  }
+
+  test("Should correctly build a rank feature query with a saturation function") {
+    {
+      Given("A rank feature query with a saturation function")
+      val query = RankFeatureQuery("pagerank").withSaturation(Saturation(Some(2)))
+
+      When("Rank feature query is built")
+      val queryBody = RankFeatureQueryBuilderFn(query)
+
+      Then("query should have right fields")
+      queryBody.string() shouldEqual rankFeatureQueryWithSaturation
+    }
+
+    def rankFeatureQueryWithSaturation: String =
+      """
+        |{
+        |   "rank_feature":{
+        |      "field": "pagerank",
+        |      "saturation": {
+        |          "pivot": 2
+        |      }
+        |   }
+        |}
+    """.stripMargin.replaceAllLiterally(" ", "").replace("\n", "")
+
+    Given("A rank feature query with a saturation function without specified pivot")
+    val query = RankFeatureQuery("pagerank").withSaturation(Saturation(None))
+
+    When("Rank feature query is built")
+    val queryBody = RankFeatureQueryBuilderFn(query)
+
+    Then("query should have right fields")
+    queryBody.string() shouldEqual minimalRankFeatureQuery
+  }
+
+  def minimalRankFeatureQuery: String =
+    """
+      |{
+      |   "rank_feature":{
+      |      "field": "pagerank",
+      |      "saturation": {}
+      |   }
+      |}
+    """.stripMargin.replaceAllLiterally(" ", "").replace("\n", "")
+}

--- a/elastic4s-tests/src/test/resources/json/search/search_rank_feature.json
+++ b/elastic4s-tests/src/test/resources/json/search/search_rank_feature.json
@@ -1,0 +1,13 @@
+{
+    "size": 5,
+    "query": {
+        "rank_feature": {
+            "field": "pagerank",
+            "boost": 0.5,
+            "sigmoid": {
+                "pivot": 7,
+                "exponent": 0.6
+            }
+        }
+    }
+}

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
@@ -7,6 +7,7 @@ import com.sksamuel.elastic4s.requests.analyzers.{FrenchLanguageAnalyzer, Snowba
 import com.sksamuel.elastic4s.requests.common.{DistanceUnit, FetchSourceContext, ValueType}
 import com.sksamuel.elastic4s.requests.searches._
 import com.sksamuel.elastic4s.requests.searches.aggs.{SubAggCollectionMode, TermsOrder}
+import com.sksamuel.elastic4s.requests.searches.queries.RankFeatureQuery.Sigmoid
 import com.sksamuel.elastic4s.requests.searches.queries.funcscorer.MultiValueMode
 import com.sksamuel.elastic4s.requests.searches.queries.geo.GeoDistance
 import com.sksamuel.elastic4s.requests.searches.queries.matches.{MultiMatchQueryBuilderType, ZeroTermsQuery}
@@ -84,6 +85,13 @@ class SearchDslTest extends AnyFlatSpec with MockitoSugar with JsonSugar with On
       rangeQuery("coldplay") gte 4 lt 10 boost 1.2
     }
     req.request.entity.get.get should matchJsonResource("/json/search/search_range.json")
+  }
+
+  it should "generate json for a rank feature query" in {
+    val req = search("*") limit 5 query {
+      rankFeatureQuery("pagerank").boost(0.5).withSigmoid(Sigmoid(7, 0.6))
+    }
+    req.request.entity.get.get should matchJsonResource("/json/search/search_rank_feature.json")
   }
 
   it should "generate json for a wildcard query" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/RankFeatureQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/RankFeatureQueryTest.scala
@@ -1,0 +1,75 @@
+package com.sksamuel.elastic4s.search.queries
+
+import com.sksamuel.elastic4s.fields.{RankFeatureField, RankFeaturesField}
+import com.sksamuel.elastic4s.requests.common.RefreshPolicy
+import com.sksamuel.elastic4s.testkit.DockerTests
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
+
+class RankFeatureQueryTest extends AnyFlatSpec with Matchers with DockerTests {
+  Try {
+    client.execute {
+      deleteIndex("rankfeaturetest")
+    }.await
+  }
+
+  client.execute {
+    createIndex("rankfeaturetest").mapping(
+      properties(
+        RankFeatureField("pagerank"),
+        RankFeatureField("url_length", Some(false)),
+        RankFeaturesField("topics")
+      )
+    )
+  }.await
+
+  client.execute {
+    createIndex("rankfeaturetest")
+  }.await
+
+  client.execute {
+    bulk(
+      indexInto("rankfeaturetest").fields(
+        "url" -> "http://en.wikipedia.org/wiki/2016_Summer_Olympics",
+        "content" -> "Rio 2016",
+        "pagerank" -> 50.3,
+        "url_length" -> 42,
+        "topics" -> Map("sports" -> 50, "brazil" -> 30)
+        ),
+      indexInto("rankfeaturetest").fields(
+        "url" -> "http://en.wikipedia.org/wiki/2016_Brazilian_Grand_Prix",
+        "content" -> "Formula One motor race held on 13 November 2016",
+        "pagerank" -> 50.3,
+        "url_length" -> 47,
+        "topics" -> Map("sports" -> 35, "formula one" -> 65, "brazil" -> 20)
+      ),
+      indexInto("rankfeaturetest").fields(
+        "url" -> "http://en.wikipedia.org/wiki/Deadpool_(film)",
+        "content" -> "Deadpool is a 2016 American superhero film",
+        "pagerank" -> 50.3,
+        "url_length" -> 37,
+        "topics" -> Map("movies" -> 60, "super hero" -> 65)
+      )
+    ).refresh(RefreshPolicy.Immediate)
+  }.await
+
+  "rank feature query" should "work as in the elasticsearch docs" in {
+    val resp = client.execute {
+      search("rankfeaturetest").query {
+        boolQuery()
+          .must(matchQuery("content", "2016"))
+          .should {
+            List(rankFeatureQuery("pagerank"),
+            rankFeatureQuery("url_length").boost(0.1),
+            rankFeatureQuery("topics.sports").boost(0.4))
+          }
+      }
+    }.await.result
+
+    resp.totalHits shouldBe 3
+    resp.hits.hits.head.sourceField("content") shouldBe "Rio 2016"
+    resp.hits.hits.last.sourceField("content") shouldBe "Deadpool is a 2016 American superhero film"
+  }
+}


### PR DESCRIPTION
Applying this PR will add the `rank feature query` feature, which was introduced in Elasticsearch 7.0 (https://www.elastic.co/guide/en/elasticsearch/reference/7.6/query-dsl-rank-feature-query.html).
For the docker based test I took the example from the Elasticsearch website.

I went for a small ADT for the different `FunctionObject`s that can be provided (`Saturation`, `Logarithm` and `Sigmoid`) instead of making them separate parameters. I like that in this way it enforces the "Only one function saturation, log, or sigmoid can be provided." invariant. What I don't like is the name "functionObject".
If you prefer to have separate parameters or have other suggestions on what I could improve/add I'm happy to make changes.

Closes https://github.com/sksamuel/elastic4s/issues/2091.