### PR TITLE
Fix setting Akka HTTP credentials

### DIFF
--- a/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClient.scala
+++ b/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClient.scala
@@ -237,13 +237,13 @@ class AkkaHttpClient private[akka] (
       entity = request.entity.map(toEntity).getOrElse(HttpEntity.Empty)
     )
 
-    if (settings.hasCredentialsDefined) {
-      httpRequest.addCredentials(
-        BasicHttpCredentials(settings.username.get, settings.password.get)
-      )
-    }
-
-    settings.requestCallback(httpRequest)
+    settings.requestCallback(
+      if (settings.hasCredentialsDefined) {
+        httpRequest.addCredentials(BasicHttpCredentials(settings.username.get, settings.password.get))
+      } else {
+        httpRequest
+      }
+    )
   }
 
   private def toResponse(response: HttpResponse,


### PR DESCRIPTION
Fixes a bug from #2146 which caused the credentials to be effectively ignored. Since `httpRequest.addCredentials` returns a copy of `httpRequest` the original implementation didn't work. Now, the copy with the credentials is used when making the request.