### PR TITLE
Fix deserialization of some elastic responses to snapshot operations

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/api/SnapshotApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/api/SnapshotApi.scala
@@ -44,7 +44,7 @@ trait SnapshotApi {
     def from(repo: String) = RestoreSnapshotRequest(name, repo)
   }
 
-  def createRepository(snapshotName: String, `type`: String) = CreateRepositoryRequest(snapshotName, `type`)
+  def createRepository(repositoryName: String, `type`: String) = CreateRepositoryRequest(repositoryName, `type`)
 
   @deprecated("use createRepository(name: String, repository: String)", "6.0.2")
   def createRepository(name: String) = new CreateRepositoryExpectsType(name)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/snapshots/response.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/snapshots/response.scala
@@ -5,7 +5,7 @@ import com.sksamuel.elastic4s.requests.common.Shards
 import scala.concurrent.duration._
 
 case class CreateRepositoryResponse(acknowledged: Boolean)
-@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION, property = "accepted")
+@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
 @JsonSubTypes(
   Array(
     new JsonSubTypes.Type(value = classOf[CreateSnapshotResponseAsync], name = "accepted"),
@@ -33,7 +33,7 @@ case class Snapshot(snapshot: String,
 }
 
 case class DeleteSnapshotResponse(acknowledged: Boolean)
-@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION, property = "accepted")
+@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
 @JsonSubTypes(
   Array(
     new JsonSubTypes.Type(value = classOf[RestoreSnapshotResponseAsync], name = "accepted"),

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/snapshots/response.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/snapshots/response.scala
@@ -22,6 +22,6 @@ case class Snapshot(snapshot: String,
 }
 
 case class DeleteSnapshotResponse(acknowledged: Boolean)
-case class RestoreSnapshotResponse(acknowledged: Boolean)
+case class RestoreSnapshotResponse(accepted: Boolean)
 
 

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/snapshots/response.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/snapshots/response.scala
@@ -1,11 +1,22 @@
 package com.sksamuel.elastic4s.requests.snapshots
 
-import com.fasterxml.jackson.annotation.JsonProperty
-
+import com.fasterxml.jackson.annotation.{JsonProperty, JsonSubTypes, JsonTypeInfo}
+import com.sksamuel.elastic4s.requests.common.Shards
 import scala.concurrent.duration._
 
 case class CreateRepositoryResponse(acknowledged: Boolean)
-case class CreateSnapshotResponse(accepted: Boolean)
+@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION, property = "accepted")
+@JsonSubTypes(
+  Array(
+    new JsonSubTypes.Type(value = classOf[CreateSnapshotResponseAsync], name = "accepted"),
+    new JsonSubTypes.Type(value = classOf[CreateSnapshotResponseAwait], name = "snapshot")))
+sealed trait CreateSnapshotResponse { def succeeded: Boolean }
+case class CreateSnapshotResponseAsync(accepted: Boolean) extends CreateSnapshotResponse {
+  override def succeeded: Boolean = accepted
+}
+case class CreateSnapshotResponseAwait(snapshot: Snapshot) extends CreateSnapshotResponse {
+  override def succeeded: Boolean = snapshot.state == "SUCCESS"
+}
 case class GetSnapshotResponse(snapshots: Seq[Snapshot])
 case class Snapshot(snapshot: String,
                     uuid: String,
@@ -22,6 +33,18 @@ case class Snapshot(snapshot: String,
 }
 
 case class DeleteSnapshotResponse(acknowledged: Boolean)
-case class RestoreSnapshotResponse(accepted: Boolean)
-
-
+@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION, property = "accepted")
+@JsonSubTypes(
+  Array(
+    new JsonSubTypes.Type(value = classOf[RestoreSnapshotResponseAsync], name = "accepted"),
+    new JsonSubTypes.Type(value = classOf[RestoreSnapshotResponseAwait], name = "snapshot")))
+sealed trait RestoreSnapshotResponse {
+  def succeeded: Boolean
+}
+case class RestoreSnapshotResponseAsync(accepted: Boolean) extends RestoreSnapshotResponse {
+  override def succeeded: Boolean = accepted
+}
+case class RestoreSnapshotResponseSnapshot(snapshot: String, indices: Seq[String], shards: Shards)
+case class RestoreSnapshotResponseAwait(snapshot: RestoreSnapshotResponseSnapshot) extends RestoreSnapshotResponse {
+  override def succeeded: Boolean = snapshot.shards.failed == 0
+}

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/snapshot/SnapshotHandlers.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/snapshot/SnapshotHandlers.scala
@@ -2,7 +2,7 @@ package com.sksamuel.elastic4s.handlers.snapshot
 
 import com.sksamuel.elastic4s.json.XContentFactory
 import com.sksamuel.elastic4s.requests.snapshots.{CreateRepositoryRequest, CreateRepositoryResponse, CreateSnapshotRequest, CreateSnapshotResponse, DeleteSnapshotRequest, DeleteSnapshotResponse, GetSnapshotResponse, GetSnapshotsRequest, RestoreSnapshotRequest, RestoreSnapshotResponse, RestoreSnapshotResponseAsync, RestoreSnapshotResponseAwait}
-import com.sksamuel.elastic4s.{ElasticRequest, Handler, HttpEntity, ResponseHandler}
+import com.sksamuel.elastic4s.{ElasticRequest, Handler, HttpEntity}
 
 trait SnapshotHandlers {
 

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/snapshot/SnapshotHandlers.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/snapshot/SnapshotHandlers.scala
@@ -1,8 +1,8 @@
 package com.sksamuel.elastic4s.handlers.snapshot
 
 import com.sksamuel.elastic4s.json.XContentFactory
-import com.sksamuel.elastic4s.requests.snapshots.{CreateRepositoryRequest, CreateRepositoryResponse, CreateSnapshotRequest, CreateSnapshotResponse, DeleteSnapshotRequest, DeleteSnapshotResponse, GetSnapshotResponse, GetSnapshotsRequest, RestoreSnapshotRequest, RestoreSnapshotResponse}
-import com.sksamuel.elastic4s.{ElasticRequest, Handler, HttpEntity}
+import com.sksamuel.elastic4s.requests.snapshots.{CreateRepositoryRequest, CreateRepositoryResponse, CreateSnapshotRequest, CreateSnapshotResponse, DeleteSnapshotRequest, DeleteSnapshotResponse, GetSnapshotResponse, GetSnapshotsRequest, RestoreSnapshotRequest, RestoreSnapshotResponse, RestoreSnapshotResponseAsync, RestoreSnapshotResponseAwait}
+import com.sksamuel.elastic4s.{ElasticRequest, Handler, HttpEntity, ResponseHandler}
 
 trait SnapshotHandlers {
 

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/snapshot/SnapshotHandlers.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/snapshot/SnapshotHandlers.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.elastic4s.handlers.snapshot
 
 import com.sksamuel.elastic4s.json.XContentFactory
-import com.sksamuel.elastic4s.requests.snapshots.{CreateRepositoryRequest, CreateRepositoryResponse, CreateSnapshotRequest, CreateSnapshotResponse, DeleteSnapshotRequest, DeleteSnapshotResponse, GetSnapshotResponse, GetSnapshotsRequest, RestoreSnapshotRequest, RestoreSnapshotResponse, RestoreSnapshotResponseAsync, RestoreSnapshotResponseAwait}
+import com.sksamuel.elastic4s.requests.snapshots.{CreateRepositoryRequest, CreateRepositoryResponse, CreateSnapshotRequest, CreateSnapshotResponse, DeleteSnapshotRequest, DeleteSnapshotResponse, GetSnapshotResponse, GetSnapshotsRequest, RestoreSnapshotRequest, RestoreSnapshotResponse}
 import com.sksamuel.elastic4s.{ElasticRequest, Handler, HttpEntity}
 
 trait SnapshotHandlers {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/snapshots/SnapshotTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/snapshots/SnapshotTest.scala
@@ -74,7 +74,7 @@ class SnapshotTest extends AnyFlatSpec with Matchers with DockerTests {
   it should "succeed when request is correct" in {
     client.execute(deleteIndex("*")).await.isSuccess shouldBe true
     client.execute {
-      restoreSnapshot(snapshotName, repoName)// waitForCompletion true
+      restoreSnapshot(snapshotName, repoName)
     }.await.result.succeeded shouldEqual true
   }
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/snapshots/SnapshotTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/snapshots/SnapshotTest.scala
@@ -2,6 +2,7 @@ package com.sksamuel.elastic4s.requests.snapshots
 
 import java.util.UUID
 
+import com.sksamuel.elastic4s.Index
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -72,23 +73,23 @@ class SnapshotTest extends AnyFlatSpec with Matchers with DockerTests {
   }
 
   it should "succeed when request is correct" in {
-    client.execute(deleteIndex("*")).await.isSuccess shouldBe true
+    client.execute(deleteIndex("tmpidx")).await.isSuccess shouldBe true
     client.execute {
-      restoreSnapshot(snapshotName, repoName)
+      restoreSnapshot(snapshotName, repoName) index Index("tmpidx")
     }.await.result.succeeded shouldEqual true
   }
 
   it should "succeeded if waitForCompletion = false" in {
-    client.execute(deleteIndex("*")).await.isSuccess shouldBe true
+    client.execute(deleteIndex("tmpidx")).await.isSuccess shouldBe true
     client.execute {
-      restoreSnapshot(snapshotName, repoName) waitForCompletion false
+      restoreSnapshot(snapshotName, repoName) index Index("tmpidx") waitForCompletion false
     }.await.result.succeeded shouldEqual true
   }
 
   it should "succeeded if waitForCompletion = true" in {
-    client.execute(deleteIndex("*")).await.isSuccess shouldBe true
+    client.execute(deleteIndex("tmpidx")).await.isSuccess shouldBe true
     client.execute {
-      restoreSnapshot(snapshotName, repoName) waitForCompletion true
+      restoreSnapshot(snapshotName, repoName) index Index("tmpidx") waitForCompletion true
     }.await.result.succeeded shouldEqual true
   }
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/snapshots/SnapshotTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/snapshots/SnapshotTest.scala
@@ -57,6 +57,24 @@ class SnapshotTest extends AnyFlatSpec with Matchers with DockerTests {
     }.await.error.`type` shouldBe "repository_missing_exception"
   }
 
+  "restore snapshot" should "be accepted" in {
+    client.execute {
+      restoreSnapshot("snap1", repoName)
+    }.await.result.accepted shouldEqual true
+  }
+
+  it should "error when the snapshot does not exist" in {
+    client.execute {
+      restoreSnapshot("missing_snapshot", repoName)
+    }.await.error.`type` shouldBe "snapshot_missing_exception"
+  }
+
+  it should "error when the repo does not exist" in {
+    client.execute {
+      restoreSnapshot("snap1", "missing_repo")
+    }.await.error.`type` shouldBe "repository_missing_exception"
+  }
+
   "deleteSnapshot" should "remove the named snapshot" in {
     client.execute {
       deleteSnapshot("snap1", repoName)

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/snapshots/SnapshotTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/snapshots/SnapshotTest.scala
@@ -11,11 +11,6 @@ class SnapshotTest extends AnyFlatSpec with Matchers with DockerTests {
   private val repoName = "repotest_" + UUID.randomUUID().toString
   private val snapshotName = "snap1"
 
-  // To avoid unexpected index clashes when attempting to restore snapshots
-  "cleaning up old indices" should "succeed" in {
-    client.execute(deleteIndex("*")).await.isSuccess shouldBe true
-  }
-
   "createRepository" should "create a new repo" in {
     val resp = client.execute {
       createRepository(repoName, "fs").settings(Map("location" -> ("/tmp/elastic4s/backup_" + UUID.randomUUID.toString)))
@@ -30,7 +25,7 @@ class SnapshotTest extends AnyFlatSpec with Matchers with DockerTests {
   }
 
   "createSnapshot" should "create a new snapshot" in {
-    // create an index to restore, so that we can test some of the behaviour around that
+    // ensure there's at least one index to restore, so that we can test some of the behaviour around that
     createIdx("tmpidx").isSuccess shouldBe true
     client.execute {
       createSnapshot("snap0", repoName)
@@ -77,21 +72,21 @@ class SnapshotTest extends AnyFlatSpec with Matchers with DockerTests {
   }
 
   it should "succeed when request is correct" in {
-    client.execute {deleteIndex("tmpidx")}.await.isSuccess shouldBe true
+    client.execute(deleteIndex("*")).await.isSuccess shouldBe true
     client.execute {
       restoreSnapshot(snapshotName, repoName)// waitForCompletion true
     }.await.result.succeeded shouldEqual true
   }
 
   it should "succeeded if waitForCompletion = false" in {
-    client.execute { deleteIndex("tmpidx") }.await.isSuccess shouldBe true
+    client.execute(deleteIndex("*")).await.isSuccess shouldBe true
     client.execute {
       restoreSnapshot(snapshotName, repoName) waitForCompletion false
     }.await.result.succeeded shouldEqual true
   }
 
   it should "succeeded if waitForCompletion = true" in {
-    client.execute { deleteIndex("tmpidx") }.await.isSuccess shouldBe true
+    client.execute(deleteIndex("*")).await.isSuccess shouldBe true
     client.execute {
       restoreSnapshot(snapshotName, repoName) waitForCompletion true
     }.await.result.succeeded shouldEqual true

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/snapshots/SnapshotTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/snapshots/SnapshotTest.scala
@@ -11,6 +11,11 @@ class SnapshotTest extends AnyFlatSpec with Matchers with DockerTests {
   private val repoName = "repotest_" + UUID.randomUUID().toString
   private val snapshotName = "snap1"
 
+  // To avoid unexpected index clashes when attempting to restore snapshots
+  "cleaning up old indices" should "succeed" in {
+    client.execute(deleteIndex("*")).await.isSuccess shouldBe true
+  }
+
   "createRepository" should "create a new repo" in {
     val resp = client.execute {
       createRepository(repoName, "fs").settings(Map("location" -> ("/tmp/elastic4s/backup_" + UUID.randomUUID.toString)))

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/snapshots/SnapshotTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/snapshots/SnapshotTest.scala
@@ -9,6 +9,7 @@ import org.scalatest.matchers.should.Matchers
 class SnapshotTest extends AnyFlatSpec with Matchers with DockerTests {
 
   private val repoName = "repotest_" + UUID.randomUUID().toString
+  private val snapshotName = "snap1"
 
   "createRepository" should "create a new repo" in {
     val resp = client.execute {
@@ -24,23 +25,30 @@ class SnapshotTest extends AnyFlatSpec with Matchers with DockerTests {
   }
 
   "createSnapshot" should "create a new snapshot" in {
-    val resp = client.execute {
-      createSnapshot("snap1", repoName)
-    }.await
-    resp.result.accepted shouldBe true
+    // create an index to restore, so that we can test some of the behaviour around that
+    createIdx("tmpidx").isSuccess shouldBe true
+    client.execute {
+      createSnapshot("snap0", repoName)
+    }.await.result.succeeded shouldBe true
+  }
+
+  it should "deserialize when waitForCompletion = true" in {
+    client.execute {
+      createSnapshot(snapshotName, repoName) waitForCompletion true
+    }.await.result.succeeded shouldBe true
   }
 
   it should "error when the repo does not exist" in {
     client.execute {
-      createSnapshot("snap1", "abbbbc")
+      createSnapshot(snapshotName, "abbbbc")
     }.await.error.`type` shouldBe "repository_missing_exception"
   }
 
   "getSnapshot" should "return the named snapshot" in {
     val resp = client.execute {
-      getSnapshot("snap1", repoName)
+      getSnapshot(snapshotName, repoName)
     }.await.result
-    resp.snapshots.head.snapshot shouldBe "snap1"
+    resp.snapshots.head.snapshot shouldBe snapshotName
     resp.snapshots.head.uuid should not be null
     resp.snapshots.head.version should not be null
   }
@@ -53,34 +61,55 @@ class SnapshotTest extends AnyFlatSpec with Matchers with DockerTests {
 
   it should "error when the repo does not exist" in {
     client.execute {
-      getSnapshot("snap1", "bbbbb")
+      getSnapshot(snapshotName, "bbbbb")
     }.await.error.`type` shouldBe "repository_missing_exception"
   }
 
-  "restore snapshot" should "be accepted" in {
+  "restore snapshot" should "error when an index clashes" in {
     client.execute {
-      restoreSnapshot("snap1", repoName)
-    }.await.result.accepted shouldEqual true
+      restoreSnapshot(snapshotName, repoName) waitForCompletion true
+    }.await.error.`type` shouldBe "snapshot_restore_exception"
+  }
+
+  it should "succeed when request is correct" in {
+    client.execute {deleteIndex("tmpidx")}.await.isSuccess shouldBe true
+    client.execute {
+      restoreSnapshot(snapshotName, repoName)// waitForCompletion true
+    }.await.result.succeeded shouldEqual true
+  }
+
+  it should "succeeded if waitForCompletion = false" in {
+    client.execute { deleteIndex("tmpidx") }.await.isSuccess shouldBe true
+    client.execute {
+      restoreSnapshot(snapshotName, repoName) waitForCompletion false
+    }.await.result.succeeded shouldEqual true
+  }
+
+  it should "succeeded if waitForCompletion = true" in {
+    client.execute { deleteIndex("tmpidx") }.await.isSuccess shouldBe true
+    client.execute {
+      restoreSnapshot(snapshotName, repoName) waitForCompletion true
+    }.await.result.succeeded shouldEqual true
   }
 
   it should "error when the snapshot does not exist" in {
     client.execute {
       restoreSnapshot("missing_snapshot", repoName)
-    }.await.error.`type` shouldBe "snapshot_missing_exception"
+    }.await.error.`type` shouldBe "snapshot_restore_exception"
   }
 
   it should "error when the repo does not exist" in {
     client.execute {
-      restoreSnapshot("snap1", "missing_repo")
+      restoreSnapshot(snapshotName, "missing_repo")
     }.await.error.`type` shouldBe "repository_missing_exception"
   }
 
   "deleteSnapshot" should "remove the named snapshot" in {
     client.execute {
-      deleteSnapshot("snap1", repoName)
+      deleteSnapshot(snapshotName, repoName)
     }.await.result.acknowledged shouldBe true
     client.execute {
-      getSnapshot("snap1", repoName)
+      getSnapshot(snapshotName, repoName)
     }.await.error.`type` shouldBe "snapshot_missing_exception"
   }
 }


### PR DESCRIPTION
'default' `RestoreSnapshotResponse` contains an `accepted` boolean, not `acknowledged`. Also, if waitForCompletion = true, the response is in a different format entirely. This fixes response deserialization for `RestoreSnapshotResponse` and `CreateSnapshotResponse`, but it's highly probably that there are many other cases where the response from elasticsearch doesn't match the response type from the handler... Haven't got into any further depth on that possibility here, though.