### PR TITLE
Add aggregate-metric field

### DIFF
--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/AggregateMetricField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/AggregateMetricField.scala
@@ -1,0 +1,5 @@
+package com.sksamuel.elastic4s.fields
+
+case class AggregateMetricField(name: String, metrics: Seq[String], defaultMetric: String) extends ElasticField {
+  override def `type`: String = "aggregate_metric_double"
+}

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/AggregateMetricFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/AggregateMetricFieldBuilderFn.scala
@@ -1,0 +1,14 @@
+package com.sksamuel.elastic4s.handlers.fields
+
+import com.sksamuel.elastic4s.fields.AggregateMetricField
+import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
+
+object AggregateMetricFieldBuilderFn {
+  def build(field: AggregateMetricField): XContentBuilder = {
+    val builder = XContentFactory.jsonBuilder()
+    builder.field("type", field.`type`)
+    if (field.metrics.nonEmpty) builder.array("metrics", field.metrics.toArray)
+    builder.field("default_metric", field.defaultMetric)
+    builder.endObject()
+  }
+}

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/ElasticFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/ElasticFieldBuilderFn.scala
@@ -1,12 +1,13 @@
 package com.sksamuel.elastic4s.handlers.fields
 
-import com.sksamuel.elastic4s.fields.{AliasField, AnnotatedTextField, BinaryField, BooleanField, CompletionField, ConstantKeywordField, DateField, DateNanosField, DenseVectorField, ElasticField, FlattenedField, GeoPointField, GeoShapeField, HistogramField, IpField, IpRangeField, JoinField, KeywordField, Murmur3Field, NestedField, NumberField, ObjectField, PercolatorField, RangeField, RankFeatureField, RankFeaturesField, SearchAsYouTypeField, TextField, TokenCountField, VersionField, WildcardField}
+import com.sksamuel.elastic4s.fields.{AggregateMetricField, AliasField, AnnotatedTextField, BinaryField, BooleanField, CompletionField, ConstantKeywordField, DateField, DateNanosField, DenseVectorField, ElasticField, FlattenedField, GeoPointField, GeoShapeField, HistogramField, IpField, IpRangeField, JoinField, KeywordField, Murmur3Field, NestedField, NumberField, ObjectField, PercolatorField, RangeField, RankFeatureField, RankFeaturesField, SearchAsYouTypeField, TextField, TokenCountField, VersionField, WildcardField}
 import com.sksamuel.elastic4s.json.XContentBuilder
 
 object ElasticFieldBuilderFn {
 
   def apply(field: ElasticField): XContentBuilder = {
     field match {
+      case f: AggregateMetricField => AggregateMetricFieldBuilderFn.build(f)
       case f: AliasField => AliasFieldBuilderFn.build(f)
       case f: AnnotatedTextField => AnnotatedTextFieldBuilderFn.build(f)
       case f: BinaryField => BinaryFieldBuilderFn.build(f)


### PR DESCRIPTION
Applying this PR will add the aggregate-metric field, which was introduced in Elasticsearch 7.11 (https://www.elastic.co/guide/en/elasticsearch/reference/7.11/aggregate-metric-double.html#aggregate-metric-double).