### PR TITLE
Fix deprecation warnings for nested sorting

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/SortBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/SortBuilderFn.scala
@@ -22,8 +22,8 @@ object FieldSortBuilderFn {
     fs.missing.foreach(builder.autofield("missing", _))
     fs.sortMode.map(EnumConversions.sortMode).foreach(builder.field("mode", _))
     builder.field("order", EnumConversions.order(fs.order))
-    fs.nestedPath.foreach(builder.field("nested_path", _))
-    fs.nestedFilter.map(QueryBuilderFn.apply).map(_.string).foreach(builder.rawField("nested_filter", _))
+    fs.nestedPath.foreach(builder.field("path", _))
+    fs.nestedFilter.map(QueryBuilderFn.apply).map(_.string).foreach(builder.rawField("filter", _))
 
     builder.endObject().endObject()
   }
@@ -63,8 +63,8 @@ object GeoDistanceSortBuilderFn {
       EnumConversions.unit(unit)
     }
     geo.unit.map(EnumConversions.unit).foreach(unit => builder.field("unit", unit))
-    geo.nestedPath.foreach(builder.field("nested_path", _))
-    geo.nestedFilter.map(QueryBuilderFn.apply).map(_.string).foreach(builder.rawField("nested_filter", _))
+    geo.nestedPath.foreach(builder.field("path", _))
+    geo.nestedFilter.map(QueryBuilderFn.apply).map(_.string).foreach(builder.rawField("filter", _))
 
     builder
   }
@@ -87,8 +87,8 @@ object ScriptSortBuilderFn {
 
     scriptSort.order.map(a => builder.field("order", EnumConversions.order(a)))
     scriptSort.sortMode.map(a => builder.field("mode", EnumConversions.sortMode(a)))
-    scriptSort.nestedPath.map(a => builder.field("nested_path", a))
-    scriptSort.nestedFilter.map(QueryBuilderFn.apply).map(_.string).foreach(builder.rawField("nested_filter", _))
+    scriptSort.nestedPath.map(a => builder.field("path", a))
+    scriptSort.nestedFilter.map(QueryBuilderFn.apply).map(_.string).foreach(builder.rawField("filter", _))
 
     builder.endObject()
   }

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/queries/SortBuilderFnTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/queries/SortBuilderFnTest.scala
@@ -25,7 +25,7 @@ class SortBuilderFnTest extends AnyFunSuite with Matchers {
       .nestedPath("foo.bar")
       .nestedFilter(matchQuery("foo.bar", "foo"))
     SortBuilderFn(request).string() shouldBe
-      """{"_script":{"script":{"source":"dummy script","lang":"painless","params":{"nump":10.2,"stringp":"ciao","boolp":true}},"type":"number","order":"desc","nested_path":"foo.bar","nested_filter":{"match":{"foo.bar":{"query":"foo"}}}}}"""
+      """{"_script":{"script":{"source":"dummy script","lang":"painless","params":{"nump":10.2,"stringp":"ciao","boolp":true}},"type":"number","order":"desc","path":"foo.bar","filter":{"match":{"foo.bar":{"query":"foo"}}}}}"""
   }
 
   test("geo distance sort does not generate unit field by default") {

--- a/elastic4s-tests/src/test/resources/json/search/search_sort_field.json
+++ b/elastic4s-tests/src/test/resources/json/search/search_sort_field.json
@@ -5,7 +5,7 @@
                 "order": "desc",
                 "missing": "no-singer",
                 "mode": "avg",
-                "nested_path": "nest"
+                "path": "nest"
             }
         }
     ]

--- a/elastic4s-tests/src/test/resources/json/search/search_sort_nested_field.json
+++ b/elastic4s-tests/src/test/resources/json/search/search_sort_nested_field.json
@@ -4,7 +4,7 @@
             "singer.weight": {
                 "mode": "sum",
                 "order": "desc",
-                "nested_filter": {
+                "filter": {
                     "term": {
                         "singer.name": {
                             "value": "coldplay"

--- a/elastic4s-tests/src/test/resources/json/search/search_sort_script.json
+++ b/elastic4s-tests/src/test/resources/json/search/search_sort_script.json
@@ -9,7 +9,7 @@
                 "type": "number",
                 "order": "desc",
                 "mode": "min",
-                "nested_path": "a.b.c"
+                "path": "a.b.c"
             }
         }
     ]


### PR DESCRIPTION
The `nested_filter` and `nested_path` fields have been deprecated since 6.1
https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#nested-sorting