### PR TITLE
Wrap StatsBucketAggResult values in Option before converting

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/responses/aggresponses.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/responses/aggresponses.scala
@@ -305,9 +305,9 @@ trait HasAggregations extends AggResult with Transformable {
     StatsBucketAggResult(
       name,
       count = agg(name)("count").toString.toLong,
-      min = agg(name).getOrElse("min", 0).toString.toDouble,
-      max = agg(name).getOrElse("max", 0).toString.toDouble,
-      avg = agg(name).getOrElse("avg", 0).toString.toDouble,
+      min = Option(agg(name).getOrElse("min", 0)).getOrElse(0).toString.toDouble,
+      max = Option(agg(name).getOrElse("max", 0)).getOrElse(0).toString.toDouble,
+      avg = Option(agg(name).getOrElse("avg", 0)).getOrElse(0).toString.toDouble,
       sum = agg(name).getOrElse("sum", 0).toString.toDouble
     )
 }


### PR DESCRIPTION
Bug: [2349](https://github.com/sksamuel/elastic4s/issues/2349). When the StatsBucketAggResult is empty, the "count" and "sum" are 0, but the values for the keys "min", "max", and "avg" are null, so a Null Pointer Exception is thrown when converting toString.toDouble. By wrapping these in an Option, we can check that a value exists and set to 0 if not.