### PR TITLE
Fix SearchAsYouTypeField `type` field value

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/mappings/SearchAsYouTypeField.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/mappings/SearchAsYouTypeField.scala
@@ -29,7 +29,7 @@ case class SearchAsYouTypeField(name: String,
 
   type T = SearchAsYouTypeField
 
-  override def `type` = "text"
+  override def `type` = "search_as_you_type"
 
   override def boost(boost: Double): T = copy(boost = boost.some)
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/SearchAsYouTypeFieldTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/SearchAsYouTypeFieldTest.scala
@@ -28,6 +28,6 @@ class SearchAsYouTypeFieldTest extends AnyFlatSpec with Matchers with ElasticApi
       .nullValue("nully")
       .maxShingleSize(4)
     FieldBuilderFn(field).string() shouldBe
-      """{"type":"text","analyzer":"armenian","boost":1.2,"copy_to":["copy1","copy2"],"doc_values":true,"index":"true","normalizer":"mynorm","norms":true,"null_value":"nully","search_analyzer":"english","store":true,"fielddata":true,"max_input_length":12,"ignore_above":30,"similarity":"classic","index_options":"freqs","max_shingle_size":4}"""
+      """{"type":"search_as_you_type","analyzer":"armenian","boost":1.2,"copy_to":["copy1","copy2"],"doc_values":true,"index":"true","normalizer":"mynorm","norms":true,"null_value":"nully","search_analyzer":"english","store":true,"fielddata":true,"max_input_length":12,"ignore_above":30,"similarity":"classic","index_options":"freqs","max_shingle_size":4}"""
   }
 }


### PR DESCRIPTION
type should be `search_as_you_type`

please, release this as hotfix 🙏 

https://www.elastic.co/guide/en/elasticsearch/reference/current/search-as-you-type.html#search-as-you-type