### PR TITLE
Move s.host.success(host) into Success case to avoid 'Promise already completed' exception

### DIFF
--- a/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClient.scala
+++ b/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClient.scala
@@ -46,9 +46,9 @@ class AkkaHttpClient private[akka] (
             (in, hosts.next()) match {
               case ((r, s), Some(host)) =>
                 // if host is resolved - send request forward
-                s.host.success(host)
                 toRequest(r, host) match {
                   case Success(req) =>
+                    s.host.success(host)
                     (req, s) :: Nil
                   case Failure(e) =>
                     s.host.failure(e)


### PR DESCRIPTION
Fixes https://github.com/sksamuel/elastic4s/issues/2272