### PR TITLE
Add intervals query

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/QueryApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/QueryApi.scala
@@ -108,6 +108,8 @@ trait QueryApi {
 
   def innerHits(name: String): com.sksamuel.elastic4s.requests.searches.queries.InnerHit = com.sksamuel.elastic4s.requests.searches.queries.InnerHit(name)
 
+  def intervalsQuery(field: String, rule: IntervalsRule): IntervalsQuery = IntervalsQuery(field, rule)
+
   def matchQuery(field: String, value: Any): MatchQuery = MatchQuery(field, value)
 
   def matchPhraseQuery(field: String, value: Any): MatchPhrase = MatchPhrase(field, value)

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/IntervalsQuery.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/IntervalsQuery.scala
@@ -1,0 +1,92 @@
+package com.sksamuel.elastic4s.requests.searches.queries
+
+import com.sksamuel.elastic4s.requests.script.Script
+import com.sksamuel.exts.OptionImplicits._
+
+case class IntervalsQuery(field: String, rule: IntervalsRule) extends Query
+
+sealed trait IntervalsRule
+case class Match(query: String,
+                 maxGaps: Option[Int] = None,
+                 ordered: Option[Boolean] = None,
+                 analyzer: Option[String] = None,
+                 filter: Option[IntervalsFilter] = None,
+                 useField: Option[String] = None) extends IntervalsRule {
+  override def toString = "match"
+
+  def maxGaps(maxGaps: Int): Match = copy(maxGaps = maxGaps.some)
+  def ordered(ordered: Boolean): Match = copy(ordered = ordered.some)
+  def analyzer(analyzer: String): Match = copy(analyzer = analyzer.some)
+  def filter(filter: IntervalsFilter): Match = copy(filter = filter.some)
+  def useField(useField: String): Match = copy(useField = useField.some)
+}
+
+case class Prefix(prefix: String,
+                  analyzer: Option[String] = None,
+                  useField: Option[String] = None) extends IntervalsRule {
+  override def toString = "prefix"
+
+  def analyzer(analyzer: String): Prefix = copy(analyzer = analyzer.some)
+  def useField(useField: String): Prefix = copy(useField = useField.some)
+}
+
+case class Wildcard(pattern: String,
+                    analyzer: Option[String] = None,
+                    useField: Option[String] = None) extends IntervalsRule {
+  override def toString = "wildcard"
+
+  def analyzer(analyzer: String): Wildcard = copy(analyzer = analyzer.some)
+  def useField(useField: String): Wildcard = copy(useField = useField.some)
+}
+
+case class Fuzzy(term: String,
+                 prefixLength: Option[String] = None,
+                 transpositions: Option[Boolean] = None,
+                 fuzziness: Option[String] = None,
+                 analyzer: Option[String] = None,
+                 useField: Option[String] = None) extends IntervalsRule {
+  override def toString = "fuzzy"
+
+  def prefixLength(prefixLength: String): Fuzzy = copy(prefixLength = prefixLength.some) // maybe Int ?
+  def transpositions(transpositions: Boolean): Fuzzy = copy(transpositions = transpositions.some)
+  def fuzziness(fuzziness: String): Fuzzy = copy(fuzziness = fuzziness.some)
+  def analyzer(analyzer: String): Fuzzy = copy(analyzer = analyzer.some)
+  def useField(useField: String): Fuzzy = copy(useField = useField.some)
+}
+
+case class AllOf(intervals: List[IntervalsRule],
+                 maxGaps: Option[Int] = None,
+                 ordered: Option[Boolean] = None,
+                 filter: Option[IntervalsFilter] = None) extends IntervalsRule {
+  override def toString = "all_of"
+
+  def maxGaps(maxGaps: Int): AllOf = copy(maxGaps = maxGaps.some)
+  def ordered(ordered: Boolean): AllOf = copy(ordered = ordered.some)
+  def filter(filter: IntervalsFilter): AllOf = copy(filter = filter.some)
+}
+case class AnyOf(intervals: List[IntervalsRule],
+                 filter: Option[IntervalsFilter] = None) extends IntervalsRule {
+  override def toString = "any_of"
+
+  def filter(filter: IntervalsFilter): AnyOf = copy(filter = filter.some)
+}
+
+case class IntervalsFilter(after: Option[IntervalsRule] = None,
+                           before: Option[IntervalsRule] = None,
+                           containedBy: Option[IntervalsRule] = None,
+                           containing: Option[IntervalsRule] = None,
+                           notContainedBy: Option[IntervalsRule] = None,
+                           notContaining: Option[IntervalsRule] = None,
+                           notOverlapping: Option[IntervalsRule] = None,
+                           overlapping: Option[IntervalsRule] = None,
+                           script: Option[Script] = None) {
+  def after(rule: IntervalsRule): IntervalsFilter = copy(after = rule.some)
+  def before(rule: IntervalsRule): IntervalsFilter = copy(before = rule.some)
+  def containedBy(rule: IntervalsRule): IntervalsFilter = copy(containedBy = rule.some)
+  def containing(rule: IntervalsRule): IntervalsFilter = copy(containing = rule.some)
+  def notContainedBy(rule: IntervalsRule): IntervalsFilter = copy(notContainedBy = rule.some)
+  def notContaining(rule: IntervalsRule): IntervalsFilter = copy(notContaining = rule.some)
+  def notOverlapping(rule: IntervalsRule): IntervalsFilter = copy(notOverlapping = rule.some)
+  def overlapping(rule: IntervalsRule): IntervalsFilter = copy(overlapping = rule.some)
+  def script(script: Script): IntervalsFilter = copy(script = script.some)
+}

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/IntervalsQueryBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/IntervalsQueryBuilderFn.scala
@@ -1,0 +1,94 @@
+package com.sksamuel.elastic4s.requests.searches.queries
+
+import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
+import com.sksamuel.elastic4s.requests.script.ScriptBuilderFn
+
+object IntervalsFilterBuilderFn {
+  def apply(f: IntervalsFilter): XContentBuilder = {
+    val builder = XContentFactory.jsonBuilder()
+    f.after.foreach{ r => builder.rawField("after", IntervalsRuleBuilderFn(r)) }
+    f.before.foreach{ r => builder.rawField("before", IntervalsRuleBuilderFn(r)) }
+    f.containedBy.foreach{ r => builder.rawField("contained_by", IntervalsRuleBuilderFn(r)) }
+    f.containing.foreach{ r => builder.rawField("containing", IntervalsRuleBuilderFn(r)) }
+    f.notContainedBy.foreach{ r => builder.rawField("not_contained_by", IntervalsRuleBuilderFn(r)) }
+    f.notContaining.foreach{ r => builder.rawField("not_containing", IntervalsRuleBuilderFn(r)) }
+    f.notOverlapping.foreach{ r => builder.rawField("not_overlapping", IntervalsRuleBuilderFn(r)) }
+    f.overlapping.foreach{ r => builder.rawField("overlapping", IntervalsRuleBuilderFn(r)) }
+    f.script.foreach{ s => builder.rawField("script", ScriptBuilderFn(s)) }
+    builder
+  }
+}
+
+object IntervalsRuleBuilderFn {
+  def apply(r: IntervalsRule): XContentBuilder = {
+    val builder = XContentFactory.jsonBuilder()
+    r match {
+      case Match(query: String, maxGaps: Option[Int], ordered: Option[Boolean], analyzer: Option[String], filter: Option[IntervalsFilter], useField: Option[String]) =>
+        builder.startObject("match")
+        builder.field("query", query)
+        maxGaps.foreach(builder.field("max_gaps", _))
+        ordered.foreach(builder.field("ordered", _))
+        analyzer.foreach(builder.field("analyzer", _))
+        filter.foreach{ f => builder.rawField("filter", IntervalsFilterBuilderFn(f)) }
+        useField.foreach(builder.field("use_field", _))
+        builder.endObject()
+      case Prefix(prefix: String, analyzer: Option[String], useField: Option[String]) =>
+        builder.startObject("prefix")
+        builder.field("prefix", prefix)
+        analyzer.foreach(builder.field("analyzer", _))
+        useField.foreach(builder.field("use_field", _))
+        builder.endObject()
+      case Wildcard(pattern: String, analyzer: Option[String], useField: Option[String]) =>
+        builder.startObject("wildcard")
+        builder.field("pattern", pattern)
+        analyzer.foreach(builder.field("analyzer", _))
+        useField.foreach(builder.field("use_field", _))
+        builder.endObject()
+      case Fuzzy(term: String, prefixLength: Option[String], transpositions: Option[Boolean], fuzziness: Option[String], analyzer: Option[String], useField: Option[String]) =>
+        builder.startObject("fuzzy")
+        builder.field("term", term)
+        prefixLength.foreach(builder.field("prefix_length", _))
+        transpositions.foreach(builder.field("transpositions", _))
+        fuzziness.foreach(builder.field("fuzziness", _))
+        analyzer.foreach(builder.field("analyzer", _))
+        useField.foreach(builder.field("use_field", _))
+        builder.endObject()
+      case AllOf(intervals: List[IntervalsRule], maxGaps: Option[Int], ordered: Option[Boolean], filter: Option[IntervalsFilter]) =>
+        builder.startObject("all_of")
+
+        if (intervals.nonEmpty) {
+          builder.startArray("intervals")
+          intervals.foreach{ r => builder.rawValue(IntervalsRuleBuilderFn(r)) }
+          builder.endArray()
+        }
+
+        maxGaps.foreach(builder.field("max_gaps", _))
+        ordered.foreach(builder.field("ordered", _))
+
+        filter.foreach{ f => builder.rawField("filter", IntervalsFilterBuilderFn(f)) }
+        builder.endObject()
+      case AnyOf(intervals: List[IntervalsRule], filter: Option[IntervalsFilter]) =>
+        builder.startObject("any_of")
+
+        if (intervals.nonEmpty) {
+          builder.startArray("intervals")
+          intervals.foreach{ r => builder.rawValue(IntervalsRuleBuilderFn(r)) }
+          builder.endArray()
+        }
+
+        filter.foreach{ f => builder.rawField("filter", IntervalsFilterBuilderFn(f)) }
+
+        builder.endObject()
+    }
+    builder
+  }
+}
+
+object IntervalsQueryBuilderFn {
+  def apply(q: IntervalsQuery): XContentBuilder = {
+    val builder = XContentFactory.jsonBuilder()
+    builder.startObject("intervals")
+    builder.rawField(q.field, IntervalsRuleBuilderFn(q.rule))
+    builder.endObject()
+  }
+}

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/QueryBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/QueryBuilderFn.scala
@@ -28,6 +28,7 @@ object QueryBuilderFn {
     case q: HasChildQuery       => HasChildBodyFn(q)
     case q: HasParentQuery      => HasParentBodyFn(q)
     case q: IdQuery             => IdQueryBodyFn(q)
+    case q: IntervalsQuery      => IntervalsQueryBuilderFn(q)
     case q: MatchAllQuery       => MatchAllBodyFn(q)
     case q: MatchNoneQuery      => MatchNoneBodyFn(q)
     case q: MatchQuery          => MatchQueryBuilderFn(q)

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/queries/IntervalsQueryBuilderFnTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/queries/IntervalsQueryBuilderFnTest.scala
@@ -1,0 +1,126 @@
+package com.sksamuel.elastic4s.requests.searches.queries
+
+import com.sksamuel.elastic4s.JsonSugar
+import com.sksamuel.elastic4s.requests.script.Script
+import org.scalatest.GivenWhenThen
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class IntervalsQueryBuilderFnTest extends AnyFunSuite with Matchers with GivenWhenThen with JsonSugar {
+  test("Should correctly build intervals query") {
+    Given("An intervals query")
+    val query = IntervalsQuery("my_text", AllOf(List(
+      Match(query = "my favorite food").maxGaps(0).ordered(true),
+      AnyOf(intervals = List(
+        Match(query = "hot water"),
+        Match(query = "cold porridge")
+      ))
+    )).ordered(true))
+
+    When("Intervals query is built")
+    val queryBody = IntervalsQueryBuilderFn(query)
+
+    Then("query should have right fields")
+    queryBody.string() should matchJson(intervalsQuery)
+  }
+
+  def intervalsQuery: String =
+    """
+      |{
+      |  "intervals" : {
+      |    "my_text" : {
+      |      "all_of" : {
+      |        "ordered" : true,
+      |        "intervals" : [
+      |          {
+      |            "match" : {
+      |              "query" : "my favorite food",
+      |              "max_gaps" : 0,
+      |              "ordered" : true
+      |            }
+      |          },
+      |          {
+      |            "any_of" : {
+      |              "intervals" : [
+      |                { "match" : { "query" : "hot water" } },
+      |                { "match" : { "query" : "cold porridge" } }
+      |              ]
+      |            }
+      |          }
+      |        ]
+      |      }
+      |    }
+      |  }
+      |}
+    """.stripMargin.replace("\n", "")
+
+  test("Should correctly build intervals query with a filter") {
+    Given("An intervals query with a filter")
+    val query = IntervalsQuery("my_text", Match(query = "hot porridge").maxGaps(10).filter(
+      IntervalsFilter().notContaining(Match(query = "salty")
+    )))
+
+    When("Intervals query is built")
+    val queryBody = IntervalsQueryBuilderFn(query)
+
+    println(queryBody.string())
+    Then("query should have right fields")
+    queryBody.string() should matchJson(intervalsWithFilterQuery)
+  }
+
+
+  def intervalsWithFilterQuery: String =
+    """
+      |{
+      |  "intervals" : {
+      |    "my_text" : {
+      |      "match" : {
+      |        "query" : "hot porridge",
+      |        "max_gaps" : 10,
+      |        "filter" : {
+      |          "not_containing" : {
+      |            "match" : {
+      |              "query" : "salty"
+      |            }
+      |          }
+      |        }
+      |      }
+      |    }
+      |  }
+      |}
+    """.stripMargin.replace("\n", "")
+
+  test("Should correctly build intervals query with a script") {
+    Given("An intervals query with a script")
+    val query = IntervalsQuery("my_text", Match("hot porridge").filter(
+      IntervalsFilter().script(Script(
+        "interval.start > 10 && interval.end < 20 && interval.gaps == 0"
+      ))
+    ))
+
+    When("Intervals query is built")
+    val queryBody = IntervalsQueryBuilderFn(query)
+
+    println(queryBody.string())
+    Then("query should have right fields")
+    queryBody.string() should matchJson(intervalsWithScriptQuery)
+  }
+
+  def intervalsWithScriptQuery: String =
+    """
+      |{
+      |  "intervals" : {
+      |    "my_text" : {
+      |      "match" : {
+      |        "query" : "hot porridge",
+      |        "filter" : {
+      |          "script" : {
+      |            "source" : "interval.start > 10 && interval.end < 20 && interval.gaps == 0"
+      |          }
+      |        }
+      |      }
+      |    }
+      |  }
+      |}
+    """.stripMargin.replace("\n", "")
+}

--- a/elastic4s-tests/src/test/resources/json/search/search_intervals.json
+++ b/elastic4s-tests/src/test/resources/json/search/search_intervals.json
@@ -1,0 +1,37 @@
+{
+    "query": {
+        "intervals": {
+            "my_text": {
+                "all_of": {
+                    "intervals": [
+                        {
+                            "match": {
+                                "query": "my favorite food",
+                                "max_gaps": 0,
+                                "ordered": true
+                            }
+                        },
+                        {
+                            "any_of": {
+                                "intervals": [
+                                    {
+                                        "match": {
+                                            "query": "hot water"
+                                        }
+                                    },
+                                    {
+                                        "match": {
+                                            "query": "cold porridge"
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "ordered": true
+                }
+            }
+        }
+    },
+    "size": 5
+}

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
@@ -11,7 +11,7 @@ import com.sksamuel.elastic4s.requests.searches.queries.RankFeatureQuery.Sigmoid
 import com.sksamuel.elastic4s.requests.searches.queries.funcscorer.MultiValueMode
 import com.sksamuel.elastic4s.requests.searches.queries.geo.GeoDistance
 import com.sksamuel.elastic4s.requests.searches.queries.matches.{MultiMatchQueryBuilderType, ZeroTermsQuery}
-import com.sksamuel.elastic4s.requests.searches.queries.{RegexpFlag, SimpleQueryStringFlag}
+import com.sksamuel.elastic4s.requests.searches.queries.{AllOf, AnyOf, IntervalsQuery, Match, RegexpFlag, SimpleQueryStringFlag}
 import com.sksamuel.elastic4s.requests.searches.sort.{SortMode, SortOrder}
 import com.sksamuel.elastic4s.requests.searches.suggestion.{DirectGenerator, Fuzziness, SuggestMode}
 import org.scalatest.OneInstancePerTest
@@ -92,6 +92,19 @@ class SearchDslTest extends AnyFlatSpec with MockitoSugar with JsonSugar with On
       rankFeatureQuery("pagerank").boost(0.5).withSigmoid(Sigmoid(7, 0.6))
     }
     req.request.entity.get.get should matchJsonResource("/json/search/search_rank_feature.json")
+  }
+
+  it should "generate json for an intervals query" in {
+    val req = search("*") limit 5 query {
+      IntervalsQuery("my_text", AllOf(List(
+        Match(query = "my favorite food").maxGaps(0).ordered(true),
+        AnyOf(intervals = List(
+          Match(query = "hot water"),
+          Match(query = "cold porridge")
+        ))
+      )).ordered(true))
+    }
+    req.request.entity.get.get should matchJsonResource("/json/search/search_intervals.json")
   }
 
   it should "generate json for a wildcard query" in {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/IntervalsQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/IntervalsQueryTest.scala
@@ -1,0 +1,49 @@
+package com.sksamuel.elastic4s.search.queries
+
+import com.sksamuel.elastic4s.requests.common.RefreshPolicy
+import com.sksamuel.elastic4s.requests.searches.queries.{AllOf, AnyOf, IntervalsQuery, Match}
+import com.sksamuel.elastic4s.testkit.DockerTests
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
+
+class IntervalsQueryTest extends AnyFlatSpec with Matchers with DockerTests {
+  Try {
+    client.execute {
+      deleteIndex("intervalstest")
+    }.await
+  }
+
+  client.execute {
+    createIndex("intervalstest")
+  }.await
+
+  client.execute {
+    bulk(
+      indexInto("intervalstest").fields(
+        "my_text" -> "my favorite food is cold porridge"
+        ),
+      indexInto("intervalstest").fields(
+        "my_text" -> "when it's cold my favorite food is porridge"
+      )
+    ).refresh(RefreshPolicy.Immediate)
+  }.await
+
+  "intervals query" should "work as in the elasticsearch docs" in {
+    val resp = client.execute {
+      search("intervalstest").query {
+        IntervalsQuery("my_text", AllOf(List(
+          Match(query = "favorite food").maxGaps(0).ordered(true),
+          AnyOf(intervals = List(
+            Match(query = "hot water"),
+            Match(query = "cold porridge")
+          ))
+        )).ordered(true))
+      }
+    }.await.result
+
+    resp.totalHits shouldBe 1
+    resp.hits.hits.head.sourceField("my_text") shouldBe "my favorite food is cold porridge"
+  }
+}


### PR DESCRIPTION
Applying this PR will add the intervals query feature, which was introduced in Elasticsearch 7.0 (https://www.elastic.co/guide/en/elasticsearch/reference/7.7/query-dsl-intervals-query.html).
For the tests I took the examples from the Elasticsearch website.

Closes #2090.