### PR TITLE
Add wildcard field

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/fields/builders/ElasticFieldBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/fields/builders/ElasticFieldBuilderFn.scala
@@ -1,5 +1,5 @@
 package com.sksamuel.elastic4s.fields.builders
-import com.sksamuel.elastic4s.fields.{AliasField, AnnotatedTextField, BinaryField, BooleanField, CompletionField, ConstantKeywordField, DateField, DateNanosField, DenseVectorField, ElasticField, FlattenedField, GeoPointField, GeoShapeField, HistogramField, JoinField, KeywordField, Murmur3Field, NestedField, NumberField, ObjectField, PercolatorField, RangeField, RankFeatureField, RankFeaturesField, SearchAsYouTypeField, TextField, TokenCountField}
+import com.sksamuel.elastic4s.fields.{AliasField, AnnotatedTextField, BinaryField, BooleanField, CompletionField, ConstantKeywordField, DateField, DateNanosField, DenseVectorField, ElasticField, FlattenedField, GeoPointField, GeoShapeField, HistogramField, JoinField, KeywordField, Murmur3Field, NestedField, NumberField, ObjectField, PercolatorField, RangeField, RankFeatureField, RankFeaturesField, SearchAsYouTypeField, TextField, TokenCountField, WildcardField}
 import com.sksamuel.elastic4s.json.XContentBuilder
 
 object ElasticFieldBuilderFn {
@@ -32,6 +32,7 @@ object ElasticFieldBuilderFn {
       case f: SearchAsYouTypeField => SearchAsYouTypeFieldBuilderFn.build(f)
       case f: TextField => TextFieldBuilderFn.build(f)
       case f: TokenCountField => TokenCountFieldBuilderFn.build(f)
+      case f: WildcardField => WildcardFieldBuilderFn.build(f)
     }
   }
 }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/fields/builders/WildcardFieldBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/fields/builders/WildcardFieldBuilderFn.scala
@@ -1,0 +1,14 @@
+package com.sksamuel.elastic4s.fields.builders
+
+import com.sksamuel.elastic4s.fields.WildcardField
+import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
+
+object WildcardFieldBuilderFn {
+
+  def build(field: WildcardField): XContentBuilder = {
+    val builder = XContentFactory.jsonBuilder()
+    builder.field("type", field.`type`)
+    field.ignoreAbove.foreach(builder.field("ignore_above", _))
+    builder.endObject()
+  }
+}

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/fields/fields.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/fields/fields.scala
@@ -11,6 +11,11 @@ case class ConstantKeywordField(override val name: String, value: String) extend
   override def `type`: String = "constant_keyword"
 }
 
+case class WildcardField(override val name: String,
+                         ignoreAbove: Option[Int] = None) extends ElasticField {
+  override def `type`: String = "wildcard"
+}
+
 case class TextField(override val name: String,
                      analyzer: Option[String] = None,
                      boost: Option[Double] = None,


### PR DESCRIPTION
Applying this PR will add the wildcard field, which was introduced in Elasticsearch 7.9 (https://www.elastic.co/guide/en/elasticsearch/reference/7.9/keyword.html#wildcard-field-type).