### PR TITLE
Update list of passed arguments

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -39,7 +39,7 @@ val callback = new HttpClientConfigCallback {
 }
 
 val props = ElasticProperties("http://host1:9200")
-val client = ElasticClient(JavaClient(props, httpClientConfigCallback = callback))
+val client = ElasticClient(JavaClient(props, requestConfigCallback = NoOpRequestConfigCallback, httpClientConfigCallback = callback))
 ```
 
 


### PR DESCRIPTION
Hello guys!

This is small change in documentation. 

`JavaClient` doesn't have predefined parameters in the constructor so we have to specify requestConfigCallback argument. 