### PR TITLE
CompletionSuggestionBuilderFn with regex: remove NotImplementedError caused by ???

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/suggestion/CompletionSuggestionBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/suggestion/CompletionSuggestionBuilderFn.scala
@@ -24,7 +24,6 @@ object CompletionSuggestionBuilderFn {
     completion.skipDuplicates.foreach(builder.field("skip_duplicates", _))
 
     completion.regex.foreach { regex =>
-      ??? // should use regex here ??
       builder.startObject("regex")
       completion.maxDeterminizedStates.foreach(builder.field("max_determinized_states", _))
       if (completion.regexFlags.nonEmpty)


### PR DESCRIPTION
fix for issue on:
https://github.com/sksamuel/elastic4s/issues/2151

The tests for the core project for all scala versions were green:
```
sbt
project core
+test
```

