### PR TITLE
parse nested field properties in GetIndexResponse

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/IndexHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/IndexHandlers.scala
@@ -73,7 +73,7 @@ trait IndexHandlers {
 case class Mapping(properties: Map[String, Field],
                    @JsonProperty("_meta") meta: Map[String, String] = Map.empty)
 
-case class Field(`type`: String)
+case class Field(`type`: Option[String], properties: Option[Map[String, Field]] = None)
 
 case class GetIndexResponse(aliases: Map[String, Map[String, Any]],
                             mappings: Mapping,


### PR DESCRIPTION
ES can returned nested property descriptions, which we weren't parsing. In those nested cases, the `type` field may also be absent (it may _also_ be present, e.g. if the field is a 'nested', rather than 'object' type)