### PR TITLE
fix: source is ignored when using `multi()`

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/MultiSearchBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/MultiSearchBuilderFn.scala
@@ -26,9 +26,9 @@ object MultiSearchBuilderFn {
       }
       header.endObject()
 
-      val body = SearchBodyBuilderFn(search)
+      val body = request.source.getOrElse(SearchBodyBuilderFn(request).string())
 
-      Seq(header.string(), body.string())
+      Seq(header.string(), body)
 
     }.mkString("\n") + "\n"
   }


### PR DESCRIPTION
When invoking the `multi` search anything on request.source is ignored since this logic lives in the SearchHandlers.scala