### PR TITLE
backport CompletionSuggestionBuilderFn regex problem from 7.8.1 to 7.5.1

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/suggestion/CompletionSuggestionBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/suggestion/CompletionSuggestionBuilderFn.scala
@@ -23,7 +23,6 @@ object CompletionSuggestionBuilderFn {
     completion.skipDuplicates.foreach(builder.field("skip_duplicates", _))
 
     completion.regex.foreach { regex =>
-      ??? // should use regex here ??
       builder.startObject("regex")
       completion.maxDeterminizedStates.foreach(builder.field("max_determinized_states", _))
       if (completion.regexFlags.nonEmpty)


### PR DESCRIPTION
https://github.com/sksamuel/elastic4s/pull/2152

backported that simple fix to 7.5.x(via cherrypick) because thats the version of ES i'm stuck with atm 🤷‍♂️ 

if there's any other way you prefer doing backports let me know
