### PR TITLE
Update ip field

### DIFF
--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/IpField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/IpField.scala
@@ -4,10 +4,10 @@ import com.sksamuel.exts.OptionImplicits.RichOptionImplicits
 
 case class IpField(name: String,
                    boost: Option[Double] = None,
-                   copyTo: Seq[String] = Nil,
                    docValues: Option[Boolean] = None,
+                   ignoreMalformed: Option[Boolean] = None,
                    index: Option[Boolean] = None,
-                   properties: Seq[ElasticField] = Nil,
+                   nullValue: Option[String] = None,
                    store: Option[Boolean] = None) extends ElasticField {
   override def `type`: String = "ip"
   def boost(boost: Double): IpField = copy(boost = boost.some)

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/IpFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/IpFieldBuilderFn.scala
@@ -11,8 +11,9 @@ object IpFieldBuilderFn {
     builder.field("type", field.`type`)
     field.boost.foreach(builder.field("boost", _))
     field.docValues.foreach(builder.field("doc_values", _))
+    field.ignoreMalformed.foreach(builder.field("ignore_malformed", _))
     field.index.foreach(builder.field("index", _))
-    field.docValues.foreach(builder.field("doc_values", _))
+    field.nullValue.foreach(builder.field("null_value", _))
     field.store.foreach(builder.field("store", _))
     builder.endObject()
   }


### PR DESCRIPTION
Applying this PR will update the `ip` field. As far as I can see, reading https://www.elastic.co/guide/en/elasticsearch/reference/current/ip.html, the `copyTo` and `properties` are not valid parameters but `ignoreMalformed` and `nullValue` are.
