### PR TITLE
Fix nested path and filter sort

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/SortBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/SortBuilderFn.scala
@@ -22,8 +22,8 @@ object FieldSortBuilderFn {
     fs.missing.foreach(builder.autofield("missing", _))
     fs.sortMode.map(EnumConversions.sortMode).foreach(builder.field("mode", _))
     builder.field("order", EnumConversions.order(fs.order))
-    fs.nestedPath.foreach(builder.field("path", _))
-    fs.nestedFilter.map(QueryBuilderFn.apply).map(_.string).foreach(builder.rawField("filter", _))
+    fs.nestedPath.foreach(builder.startObject("nested").field("path", _).endObject())
+    fs.nestedFilter.map(QueryBuilderFn.apply).map(_.string).foreach(builder.startObject("nested").rawField("filter", _).endObject())
 
     builder.endObject().endObject()
   }

--- a/elastic4s-tests/src/test/resources/json/search/search_sort_field.json
+++ b/elastic4s-tests/src/test/resources/json/search/search_sort_field.json
@@ -5,7 +5,9 @@
                 "order": "desc",
                 "missing": "no-singer",
                 "mode": "avg",
-                "path": "nest"
+                "nested": {
+                    "path": "nest"
+                }
             }
         }
     ]

--- a/elastic4s-tests/src/test/resources/json/search/search_sort_nested_field.json
+++ b/elastic4s-tests/src/test/resources/json/search/search_sort_nested_field.json
@@ -4,10 +4,12 @@
             "singer.weight": {
                 "mode": "sum",
                 "order": "desc",
-                "filter": {
-                    "term": {
-                        "singer.name": {
-                            "value": "coldplay"
+                "nested": {
+                    "filter": {
+                        "term": {
+                            "singer.name": {
+                                "value": "coldplay"
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This PR fixes a mixup I made with my previous PR (this one #2173)
The change in that PR only changed `nested_path` and `nested_filter` to `path` and `filter` where it actually should have been like this:
```json
"nested": {
  "path": "some path",
  "filter": {
    "term": "some term"
  }
}
```