### PR TITLE
Add ParamSerializer[T] instances for circe, play, json4s and jackson

### DIFF
--- a/elastic4s-json-circe/src/main/scala/com/sksamuel/elastic4s/circe/package.scala
+++ b/elastic4s-json-circe/src/main/scala/com/sksamuel/elastic4s/circe/package.scala
@@ -4,7 +4,7 @@ import io.circe._
 import io.circe.jawn._
 
 import scala.annotation.implicitNotFound
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Success}
 
 /**
   * Automatic HitAs and Indexable derivation
@@ -34,23 +34,26 @@ package object circe {
   @implicitNotFound(
     "No Decoder for type ${T} found. Use 'import io.circe.generic.auto._' or provide an implicit Decoder instance "
   )
-  implicit def hitReaderWithCirce[T](implicit decoder: Decoder[T]): HitReader[T] = new HitReader[T] {
-    override def read(hit: Hit): Try[T] = decode[T](hit.sourceAsString).fold(Failure(_), Success(_))
-  }
+  implicit def hitReaderWithCirce[T](implicit decoder: Decoder[T]): HitReader[T] =
+    (hit: Hit) => decode[T](hit.sourceAsString).fold(Failure(_), Success(_))
 
   @implicitNotFound(
     "No Encoder for type ${T} found. Use 'import io.circe.generic.auto._' or provide an implicit Encoder instance "
   )
   implicit def indexableWithCirce[T](implicit encoder: Encoder[T],
-                                     printer: Json => String = Printer.noSpaces.pretty): Indexable[T] =
-    new Indexable[T] {
-      override def json(t: T): String = printer(encoder(t))
-    }
+                                     printer: Json => String = Printer.noSpaces.print): Indexable[T] =
+    (t: T) => printer(encoder(t))
 
   @implicitNotFound(
     "No Decoder for type ${T} found. Use 'import io.circe.generic.auto._' or provide an implicit Decoder instance "
   )
-  implicit def aggReaderWithCirce[T](implicit encoder: Decoder[T]): AggReader[T] = new AggReader[T] {
-    override def read(json: String): Try[T] = decode[T](json).fold(Failure(_), Success(_))
-  }
+  implicit def aggReaderWithCirce[T](implicit encoder: Decoder[T]): AggReader[T] =
+    (json: String) => decode[T](json).fold(Failure(_), Success(_))
+
+  @implicitNotFound(
+    "No Encoder for type ${T} found. Use 'import io.circe.generic.auto._' or provide an implicit Encoder instance "
+  )
+  implicit def paramSerializerWithCirce[T](implicit encoder: Encoder[T],
+                                     printer: Json => String = Printer.noSpaces.print): ParamSerializer[T] =
+    (t: T) => printer(encoder(t))
 }

--- a/elastic4s-json-circe/src/test/scala/com/sksamuel/elastic4s/circe/CodecDerivationTest.scala
+++ b/elastic4s-json-circe/src/test/scala/com/sksamuel/elastic4s/circe/CodecDerivationTest.scala
@@ -61,4 +61,21 @@ class CodecDerivationTest extends AnyWordSpec with Matchers with GivenWhenThen {
     }
   }
 
+  "A derived ParamSerializer instance" should {
+    "be implicitly found if circe.generic.auto is in imported" in {
+      """
+        import io.circe.generic.auto._
+        import com.sksamuel.elastic4s.ParamSerializer
+        implicitly[ParamSerializer[Cafe]]
+      """ should compile
+    }
+
+    "not compile if no decoder is in scope" in {
+      """
+        import com.sksamuel.elastic4s.ParamSerializer
+        implicitly[ParamSerializer[Cafe]]
+      """ shouldNot compile
+    }
+  }
+
 }

--- a/elastic4s-json-jackson/src/main/scala/com/sksamuel/elastic4s/jackson/ElasticJackson.scala
+++ b/elastic4s-json-jackson/src/main/scala/com/sksamuel/elastic4s/jackson/ElasticJackson.scala
@@ -13,30 +13,29 @@ object ElasticJackson {
   object Implicits extends Logging {
 
     implicit def JacksonJsonIndexable[T](implicit mapper: ObjectMapper = JacksonSupport.mapper): Indexable[T] =
-      new Indexable[T] {
-        override def json(t: T): String = mapper.writeValueAsString(t)
-      }
+      (t: T) => mapper.writeValueAsString(t)
+
+    implicit def JacksonJsonParamSerializer[T](implicit mapper: ObjectMapper = JacksonSupport.mapper): ParamSerializer[T] =
+      (t: T) => mapper.writeValueAsString(t)
 
     implicit def JacksonJsonHitReader[T](implicit mapper: ObjectMapper with ScalaObjectMapper = JacksonSupport.mapper,
-                                         manifest: Manifest[T]): HitReader[T] = new HitReader[T] {
-      override def read(hit: Hit): Try[T] = Try {
-        val node = mapper.readTree(mapper.writeValueAsBytes(hit.sourceAsMap)).asInstanceOf[ObjectNode]
-        if (!node.has("_id")) node.put("_id", hit.id)
-        if (!node.has("_type")) node.put("_type", hit.`type`)
-        if (!node.has("_index")) node.put("_index", hit.index)
-        //  if (!node.has("_score")) node.put("_score", hit.score)
-        if (!node.has("_version")) node.put("_version", hit.version)
-        if (!node.has("_seq_no")) node.put("_seq_no", hit.seqNo)
-        if (!node.has("_primary_term")) node.put("_primary_term", hit.primaryTerm)
-        if (!node.has("_timestamp"))
-          hit
-            .sourceFieldOpt("_timestamp")
-            .collect {
-              case f => f.toString
-            }
-            .foreach(node.put("_timestamp", _))
-        mapper.readValue[T](mapper.writeValueAsBytes(node))
-      }
+                                         manifest: Manifest[T]): HitReader[T] = (hit: Hit) => Try {
+      val node = mapper.readTree(mapper.writeValueAsBytes(hit.sourceAsMap)).asInstanceOf[ObjectNode]
+      if (!node.has("_id")) node.put("_id", hit.id)
+      if (!node.has("_type")) node.put("_type", hit.`type`)
+      if (!node.has("_index")) node.put("_index", hit.index)
+      //  if (!node.has("_score")) node.put("_score", hit.score)
+      if (!node.has("_version")) node.put("_version", hit.version)
+      if (!node.has("_seq_no")) node.put("_seq_no", hit.seqNo)
+      if (!node.has("_primary_term")) node.put("_primary_term", hit.primaryTerm)
+      if (!node.has("_timestamp"))
+        hit
+          .sourceFieldOpt("_timestamp")
+          .collect {
+            case f => f.toString
+          }
+          .foreach(node.put("_timestamp", _))
+      mapper.readValue[T](mapper.writeValueAsBytes(node))
     }
   }
 }

--- a/elastic4s-json-json4s/src/main/scala/com/sksamuel/elastic4s/json4s/ElasticJson4s.scala
+++ b/elastic4s-json-json4s/src/main/scala/com/sksamuel/elastic4s/json4s/ElasticJson4s.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.elastic4s.json4s
 
-import com.sksamuel.elastic4s.{AggReader, Hit, HitReader, Indexable}
+import com.sksamuel.elastic4s.{AggReader, Hit, HitReader, Indexable, ParamSerializer}
 import org.json4s._
 
 import scala.reflect.Manifest
@@ -10,22 +10,19 @@ object ElasticJson4s {
   object Implicits {
 
     implicit def Json4sHitReader[T](implicit json4s: Serialization, formats: Formats, mf: Manifest[T]): HitReader[T] =
-      new HitReader[T] {
-        override def read(hit: Hit): Try[T] = Try {
-          json4s.read[T](hit.sourceAsString)
-        }
+      (hit: Hit) => Try {
+        json4s.read[T](hit.sourceAsString)
       }
 
     implicit def Json4sAggReader[T](implicit json4s: Serialization, formats: Formats, mf: Manifest[T]): AggReader[T] =
-      new AggReader[T] {
-        override def read(json: String): Try[T] = Try {
-          json4s.read[T](json)
-        }
+      (json: String) => Try {
+        json4s.read[T](json)
       }
 
     implicit def Json4sIndexable[T <: AnyRef](implicit json4s: Serialization, formats: Formats): Indexable[T] =
-      new Indexable[T] {
-        override def json(t: T): String = json4s.write(t)
-      }
+      (t: T) => json4s.write(t)
+
+    implicit def Json4sParamSerializer[T <: AnyRef](implicit json4s: Serialization, formats: Formats): ParamSerializer[T] =
+      (t: T) => json4s.write(t)
   }
 }

--- a/elastic4s-json-json4s/src/test/scala/com/sksamuel/elastic4s/json4s/Json4sParamSerializerTest.scala
+++ b/elastic4s-json-json4s/src/test/scala/com/sksamuel/elastic4s/json4s/Json4sParamSerializerTest.scala
@@ -1,0 +1,26 @@
+package com.sksamuel.elastic4s.json4s
+
+import com.sksamuel.elastic4s.requests.script.Script
+import org.json4s._
+import org.json4s.jackson.Serialization
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class Json4sParamSerializerTest extends AnyWordSpec with Matchers {
+
+  case class Foo(bar: Int)
+
+  "A derived ParamSerializer instance from the elastic4s-json-json4s package" should {
+
+    "be implicitly found and used for parameter serialization" in {
+
+      import ElasticJson4s.Implicits._
+      implicit val formats: Formats = Serialization.formats(NoTypeHints)
+      implicit val serialization: Serialization = Serialization
+
+      Script("some script")
+        .paramObject("some param", Foo(77))
+        .paramsRaw shouldBe Map("some param" -> """{"bar":77}""")
+    }
+  }
+}

--- a/elastic4s-json-play/src/main/scala/com/sksamuel/elastic4s/playjson/package.scala
+++ b/elastic4s-json-play/src/main/scala/com/sksamuel/elastic4s/playjson/package.scala
@@ -8,21 +8,22 @@ import scala.util.Try
 package object playjson {
 
   @implicitNotFound("No Writes for type ${T} found. Bring an implicit Writes[T] instance in scope")
-  implicit def playJsonIndexable[T](implicit w: Writes[T]): Indexable[T] = new Indexable[T] {
-    override def json(t: T): String = Json.stringify(Json.toJson(t)(w))
-  }
+  implicit def playJsonIndexable[T](implicit w: Writes[T]): Indexable[T] =
+    (t: T) => Json.stringify(Json.toJson(t)(w))
 
   @implicitNotFound("No Reads for type ${T} found. Bring an implicit Reads[T] instance in scope")
-  implicit def playJsonHitReader[T](implicit r: Reads[T]): HitReader[T] = new HitReader[T] {
-    override def read(hit: Hit): Try[T] = Try {
+  implicit def playJsonHitReader[T](implicit r: Reads[T]): HitReader[T] =
+    (hit: Hit) => Try {
       Json.parse(hit.sourceAsString).as[T]
     }
-  }
 
   @implicitNotFound("No Reads for type ${T} found. Bring an implicit Reads[T] instance in scope")
-  implicit def playJsonAggReader[T](implicit r: Reads[T]): AggReader[T] = new AggReader[T] {
-    override def read(json: String): Try[T] = Try {
+  implicit def playJsonAggReader[T](implicit r: Reads[T]): AggReader[T] =
+    (json: String) => Try {
       Json.parse(json).as[T]
     }
-  }
+
+  @implicitNotFound("No Writes for type ${T} found. Bring an implicit Writes[T] instance in scope")
+  implicit def playJsonParamSerializer[T](implicit w: Writes[T]): ParamSerializer[T] =
+    (t: T) => Json.stringify(Json.toJson(t)(w))
 }

--- a/elastic4s-json-play/src/test/scala/com/sksamuel/elastic4s/playjson/PlayJsonParamSerializerTest.scala
+++ b/elastic4s-json-play/src/test/scala/com/sksamuel/elastic4s/playjson/PlayJsonParamSerializerTest.scala
@@ -1,0 +1,23 @@
+package com.sksamuel.elastic4s.playjson
+
+import com.sksamuel.elastic4s.requests.script.Script
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import play.api.libs.json.{Json, Writes}
+
+class PlayJsonParamSerializerTest extends AnyWordSpec with Matchers {
+
+  case class Foo(bar: Int)
+
+  "A derived ParamSerializer instance from the elastic4s-json-play package" should {
+
+    "be implicitly found and used for parameter serialization" in {
+
+      implicit val fooWrites: Writes[Foo] = Json.writes[Foo]
+
+      Script("some script")
+        .paramObject("some param", Foo(77))
+        .paramsRaw shouldBe Map("some param" -> """{"bar":77}""")
+    }
+  }
+}


### PR DESCRIPTION
The implicit to derive a ParamSerializer[T] from a json serializer was only implemented for spray json.

I thought it would be a good idea to add one for each json library supported by elastic4s.