### PR TITLE
fix for targetType in reindex request

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/reindex/ReindexBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/reindex/ReindexBuilderFn.scala
@@ -27,15 +27,16 @@ object ReindexBuilderFn {
 
     builder.array("index", request.sourceIndexes.array)
 
-    if (request.targetType.nonEmpty)
-      builder.field("type", request.targetType.get)
-
     request.filter.foreach(q => builder.rawField("query", QueryBuilderFn(q)))
     // end source
     builder.endObject()
 
     builder.startObject("dest")
     builder.field("index", request.targetIndex.name)
+
+    if (request.targetType.nonEmpty)
+      builder.field("type", request.targetType.get)
+
     // end dest
     builder.endObject()
   }


### PR DESCRIPTION
fixes #2326

I fixed it on master because I could not find the ReindexTest on the 6.7.x branch.
The test `apply targetType to dest index - not to the source index` however does fail if the fix is not applied - suggesting that,  contrary to what is specified in the elasticsearch documentation about the reindex, the type is applied also on the source if specified 🤷 .
