### PR TITLE
Support basic authentication in the akka-http client

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -51,12 +51,46 @@ Other [alternative clients](https://search.maven.org/search?q=g:com.sksamuel.ela
 
 To use these, add the appropriate module to your build, and then pass an instance of that `HttpClient` to `ElasticClient`.
 
-For example, for akka-http, we use `AkkaHttpClient`:
+#### Akka HTTP
+For Akka HTTP, we use `AkkaHttpClient`:
 
 ```scala
-val client = ElasticClient(AkkaHttpClient("http://host1:9200"))
+val client = ElasticClient(AkkaHttpClient(AkkaHttpClientSettings(List("http://host1:9200"))))
 ```
 
+It's possible to create the `AkkaHttpClientSettings` from Typesafe configuration using `AkkaHttpClientSettings.defaults` or by passing in a `Config` instance using `AkkaHttpClientSettings(config)`.
+
+The default configuration:
+
+```
+com.sksamuel.elastic4s.akka {
+  hosts: []
+  https: false
+  queue-size: 1000
+  blacklist {
+    min-duration = 1m
+    max-duration = 30m
+  }
+  max-retry-timeout = 30s
+  akka.http {
+    // akka-http settings specific for elastic4s
+    // can be overwritten in this section
+  }
+}
+```
+
+Using `AkkaHttpClientSettings.defaults` you can still override any of these settings by defining the right keys in your own `application.conf`
+
+The Akka HTTP client supports basic authentication by specifying a username and password:
+
+```
+com.sksamuel.elastic4s.akka {
+  username = user
+  password = pass
+}
+```
+
+#### STTP
 For sttp, we use `SttpRequestHttpClient`:
 
 ```scala

--- a/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientSettings.scala
+++ b/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientSettings.scala
@@ -8,23 +8,48 @@ import com.typesafe.config.{Config, ConfigFactory}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
+import scala.util.Try
 
 object AkkaHttpClientSettings {
 
-  private def defaultConfig: Config = ConfigFactory.load().getConfig("com.sksamuel.elastic4s.akka")
+  private def defaultConfig: Config =
+    ConfigFactory.load().getConfig("com.sksamuel.elastic4s.akka")
 
   lazy val default: AkkaHttpClientSettings = apply(defaultConfig)
 
   def apply(config: Config): AkkaHttpClientSettings = {
     val cfg = config.withFallback(defaultConfig)
     val hosts = cfg.getStringList("hosts").asScala.toVector
+    val username = Try(cfg.getString("username")).map(Some(_)).getOrElse(None)
+    val password = Try(cfg.getString("password")).map(Some(_)).getOrElse(None)
     val queueSize = cfg.getInt("queue-size")
     val https = cfg.getBoolean("https")
-    val blacklistMinDuration = Duration(cfg.getDuration("blacklist.min-duration", TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS)
-    val blacklistMaxDuration = Duration(cfg.getDuration("blacklist.max-duration", TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS)
-    val maxRetryTimeout = Duration(cfg.getDuration("max-retry-timeout", TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS)
-    val poolSettings = ConnectionPoolSettings(cfg.withFallback(ConfigFactory.load()))
-    AkkaHttpClientSettings(https, hosts, queueSize, poolSettings, blacklistMinDuration, blacklistMaxDuration, maxRetryTimeout)
+    val blacklistMinDuration = Duration(
+      cfg.getDuration("blacklist.min-duration", TimeUnit.MILLISECONDS),
+      TimeUnit.MILLISECONDS
+    )
+    val blacklistMaxDuration = Duration(
+      cfg.getDuration("blacklist.max-duration", TimeUnit.MILLISECONDS),
+      TimeUnit.MILLISECONDS
+    )
+    val maxRetryTimeout = Duration(
+      cfg.getDuration("max-retry-timeout", TimeUnit.MILLISECONDS),
+      TimeUnit.MILLISECONDS
+    )
+    val poolSettings = ConnectionPoolSettings(
+      cfg.withFallback(ConfigFactory.load())
+    )
+    AkkaHttpClientSettings(
+      https,
+      hosts,
+      username,
+      password,
+      queueSize,
+      poolSettings,
+      blacklistMinDuration,
+      blacklistMaxDuration,
+      maxRetryTimeout
+    )
   }
 
   def apply(): AkkaHttpClientSettings = {
@@ -36,11 +61,20 @@ object AkkaHttpClientSettings {
   }
 }
 
-case class AkkaHttpClientSettings(https: Boolean,
-                                  hosts: Vector[String],
-                                  queueSize: Int,
-                                  poolSettings: ConnectionPoolSettings,
-                                  blacklistMinDuration: FiniteDuration = AkkaHttpClientSettings.default.blacklistMinDuration,
-                                  blacklistMaxDuration: FiniteDuration = AkkaHttpClientSettings.default.blacklistMaxDuration,
-                                  maxRetryTimeout: FiniteDuration = AkkaHttpClientSettings.default.maxRetryTimeout,
-                                  requestCallback: HttpRequest => HttpRequest = identity)
+case class AkkaHttpClientSettings(
+  https: Boolean,
+  hosts: Vector[String],
+  username: Option[String],
+  password: Option[String],
+  queueSize: Int,
+  poolSettings: ConnectionPoolSettings,
+  blacklistMinDuration: FiniteDuration =
+    AkkaHttpClientSettings.default.blacklistMinDuration,
+  blacklistMaxDuration: FiniteDuration =
+    AkkaHttpClientSettings.default.blacklistMaxDuration,
+  maxRetryTimeout: FiniteDuration =
+    AkkaHttpClientSettings.default.maxRetryTimeout,
+  requestCallback: HttpRequest => HttpRequest = identity
+) {
+  def hasCredentialsDefined: Boolean = username.isDefined && password.isDefined
+}


### PR DESCRIPTION
# Context

Supports basic authentication for ElasticSearch with the akka-http client: #2145

# Note

My IDE that's set up with `scalafmt` reformatted the files I touched. I couldn't find any information on which formatter is used in elastic4s so please let me know how you'd like me to format the code to be in sync with the rest.
