### PR TITLE
Add version field

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/fields/builders/ElasticFieldBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/fields/builders/ElasticFieldBuilderFn.scala
@@ -1,5 +1,5 @@
 package com.sksamuel.elastic4s.fields.builders
-import com.sksamuel.elastic4s.fields.{AliasField, AnnotatedTextField, BinaryField, BooleanField, CompletionField, ConstantKeywordField, DateField, DateNanosField, DenseVectorField, ElasticField, FlattenedField, GeoPointField, GeoShapeField, HistogramField, JoinField, KeywordField, Murmur3Field, NestedField, NumberField, ObjectField, PercolatorField, RangeField, RankFeatureField, RankFeaturesField, SearchAsYouTypeField, TextField, TokenCountField, WildcardField}
+import com.sksamuel.elastic4s.fields.{AliasField, AnnotatedTextField, BinaryField, BooleanField, CompletionField, ConstantKeywordField, DateField, DateNanosField, DenseVectorField, ElasticField, FlattenedField, GeoPointField, GeoShapeField, HistogramField, JoinField, KeywordField, Murmur3Field, NestedField, NumberField, ObjectField, PercolatorField, RangeField, RankFeatureField, RankFeaturesField, SearchAsYouTypeField, TextField, TokenCountField, VersionField, WildcardField}
 import com.sksamuel.elastic4s.json.XContentBuilder
 
 object ElasticFieldBuilderFn {
@@ -32,6 +32,7 @@ object ElasticFieldBuilderFn {
       case f: SearchAsYouTypeField => SearchAsYouTypeFieldBuilderFn.build(f)
       case f: TextField => TextFieldBuilderFn.build(f)
       case f: TokenCountField => TokenCountFieldBuilderFn.build(f)
+      case f: VersionField => VersionFieldBuilderFn.build(f)
       case f: WildcardField => WildcardFieldBuilderFn.build(f)
     }
   }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/fields/builders/VersionFieldBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/fields/builders/VersionFieldBuilderFn.scala
@@ -1,0 +1,12 @@
+package com.sksamuel.elastic4s.fields.builders
+
+import com.sksamuel.elastic4s.fields.VersionField
+import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
+
+object VersionFieldBuilderFn {
+  def build(field: VersionField): XContentBuilder = {
+    val builder = XContentFactory.jsonBuilder()
+    builder.field("type", field.`type`)
+    builder.endObject()
+  }
+}

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/fields/fields.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/fields/fields.scala
@@ -467,3 +467,7 @@ case class AnnotatedTextField(name: String) extends ElasticField {
 case class PercolatorField(name: String) extends ElasticField {
   override def `type`: String = "percolator"
 }
+
+case class VersionField(name: String) extends ElasticField {
+  override def `type`: String = "version"
+}


### PR DESCRIPTION
Applying this PR will add the version field, which was introduced in Elasticsearch 7.10 (https://www.elastic.co/guide/en/elasticsearch/reference/7.10/version.html).