### PR TITLE
Adds case_insensitive flag to Wildcard query

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/term/WildcardQuery.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/term/WildcardQuery.scala
@@ -6,11 +6,13 @@ case class WildcardQuery(field: String,
                          query: Any,
                          boost: Option[Double] = None,
                          queryName: Option[String] = None,
-                         rewrite: Option[String] = None)
+                         rewrite: Option[String] = None,
+                         caseInsensitive: Option[Boolean] = None)
   extends Query
     with MultiTermQuery {
 
   def queryName(queryName: String): WildcardQuery = copy(queryName = Option(queryName))
   def boost(boost: Double): WildcardQuery = copy(boost = Option(boost))
   def rewrite(rewrite: String): WildcardQuery = copy(rewrite = Option(rewrite))
+  def caseInsensitive(caseInsensitive: Boolean): WildcardQuery = copy(caseInsensitive = Option(caseInsensitive))
 }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/term/WildcardQueryBodyFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/term/WildcardQueryBodyFn.scala
@@ -10,6 +10,7 @@ object WildcardQueryBodyFn {
     q.rewrite.foreach(builder.field("rewrite", _))
     q.boost.foreach(builder.field("boost", _))
     q.queryName.foreach(builder.field("_name", _))
+    q.caseInsensitive.foreach(builder.field("case_insensitive",_))
     builder.endObject().endObject().endObject()
   }
 }

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/queries/WildcardQueryBodyFnTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/queries/WildcardQueryBodyFnTest.scala
@@ -1,0 +1,28 @@
+package com.sksamuel.elastic4s.requests.searches.queries
+
+import com.sksamuel.elastic4s.requests.searches.queries.term.{WildcardQuery, WildcardQueryBodyFn}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+// Test of https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html
+class WildcardQueryBodyFnTest extends AnyFunSuite with Matchers {
+  test("Wildcard query should generate expected json") {
+    val q = WildcardQuery("myfield.wildcard", "abc*")
+    WildcardQueryBodyFn(q).string() shouldBe
+      """{"wildcard":{"myfield.wildcard":{"value":"abc*"}}}"""
+  }
+
+  test("Case insensitive Wildcard query should generate expected json") {
+    val q = WildcardQuery("myfield.wildcard", "abc*")
+      .caseInsensitive(true)
+    WildcardQueryBodyFn(q).string() shouldBe
+      """{"wildcard":{"myfield.wildcard":{"value":"abc*","case_insensitive":true}}}"""
+  }
+
+  test("Case sensitive Wildcard query should generate expected json") {
+    val q = WildcardQuery("myfield.wildcard", "abc*")
+      .caseInsensitive(false)
+    WildcardQueryBodyFn(q).string() shouldBe
+      """{"wildcard":{"myfield.wildcard":{"value":"abc*","case_insensitive":false}}}"""
+  }
+}


### PR DESCRIPTION
Adds support for case_insensitive flag introduced in ES 7.10.0

https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html#wildcard-query-field-params

I'm not sure what needs to be done to support the DSL since I don't use that myself.