### PR TITLE
Fix field sort when both nested path and nested filter are defined

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/SortBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/SortBuilderFn.scala
@@ -22,8 +22,12 @@ object FieldSortBuilderFn {
     fs.missing.foreach(builder.autofield("missing", _))
     fs.sortMode.map(EnumConversions.sortMode).foreach(builder.field("mode", _))
     builder.field("order", EnumConversions.order(fs.order))
-    fs.nestedPath.foreach(builder.startObject("nested").field("path", _).endObject())
-    fs.nestedFilter.map(QueryBuilderFn.apply).map(_.string).foreach(builder.startObject("nested").rawField("filter", _).endObject())
+    if (fs.nestedPath.nonEmpty || fs.nestedFilter.nonEmpty) {
+      builder.startObject("nested")
+      fs.nestedPath.foreach(builder.field("path", _))
+      fs.nestedFilter.map(f => QueryBuilderFn(f).string()).foreach(builder.rawField("filter", _))
+      builder.endObject()
+    }
 
     builder.endObject().endObject()
   }

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/FieldSortBuilderFnTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/FieldSortBuilderFnTest.scala
@@ -1,0 +1,25 @@
+package com.sksamuel.elastic4s.requests.searches
+
+import com.sksamuel.elastic4s.requests.searches.queries.{FieldSortBuilderFn, RangeQuery}
+import com.sksamuel.elastic4s.requests.searches.sort.FieldSort
+import com.sksamuel.elastic4s.requests.searches.sort.SortMode.{Avg, Min}
+import com.sksamuel.elastic4s.requests.searches.sort.SortOrder.Asc
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class FieldSortBuilderFnTest extends AnyFunSuite with Matchers {
+
+  test("field sort builder should support defining both nested path and nested filter") {
+    val fieldSort = FieldSort(
+      field = "parent.child.age",
+      sortMode = Some(Min),
+      order = Asc,
+      nestedPath = Some("parent"),
+      nestedFilter = Some(RangeQuery(field = "parent.child", gte = Some(21L)))
+    )
+
+    FieldSortBuilderFn(fieldSort).string() shouldBe
+      """{"parent.child.age":{"mode":"min","order":"asc","nested":{"path":"parent","filter":{"range":{"parent.child":{"gte":21}}}}}}"""
+
+  }
+}


### PR DESCRIPTION
Applying this PR will fix the field sort when both nested path and nested filter are defined. Currently when a nested filter is defined it will override the nested path in the builder.