### PR TITLE
Fix URL encoding of spaces

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticUrlEncoder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticUrlEncoder.scala
@@ -1,0 +1,7 @@
+package com.sksamuel.elastic4s
+
+import java.net.URLEncoder
+
+object ElasticUrlEncoder {
+  def encodeUrlFragment(fragment: String): String = URLEncoder.encode(fragment, "UTF-8").replace("+", "%20")
+}

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/IndexAndTypes.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/IndexAndTypes.scala
@@ -1,7 +1,5 @@
 package com.sksamuel.elastic4s
 
-import java.net.URLEncoder
-
 import scala.language.implicitConversions
 
 trait IndexesLike {
@@ -52,7 +50,7 @@ case class Indexes(values: Seq[String]) extends IndexesLike {
     if (values.isEmpty) {
       "_all"
     } else {
-      val indexNames = if (urlEncode) values.map(URLEncoder.encode(_, "UTF8").replace("+", "%20")) else values
+      val indexNames = if (urlEncode) values.map(ElasticUrlEncoder.encodeUrlFragment) else values
       indexNames.mkString(",")
     }
   }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/IndexAndTypes.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/IndexAndTypes.scala
@@ -52,7 +52,7 @@ case class Indexes(values: Seq[String]) extends IndexesLike {
     if (values.isEmpty) {
       "_all"
     } else {
-      val indexNames = if (urlEncode) values.map(URLEncoder.encode(_, "UTF8")) else values
+      val indexNames = if (urlEncode) values.map(URLEncoder.encode(_, "UTF8").replace("+", "%20")) else values
       indexNames.mkString(",")
     }
   }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/count/CountHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/count/CountHandlers.scala
@@ -1,8 +1,6 @@
 package com.sksamuel.elastic4s.requests.count
 
-import java.net.URLEncoder
-
-import com.sksamuel.elastic4s.{ElasticRequest, Handler, HttpEntity}
+import com.sksamuel.elastic4s.{ElasticRequest, ElasticUrlEncoder, Handler, HttpEntity}
 
 case class CountResponse(count: Long)
 
@@ -15,7 +13,7 @@ trait CountHandlers {
       val endpoint = if(request.indexes.isEmpty)
           "/_all/_count"
         else
-          "/" + request.indexes.values.map(URLEncoder.encode(_, "UTF-8").replace("+", "%20")).mkString(",") + "/_count"
+          "/" + request.indexes.values.map(ElasticUrlEncoder.encodeUrlFragment).mkString(",") + "/_count"
 
       val builder = CountBodyBuilderFn(request)
       val body    = builder.string()

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/count/CountHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/count/CountHandlers.scala
@@ -15,7 +15,7 @@ trait CountHandlers {
       val endpoint = if(request.indexes.isEmpty)
           "/_all/_count"
         else
-          "/" + request.indexes.values.map(URLEncoder.encode).mkString(",") + "/_count"
+          "/" + request.indexes.values.map(URLEncoder.encode(_, "UTF-8").replace("+", "%20")).mkString(",") + "/_count"
 
       val builder = CountBodyBuilderFn(request)
       val body    = builder.string()

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/delete/DeleteHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/delete/DeleteHandlers.scala
@@ -30,7 +30,7 @@ trait DeleteHandlers {
 
     override def build(request: DeleteByQueryRequest): ElasticRequest = {
 
-      val endpoint = s"/${request.indexes.values.map(URLEncoder.encode(_, "UTF-8")).mkString(",")}/_delete_by_query"
+      val endpoint = s"/${request.indexes.values.map(URLEncoder.encode(_, "UTF-8").replace("+", "%20")).mkString(",")}/_delete_by_query"
 
       val params = scala.collection.mutable.Map.empty[String, String]
       if (request.proceedOnConflicts.getOrElse(false))
@@ -75,7 +75,7 @@ trait DeleteHandlers {
     override def build(request: DeleteByIdRequest): ElasticRequest = {
 
       val endpoint =
-        s"/${URLEncoder.encode(request.index.index, "UTF-8")}/_doc/${URLEncoder.encode(request.id.toString, "UTF-8")}"
+        s"/${URLEncoder.encode(request.index.index, "UTF-8").replace("+", "%20")}/_doc/${URLEncoder.encode(request.id.toString, "UTF-8").replace("+", "%20")}"
 
       val params = scala.collection.mutable.Map.empty[String, String]
       request.parent.foreach(params.put("parent", _))

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/delete/DeleteHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/delete/DeleteHandlers.scala
@@ -1,11 +1,9 @@
 package com.sksamuel.elastic4s.requests.delete
 
-import java.net.URLEncoder
-
 import com.sksamuel.elastic4s.requests.common.RefreshPolicyHttpValue
 import com.sksamuel.elastic4s.requests.indexes.VersionTypeHttpString
 import com.sksamuel.elastic4s.requests.searches.queries.QueryBuilderFn
-import com.sksamuel.elastic4s.{ElasticError, ElasticRequest, Handler, HttpEntity, HttpResponse, ResponseHandler, XContentBuilder, XContentFactory}
+import com.sksamuel.elastic4s.{ElasticError, ElasticRequest, ElasticUrlEncoder, Handler, HttpEntity, HttpResponse, ResponseHandler, XContentBuilder, XContentFactory}
 
 object DeleteByQueryBodyFn {
   def apply(request: DeleteByQueryRequest): XContentBuilder = {
@@ -30,7 +28,7 @@ trait DeleteHandlers {
 
     override def build(request: DeleteByQueryRequest): ElasticRequest = {
 
-      val endpoint = s"/${request.indexes.values.map(URLEncoder.encode(_, "UTF-8").replace("+", "%20")).mkString(",")}/_delete_by_query"
+      val endpoint = s"/${request.indexes.values.map(ElasticUrlEncoder.encodeUrlFragment).mkString(",")}/_delete_by_query"
 
       val params = scala.collection.mutable.Map.empty[String, String]
       if (request.proceedOnConflicts.getOrElse(false))
@@ -75,7 +73,7 @@ trait DeleteHandlers {
     override def build(request: DeleteByIdRequest): ElasticRequest = {
 
       val endpoint =
-        s"/${URLEncoder.encode(request.index.index, "UTF-8").replace("+", "%20")}/_doc/${URLEncoder.encode(request.id.toString, "UTF-8").replace("+", "%20")}"
+        s"/${ElasticUrlEncoder.encodeUrlFragment(request.index.index)}/_doc/${ElasticUrlEncoder.encodeUrlFragment(request.id)}"
 
       val params = scala.collection.mutable.Map.empty[String, String]
       request.parent.foreach(params.put("parent", _))

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/get/GetHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/get/GetHandlers.scala
@@ -1,11 +1,9 @@
 package com.sksamuel.elastic4s.requests.get
 
-import java.net.URLEncoder
-
 import com.fasterxml.jackson.databind.JsonNode
 import com.sksamuel.elastic4s.requests.common.FetchSourceContextQueryParameterFn
 import com.sksamuel.elastic4s.requests.indexes.VersionTypeHttpString
-import com.sksamuel.elastic4s.{ElasticError, ElasticRequest, Handler, HitReader, HttpEntity, HttpResponse, ResponseHandler}
+import com.sksamuel.elastic4s.{ElasticError, ElasticRequest, ElasticUrlEncoder, Handler, HitReader, HttpEntity, HttpResponse, ResponseHandler}
 import com.sksamuel.exts.Logging
 
 import scala.util.Try
@@ -72,7 +70,7 @@ trait GetHandlers {
     override def build(request: GetRequest): ElasticRequest = {
 
       val endpoint =
-        s"/${URLEncoder.encode(request.index.index, "UTF-8").replace("+", "%20")}/_doc/${URLEncoder.encode(request.id, "UTF-8").replace("+", "%20")}"
+        s"/${ElasticUrlEncoder.encodeUrlFragment(request.index.index)}/_doc/${ElasticUrlEncoder.encodeUrlFragment(request.id)}"
 
       val params = scala.collection.mutable.Map.empty[String, String]
       request.fetchSource.foreach { context =>

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/get/GetHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/get/GetHandlers.scala
@@ -72,7 +72,7 @@ trait GetHandlers {
     override def build(request: GetRequest): ElasticRequest = {
 
       val endpoint =
-        s"/${URLEncoder.encode(request.index.index, "UTF-8")}/_doc/${URLEncoder.encode(request.id, "UTF-8")}"
+        s"/${URLEncoder.encode(request.index.index, "UTF-8").replace("+", "%20")}/_doc/${URLEncoder.encode(request.id, "UTF-8").replace("+", "%20")}"
 
       val params = scala.collection.mutable.Map.empty[String, String]
       request.fetchSource.foreach { context =>

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/IndexHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/IndexHandlers.scala
@@ -25,9 +25,9 @@ trait IndexHandlers {
 
       val (method, endpoint) = request.id match {
         case Some(id) =>
-          "PUT" -> s"/${URLEncoder.encode(request.index.name, StandardCharsets.UTF_8.name())}/_doc/${URLEncoder.encode(id.toString, StandardCharsets.UTF_8.name())}"
+          "PUT" -> s"/${URLEncoder.encode(request.index.name, StandardCharsets.UTF_8.name()).replace("+", "%20")}/_doc/${URLEncoder.encode(id.toString, StandardCharsets.UTF_8.name()).replace("+", "%20")}"
         case None =>
-          "POST" -> s"/${URLEncoder.encode(request.index.name, StandardCharsets.UTF_8.name())}/_doc"
+          "POST" -> s"/${URLEncoder.encode(request.index.name, StandardCharsets.UTF_8.name()).replace("+", "%20")}/_doc"
       }
 
       val params = scala.collection.mutable.Map.empty[String, String]

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/IndexHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/IndexHandlers.scala
@@ -1,8 +1,5 @@
 package com.sksamuel.elastic4s.requests.indexes
 
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
-
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.sksamuel.elastic4s.HttpEntity.ByteArrayEntity
 import com.sksamuel.elastic4s._
@@ -25,9 +22,9 @@ trait IndexHandlers {
 
       val (method, endpoint) = request.id match {
         case Some(id) =>
-          "PUT" -> s"/${URLEncoder.encode(request.index.name, StandardCharsets.UTF_8.name()).replace("+", "%20")}/_doc/${URLEncoder.encode(id.toString, StandardCharsets.UTF_8.name()).replace("+", "%20")}"
+          "PUT" -> s"/${ElasticUrlEncoder.encodeUrlFragment(request.index.name)}/_doc/${ElasticUrlEncoder.encodeUrlFragment(id)}"
         case None =>
-          "POST" -> s"/${URLEncoder.encode(request.index.name, StandardCharsets.UTF_8.name()).replace("+", "%20")}/_doc"
+          "POST" -> s"/${ElasticUrlEncoder.encodeUrlFragment(request.index.name)}/_doc"
       }
 
       val params = scala.collection.mutable.Map.empty[String, String]

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/admin/IndexAdminHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/admin/IndexAdminHandlers.scala
@@ -1,12 +1,10 @@
 package com.sksamuel.elastic4s.requests.indexes.admin
 
-import java.net.URLEncoder
-
 import com.sksamuel.elastic4s.requests.admin.{AliasExistsRequest, ClearCacheRequest, CloseIndexRequest, FlushIndexRequest, GetSegmentsRequest, IndexShardStoreRequest, IndicesExistsRequest, OpenIndexRequest, RefreshIndexRequest, ShrinkIndexRequest, TypesExistsRequest, UpdateIndexLevelSettingsRequest}
 import com.sksamuel.elastic4s.requests.common.IndicesOptionsParams
 import com.sksamuel.elastic4s.requests.indexes._
 import com.sksamuel.elastic4s.requests.indexes.admin.IndexShardStoreResponse.StoreStatusResponse
-import com.sksamuel.elastic4s.{ElasticError, ElasticRequest, Handler, HttpEntity, HttpResponse, ResponseHandler, XContentFactory}
+import com.sksamuel.elastic4s.{ElasticError, ElasticRequest, Handler, HttpEntity, HttpResponse, ResponseHandler, XContentFactory, ElasticUrlEncoder}
 
 case class ShrinkIndexResponse()
 
@@ -185,7 +183,7 @@ trait IndexAdminHandlers {
 
     override def build(request: CreateIndexRequest): ElasticRequest = {
 
-      val endpoint = "/" + URLEncoder.encode(request.name, "UTF-8").replace("+", "%20")
+      val endpoint = "/" + ElasticUrlEncoder.encodeUrlFragment(request.name)
 
       val params = scala.collection.mutable.Map.empty[String, Any]
       request.waitForActiveShards.foreach(params.put("wait_for_active_shards", _))

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/admin/IndexAdminHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/admin/IndexAdminHandlers.scala
@@ -185,7 +185,7 @@ trait IndexAdminHandlers {
 
     override def build(request: CreateIndexRequest): ElasticRequest = {
 
-      val endpoint = "/" + URLEncoder.encode(request.name, "UTF-8")
+      val endpoint = "/" + URLEncoder.encode(request.name, "UTF-8").replace("+", "%20")
 
       val params = scala.collection.mutable.Map.empty[String, Any]
       request.waitForActiveShards.foreach(params.put("wait_for_active_shards", _))

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/SearchHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/SearchHandlers.scala
@@ -1,9 +1,7 @@
 package com.sksamuel.elastic4s.requests.searches
 
-import java.net.URLEncoder
-
 import com.sksamuel.elastic4s.requests.common.IndicesOptionsParams
-import com.sksamuel.elastic4s.{ElasticError, ElasticRequest, Handler, HttpEntity, HttpResponse, JacksonSupport, ResponseHandler}
+import com.sksamuel.elastic4s.{ElasticError, ElasticRequest, ElasticUrlEncoder, Handler, HttpEntity, HttpResponse, JacksonSupport, ResponseHandler}
 
 trait SearchHandlers {
 
@@ -57,7 +55,7 @@ trait SearchHandlers {
           "/_all/_search"
         else
           "/" + request.indexes.values
-            .map(URLEncoder.encode(_, "UTF-8").replace("+", "%20"))
+            .map(ElasticUrlEncoder.encodeUrlFragment)
             .mkString(",") + "/_search"
 
       val params = scala.collection.mutable.Map.empty[String, String]

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/SearchHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/SearchHandlers.scala
@@ -57,7 +57,7 @@ trait SearchHandlers {
           "/_all/_search"
         else
           "/" + request.indexes.values
-            .map(URLEncoder.encode(_, "UTF-8"))
+            .map(URLEncoder.encode(_, "UTF-8").replace("+", "%20"))
             .mkString(",") + "/_search"
 
       val params = scala.collection.mutable.Map.empty[String, String]

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/security/roles/RoleHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/security/roles/RoleHandlers.scala
@@ -10,7 +10,7 @@ trait RoleHandlers {
 	implicit object GetRoleHandler extends Handler[GetRoleRequest, Map[String,GetRoleResponse]] {
 
 		override def build(request: GetRoleRequest): ElasticRequest = {
-			val endpoint = ROLE_BASE_PATH + URLEncoder.encode(request.name, "UTF-8")
+			val endpoint = ROLE_BASE_PATH + URLEncoder.encode(request.name, "UTF-8").replace("+", "%20")
 			ElasticRequest("GET", endpoint)
 		}
 	}

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/security/roles/RoleHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/security/roles/RoleHandlers.scala
@@ -1,8 +1,6 @@
 package com.sksamuel.elastic4s.requests.security.roles
 
-import java.net.URLEncoder
-
-import com.sksamuel.elastic4s.{ElasticRequest, Handler}
+import com.sksamuel.elastic4s.{ElasticRequest, ElasticUrlEncoder, Handler}
 
 trait RoleHandlers {
 	private val ROLE_BASE_PATH = "/_security/role/"
@@ -10,7 +8,7 @@ trait RoleHandlers {
 	implicit object GetRoleHandler extends Handler[GetRoleRequest, Map[String,GetRoleResponse]] {
 
 		override def build(request: GetRoleRequest): ElasticRequest = {
-			val endpoint = ROLE_BASE_PATH + URLEncoder.encode(request.name, "UTF-8").replace("+", "%20")
+			val endpoint = ROLE_BASE_PATH + ElasticUrlEncoder.encodeUrlFragment(request.name)
 			ElasticRequest("GET", endpoint)
 		}
 	}

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/security/roles/admin/RoleAdminHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/security/roles/admin/RoleAdminHandlers.scala
@@ -1,9 +1,7 @@
 package com.sksamuel.elastic4s.requests.security.roles.admin
 
-import java.net.URLEncoder
-
 import com.sksamuel.elastic4s.requests.security.roles.{CreateOrUpdateRoleContentBuilder, CreateOrUpdateRoleRequest, CreateRole, CreateRoleResponse, DeleteRoleRequest, UpdateRole}
-import com.sksamuel.elastic4s.{ElasticError, ElasticRequest, Handler, HttpEntity, HttpResponse, ResponseHandler}
+import com.sksamuel.elastic4s.{ElasticError, ElasticRequest, ElasticUrlEncoder, Handler, HttpEntity, HttpResponse, ResponseHandler}
 
 trait RoleAdminHandlers {
 	private val ROLE_BASE_PATH = "/_security/role/"
@@ -18,7 +16,7 @@ trait RoleAdminHandlers {
 		}
 
 		override def build(request: CreateOrUpdateRoleRequest): ElasticRequest = {
-			val endpoint = ROLE_BASE_PATH + URLEncoder.encode(request.name, "UTF-8").replace("+", "%20")
+			val endpoint = ROLE_BASE_PATH + ElasticUrlEncoder.encodeUrlFragment(request.name)
 
 			val body = CreateOrUpdateRoleContentBuilder(request).string()
 			val entity = HttpEntity(body, "application/json")
@@ -41,14 +39,14 @@ trait RoleAdminHandlers {
 		}
 
 		override def build(request: DeleteRoleRequest): ElasticRequest = {
-			val endpoint = ROLE_BASE_PATH + URLEncoder.encode(request.name, "UTF-8").replace("+", "%20")
+			val endpoint = ROLE_BASE_PATH + ElasticUrlEncoder.encodeUrlFragment(request.name)
 			ElasticRequest("DELETE", endpoint)
 		}
 	}
 
 	implicit object ClearRolesCacheHandler extends Handler[ClearRolesCacheRequest, ClearRolesCacheResponse] {
 		override def build(request: ClearRolesCacheRequest): ElasticRequest = {
-			val endpoint = ROLE_BASE_PATH + URLEncoder.encode(request.name, "UTF-8").replace("+", "%20") + "/_clear_cache"
+			val endpoint = ROLE_BASE_PATH + ElasticUrlEncoder.encodeUrlFragment(request.name) + "/_clear_cache"
 			ElasticRequest("POST", endpoint)
 		}
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/security/roles/admin/RoleAdminHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/security/roles/admin/RoleAdminHandlers.scala
@@ -18,7 +18,7 @@ trait RoleAdminHandlers {
 		}
 
 		override def build(request: CreateOrUpdateRoleRequest): ElasticRequest = {
-			val endpoint = ROLE_BASE_PATH + URLEncoder.encode(request.name, "UTF-8")
+			val endpoint = ROLE_BASE_PATH + URLEncoder.encode(request.name, "UTF-8").replace("+", "%20")
 
 			val body = CreateOrUpdateRoleContentBuilder(request).string()
 			val entity = HttpEntity(body, "application/json")
@@ -41,14 +41,14 @@ trait RoleAdminHandlers {
 		}
 
 		override def build(request: DeleteRoleRequest): ElasticRequest = {
-			val endpoint = ROLE_BASE_PATH + URLEncoder.encode(request.name, "UTF-8")
+			val endpoint = ROLE_BASE_PATH + URLEncoder.encode(request.name, "UTF-8").replace("+", "%20")
 			ElasticRequest("DELETE", endpoint)
 		}
 	}
 
 	implicit object ClearRolesCacheHandler extends Handler[ClearRolesCacheRequest, ClearRolesCacheResponse] {
 		override def build(request: ClearRolesCacheRequest): ElasticRequest = {
-			val endpoint = ROLE_BASE_PATH + URLEncoder.encode(request.name, "UTF-8") + "/_clear_cache"
+			val endpoint = ROLE_BASE_PATH + URLEncoder.encode(request.name, "UTF-8").replace("+", "%20") + "/_clear_cache"
 			ElasticRequest("POST", endpoint)
 		}
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/security/users/UserHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/security/users/UserHandlers.scala
@@ -1,8 +1,6 @@
 package com.sksamuel.elastic4s.requests.security.users
 
-import java.net.URLEncoder
-
-import com.sksamuel.elastic4s.{ElasticRequest, Handler}
+import com.sksamuel.elastic4s.{ElasticRequest, ElasticUrlEncoder, Handler}
 
 trait UserHandlers {
 	private val ROLE_BASE_PATH = "/_security/user/"
@@ -10,7 +8,7 @@ trait UserHandlers {
 	implicit object GetUserHandler extends Handler[GetUserRequest, Map[String,GetUserResponse]] {
 
 		override def build(request: GetUserRequest): ElasticRequest = {
-			val endpoint = ROLE_BASE_PATH + URLEncoder.encode(request.name, "UTF-8").replace("+", "%20")
+			val endpoint = ROLE_BASE_PATH + ElasticUrlEncoder.encodeUrlFragment(request.name)
 			ElasticRequest("GET", endpoint)
 		}
 	}

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/security/users/UserHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/security/users/UserHandlers.scala
@@ -10,7 +10,7 @@ trait UserHandlers {
 	implicit object GetUserHandler extends Handler[GetUserRequest, Map[String,GetUserResponse]] {
 
 		override def build(request: GetUserRequest): ElasticRequest = {
-			val endpoint = ROLE_BASE_PATH + URLEncoder.encode(request.name, "UTF-8")
+			val endpoint = ROLE_BASE_PATH + URLEncoder.encode(request.name, "UTF-8").replace("+", "%20")
 			ElasticRequest("GET", endpoint)
 		}
 	}

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/security/users/admin/UserAdminHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/security/users/admin/UserAdminHandlers.scala
@@ -18,7 +18,7 @@ trait UserAdminHandlers {
 		}
 
 		override def build(request: CreateOrUpdateUserRequest): ElasticRequest = {
-			val endpoint = USER_BASE_PATH + URLEncoder.encode(request.name, "UTF-8")
+			val endpoint = USER_BASE_PATH + URLEncoder.encode(request.name, "UTF-8").replace("+", "%20")
 
 			val body = CreateOrUpdateUserContentBuilder(request).string()
 			val entity = HttpEntity(body, "application/json")
@@ -34,7 +34,7 @@ trait UserAdminHandlers {
 	implicit object ChangePasswordHandler extends Handler[ChangePasswordRequest, Any] {
 		override def build(request: ChangePasswordRequest): ElasticRequest = {
 			val endpoint = request.name match {
-				case Some(n) => USER_BASE_PATH + URLEncoder.encode(n, "UTF-8") + "/_password"
+				case Some(n) => USER_BASE_PATH + URLEncoder.encode(n, "UTF-8").replace("+", "%20") + "/_password"
 				case None => USER_BASE_PATH + "_password"
 			}
 			val body = ChangePasswordContentBuilder(request).string()
@@ -53,21 +53,21 @@ trait UserAdminHandlers {
 		}
 
 		override def build(request: DeleteUserRequest): ElasticRequest = {
-			val endpoint = USER_BASE_PATH + URLEncoder.encode(request.name, "UTF-8")
+			val endpoint = USER_BASE_PATH + URLEncoder.encode(request.name, "UTF-8").replace("+", "%20")
 			ElasticRequest("DELETE", endpoint)
 		}
 	}
 
 	implicit object DisableUserHandler extends Handler[DisableUserRequest, Any] {
 		override def build(request: DisableUserRequest): ElasticRequest = {
-			val endpoint = USER_BASE_PATH + URLEncoder.encode(request.name, "UTF-8") + "/_disable"
+			val endpoint = USER_BASE_PATH + URLEncoder.encode(request.name, "UTF-8").replace("+", "%20") + "/_disable"
 			ElasticRequest("PUT", endpoint)
 		}
 	}
 
 	implicit object EnableUserHandler extends Handler[EnableUserRequest, Any] {
 		override def build(request: EnableUserRequest): ElasticRequest = {
-			val endpoint = USER_BASE_PATH + URLEncoder.encode(request.name, "UTF-8") + "/_enable"
+			val endpoint = USER_BASE_PATH + URLEncoder.encode(request.name, "UTF-8").replace("+", "%20") + "/_enable"
 			ElasticRequest("PUT", endpoint)
 		}
 	}

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/security/users/admin/UserAdminHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/security/users/admin/UserAdminHandlers.scala
@@ -1,9 +1,7 @@
 package com.sksamuel.elastic4s.requests.security.users.admin
 
-import java.net.URLEncoder
-
 import com.sksamuel.elastic4s.requests.security.users.{CreateOrUpdateUserContentBuilder, CreateOrUpdateUserRequest, CreateUser, CreateUserResponse, DeleteUserRequest, UpdateUser}
-import com.sksamuel.elastic4s.{ElasticError, ElasticRequest, Handler, HttpEntity, HttpResponse, ResponseHandler}
+import com.sksamuel.elastic4s.{ElasticError, ElasticRequest, ElasticUrlEncoder, Handler, HttpEntity, HttpResponse, ResponseHandler}
 
 trait UserAdminHandlers {
 	private val USER_BASE_PATH = "/_security/user/"
@@ -18,7 +16,7 @@ trait UserAdminHandlers {
 		}
 
 		override def build(request: CreateOrUpdateUserRequest): ElasticRequest = {
-			val endpoint = USER_BASE_PATH + URLEncoder.encode(request.name, "UTF-8").replace("+", "%20")
+			val endpoint = USER_BASE_PATH + ElasticUrlEncoder.encodeUrlFragment(request.name)
 
 			val body = CreateOrUpdateUserContentBuilder(request).string()
 			val entity = HttpEntity(body, "application/json")
@@ -34,7 +32,7 @@ trait UserAdminHandlers {
 	implicit object ChangePasswordHandler extends Handler[ChangePasswordRequest, Any] {
 		override def build(request: ChangePasswordRequest): ElasticRequest = {
 			val endpoint = request.name match {
-				case Some(n) => USER_BASE_PATH + URLEncoder.encode(n, "UTF-8").replace("+", "%20") + "/_password"
+				case Some(n) => USER_BASE_PATH + ElasticUrlEncoder.encodeUrlFragment(n) + "/_password"
 				case None => USER_BASE_PATH + "_password"
 			}
 			val body = ChangePasswordContentBuilder(request).string()
@@ -53,21 +51,21 @@ trait UserAdminHandlers {
 		}
 
 		override def build(request: DeleteUserRequest): ElasticRequest = {
-			val endpoint = USER_BASE_PATH + URLEncoder.encode(request.name, "UTF-8").replace("+", "%20")
+			val endpoint = USER_BASE_PATH + ElasticUrlEncoder.encodeUrlFragment(request.name)
 			ElasticRequest("DELETE", endpoint)
 		}
 	}
 
 	implicit object DisableUserHandler extends Handler[DisableUserRequest, Any] {
 		override def build(request: DisableUserRequest): ElasticRequest = {
-			val endpoint = USER_BASE_PATH + URLEncoder.encode(request.name, "UTF-8").replace("+", "%20") + "/_disable"
+			val endpoint = USER_BASE_PATH + ElasticUrlEncoder.encodeUrlFragment(request.name) + "/_disable"
 			ElasticRequest("PUT", endpoint)
 		}
 	}
 
 	implicit object EnableUserHandler extends Handler[EnableUserRequest, Any] {
 		override def build(request: EnableUserRequest): ElasticRequest = {
-			val endpoint = USER_BASE_PATH + URLEncoder.encode(request.name, "UTF-8").replace("+", "%20") + "/_enable"
+			val endpoint = USER_BASE_PATH + ElasticUrlEncoder.encodeUrlFragment(request.name) + "/_enable"
 			ElasticRequest("PUT", endpoint)
 		}
 	}

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateHandlers.scala
@@ -61,7 +61,7 @@ trait UpdateHandlers {
     override def build(request: UpdateRequest): ElasticRequest = {
 
       val endpoint =
-        s"/${URLEncoder.encode(request.index.index, "UTF-8")}/_update/${URLEncoder.encode(request.id, "UTF-8")}"
+        s"/${URLEncoder.encode(request.index.index, "UTF-8").replace("+", "%20")}/_update/${URLEncoder.encode(request.id, "UTF-8").replace("+", "%20")}"
 
       val params = scala.collection.mutable.Map.empty[String, Any]
       request.fetchSource.foreach { context =>

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateHandlers.scala
@@ -1,12 +1,10 @@
 package com.sksamuel.elastic4s.requests.update
 
-import java.net.URLEncoder
-
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.sksamuel.elastic4s.requests.common.{DocumentRef, FetchSourceContextQueryParameterFn, RefreshPolicyHttpValue, Shards}
 import com.sksamuel.elastic4s.requests.script.ScriptBuilderFn
 import com.sksamuel.elastic4s.requests.searches.queries.QueryBuilderFn
-import com.sksamuel.elastic4s.{ElasticError, ElasticRequest, Handler, HttpEntity, HttpResponse, ResponseHandler, XContentBuilder, XContentFactory}
+import com.sksamuel.elastic4s.{ElasticError, ElasticRequest, ElasticUrlEncoder, Handler, HttpEntity, HttpResponse, ResponseHandler, XContentBuilder, XContentFactory}
 import com.sksamuel.exts.OptionImplicits._
 
 case class UpdateGet(found: Boolean, _source: Map[String, Any]) // contains the source if specified by the _source parameter
@@ -61,7 +59,7 @@ trait UpdateHandlers {
     override def build(request: UpdateRequest): ElasticRequest = {
 
       val endpoint =
-        s"/${URLEncoder.encode(request.index.index, "UTF-8").replace("+", "%20")}/_update/${URLEncoder.encode(request.id, "UTF-8").replace("+", "%20")}"
+        s"/${ElasticUrlEncoder.encodeUrlFragment(request.index.index)}/_update/${ElasticUrlEncoder.encodeUrlFragment(request.id)}"
 
       val params = scala.collection.mutable.Map.empty[String, Any]
       request.fetchSource.foreach { context =>

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/ElasticUrlEncoderTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/ElasticUrlEncoderTest.scala
@@ -1,0 +1,19 @@
+package com.sksamuel.elastic4s
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class ElasticUrlEncoderTest extends AnyFunSuite with Matchers {
+
+  test("encode plus signs as %2B") {
+    val expected = "test%2B"
+    val actual = ElasticUrlEncoder.encodeUrlFragment("test+")
+    actual shouldEqual expected
+  }
+
+  test("encode spaces as %20") {
+    val expected = "test%20test"
+    val actual = ElasticUrlEncoder.encodeUrlFragment("test test")
+    actual shouldEqual expected
+  }
+}


### PR DESCRIPTION
References https://github.com/sksamuel/elastic4s/issues/2352

I chose to just replace all plus signs with `%20`. Plus signs are encoded to `%2B` so this shouldn't break anything. 