### PR TITLE
[6.7.x] Fix deprecated source params and add `retry_on_conflict` to update request in bulk

### DIFF
--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/bulk/BulkBuilderFn.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/bulk/BulkBuilderFn.scala
@@ -56,6 +56,7 @@ object BulkBuilderFn {
         update.routing.foreach(builder.field("_routing", _))
         update.version.foreach(builder.field("version", _))
         update.versionType.foreach(builder.field("version_type", _))
+        update.retryOnConflict.foreach(builder.field("retry_on_conflict", _))
         builder.endObject()
         builder.endObject()
 

--- a/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/fetchContextBuilders.scala
+++ b/elastic4s-http/src/main/scala/com/sksamuel/elastic4s/http/fetchContextBuilders.scala
@@ -11,11 +11,11 @@ object FetchSourceContextBuilderFn {
       if (context.includes.nonEmpty || context.excludes.nonEmpty) {
         builder.startObject("_source")
         context.includes.toList match {
-          case Nil      =>
+          case Nil =>
           case includes => builder.array("includes", includes.toArray)
         }
         context.excludes.toList match {
-          case Nil      =>
+          case Nil =>
           case excludes => builder.array("excludes", excludes.toArray)
         }
         builder.endObject()
@@ -33,9 +33,9 @@ object FetchSourceContextQueryParameterFn {
     if (context.fetchSource) {
       map.put("_source", "true")
       if (context.includes.nonEmpty)
-        map.put("_source_include", context.includes.mkString(","))
+        map.put("_source_includes", context.includes.mkString(","))
       if (context.excludes.nonEmpty)
-        map.put("_source_exclude", context.excludes.mkString(","))
+        map.put("_source_excludes", context.excludes.mkString(","))
     } else
       map.put("_source", "false")
     map.toMap

--- a/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/bulk/BulkBuilderFnTest.scala
+++ b/elastic4s-http/src/test/scala/com/sksamuel/elastic4s/http/bulk/BulkBuilderFnTest.scala
@@ -42,4 +42,14 @@ class BulkBuilderFnTest extends FunSuite with Matchers {
         |{"atomicweight":1,"name":"hydrogen"}""".stripMargin
 
   }
+
+  test("bulk content builder should support retry_on_conflict in UpdateRequest") {
+    val req = bulk(
+      update("2").in("chemistry/elements").doc("atomicweight" -> 2, "name" -> "helium").retryOnConflict(3)
+    )
+
+    BulkBuilderFn(req).mkString("\n") shouldBe
+      """{"update":{"_index":"chemistry","_type":"elements","_id":"2","retry_on_conflict":3}}
+        |{"doc":{"atomicweight":2,"name":"helium"}}""".stripMargin
+  }
 }


### PR DESCRIPTION
Fix warning `Deprecated parameter [_source_include] used, expected [_source_includes] instead`.
Add `retry_on_conflict` to update request in bulk