### PR TITLE
Fix UpdateById upsert object auto-inserting

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateBuilderFn.scala
@@ -30,7 +30,7 @@ object UpdateBuilderFn {
       builder.rawField("upsert", upsert)
     }
 
-    if (request.upsertFields.nonEmpty || (request.docAsUpsert.isDefined && request.docAsUpsert.get) || request.script.isDefined) {
+    if (request.upsertFields.nonEmpty || request.scriptedUpsert.contains(true)) {
       builder.startObject("upsert")
       request.upsertFields.foreach {
         case (name, value) =>

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryBodyFnTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryBodyFnTest.scala
@@ -24,4 +24,56 @@ class UpdateByQueryBodyFnTest extends AnyWordSpec with JsonSugar {
       }
     }
   }
+
+  "update by id" should {
+    "generate correct body" when {
+      "script update" in {
+        val q = updateById("test", "1234")
+          .script(Script("script", Some("painless")))
+
+        UpdateBuilderFn(q).string() should matchJson(
+          """{"script":{"lang":"painless","source":"script"}}"""
+        )
+      }
+
+      "script upsert" in {
+        val q = updateById("test", "1234")
+          .script(Script("script", Some("painless")))
+          .scriptedUpsert(true)
+
+        UpdateBuilderFn(q).string() should matchJson(
+          """{"script":{"lang":"painless","source":"script"},"upsert":{},"scripted_upsert":true}"""
+        )
+      }
+
+      "doc update" in {
+        val q = updateById("test", "1234")
+          .doc("foo" -> "bar")
+
+        UpdateBuilderFn(q).string() should matchJson(
+          """{"doc":{"foo":"bar"}}"""
+        )
+      }
+
+      "doc upsert" in {
+        val q = updateById("test", "1234")
+          .doc("foo" -> "bar")
+          .docAsUpsert(true)
+
+        UpdateBuilderFn(q).string() should matchJson(
+          """{"doc":{"foo":"bar"},"doc_as_upsert":true}"""
+        )
+      }
+
+      "doc update and upsert" in {
+        val q = updateById("test", "1234")
+          .doc("foo" -> "bar")
+          .upsert("foo" -> "baz")
+
+        UpdateBuilderFn(q).string() should matchJson(
+          """{"doc":{"foo":"bar"},"upsert":{"foo":"baz"}}"""
+        )
+      }
+    }
+  }
 }


### PR DESCRIPTION
Due to 307777b1b331a9f9f5acd40e051456f626fe7254, it was impossible
to create non-upsert update query with script.

DocAsUpsert also no longer inserts empty upsert object into the query,
in line with ElasticSearch documentation.

Fixes #2344