### PR TITLE
Fix auto_date_histogram object name

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/AutoDateHistogramAggregationBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/AutoDateHistogramAggregationBuilder.scala
@@ -8,7 +8,7 @@ object AutoDateHistogramAggregationBuilder {
   def apply(agg: AutoDateHistogramAggregation): XContentBuilder = {
 
     val builder = XContentFactory.jsonBuilder()
-    builder.startObject("date_histogram")
+    builder.startObject("auto_date_histogram")
 
     agg.timeZone.map(EnumConversions.timeZone).foreach(builder.field("time_zone", _))
     agg.minimumInterval.foreach(builder.field("minimum_interval", _))


### PR DESCRIPTION
Looks like this was probably a copy-paste error - the auto date histogram added in https://github.com/sksamuel/elastic4s/commit/49ff096ea89058d7acbafbb1ab8ba453564d8fa3 should have been named `auto_date_histogram` https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-autodatehistogram-aggregation.html