### PR TITLE
Uncomment and fix dynamic templates tests

### DIFF
--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DynamicField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DynamicField.scala
@@ -23,7 +23,7 @@ case class DynamicField(override val name: String,
                         similarity: Option[String] = None,
                         store: Option[Boolean] = None,
                         termVector: Option[String] = None,
-               meta: Map[String, String] = Map.empty) extends ElasticField {
+                        meta: Map[String, String] = Map.empty) extends ElasticField {
   override def `type`: String = "{dynamic_type}"
   def analyzer(name: String): DynamicField = copy(analyzer = Option(name))
   def boost(boost: Double): DynamicField = copy(boost = boost.some)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DynamicField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DynamicField.scala
@@ -1,0 +1,42 @@
+package com.sksamuel.elastic4s.fields
+
+import com.sksamuel.exts.OptionImplicits.RichOptionImplicits
+
+case class DynamicField(override val name: String,
+                        analyzer: Option[String] = None,
+                        boost: Option[Double] = None,
+                        coerce: Option[Boolean] = None,
+                        copyTo: Seq[String] = Nil,
+                        docValues: Option[Boolean] = None,
+                        enabled: Option[Boolean] = None,
+                        fielddata: Option[Boolean] = None,
+                        fields: List[ElasticField] = Nil,
+                        format: Option[String] = None,
+                        ignoreAbove: Option[Int] = None,
+                        ignoreMalformed: Option[Boolean] = None,
+                        index: Option[Boolean] = None,
+                        indexOptions: Option[String] = None,
+                        locale: Option[String] = None,
+                        norms: Option[Boolean] = None,
+                        nullValue: Option[String] = None,
+                        scalingFactor: Option[Double] = None,
+                        similarity: Option[String] = None,
+                        store: Option[Boolean] = None,
+                        termVector: Option[String] = None,
+               meta: Map[String, String] = Map.empty) extends ElasticField {
+  override def `type`: String = "{dynamic_type}"
+  def analyzer(name: String): DynamicField = copy(analyzer = Option(name))
+  def boost(boost: Double): DynamicField = copy(boost = boost.some)
+  def copyTo(copyTo: String*): DynamicField = copy(copyTo = copyTo.toList)
+  def copyTo(copyTo: Iterable[String]): DynamicField = copy(copyTo = copyTo.toList)
+  def fielddata(fielddata: Boolean): DynamicField = copy(fielddata = fielddata.some)
+  def fields(fields: ElasticField*): DynamicField = copy(fields = fields.toList)
+  def fields(fields: Iterable[ElasticField]): DynamicField = copy(fields = fields.toList)
+  def stored(store: Boolean): DynamicField = copy(store = store.some)
+  def index(index: Boolean): DynamicField = copy(index = index.some)
+  def indexOptions(indexOptions: String): DynamicField = copy(indexOptions = indexOptions.some)
+  def norms(norms: Boolean): DynamicField = copy(norms = norms.some)
+  def termVector(termVector: String): DynamicField = copy(termVector = termVector.some)
+  def store(store: Boolean): DynamicField = copy(store = store.some)
+  def similarity(similarity: String): DynamicField = copy(similarity = similarity.some)
+}

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/DateFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/DateFieldBuilderFn.scala
@@ -14,7 +14,7 @@ object DateFieldBuilderFn {
     if (field.copyTo.nonEmpty) builder.array("copy_to", field.copyTo.toArray)
     field.docValues.foreach(builder.field("doc_values", _))
     field.format.foreach(builder.field("format", _))
-    field.locale.foreach(builder.field("locate", _))
+    field.locale.foreach(builder.field("locale", _))
     field.ignoreMalformed.foreach(builder.field("ignore_malformed", _))
     field.index.foreach(builder.field("index", _))
     field.nullValue.foreach(builder.field("null_value", _))

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/DateNanosFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/DateNanosFieldBuilderFn.scala
@@ -14,7 +14,7 @@ object DateNanosFieldBuilderFn {
     if (field.copyTo.nonEmpty) builder.array("copy_to", field.copyTo.toArray)
     field.docValues.foreach(builder.field("doc_values", _))
     field.format.foreach(builder.field("format", _))
-    field.locale.foreach(builder.field("locate", _))
+    field.locale.foreach(builder.field("locale", _))
     field.ignoreMalformed.foreach(builder.field("ignore_malformed", _))
     field.index.foreach(builder.field("index", _))
     field.nullValue.foreach(builder.field("null_value", _))

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/DynamicFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/DynamicFieldBuilderFn.scala
@@ -1,0 +1,43 @@
+package com.sksamuel.elastic4s.handlers.fields
+
+import com.sksamuel.elastic4s.fields.DynamicField
+import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
+
+object DynamicFieldBuilderFn {
+
+  def build(field: DynamicField): XContentBuilder = {
+
+    val builder = XContentFactory.jsonBuilder()
+    builder.field("type", field.`type`)
+
+    field.analyzer.foreach(builder.field("analyzer", _))
+    field.boost.foreach(builder.field("boost", _))
+    field.coerce.foreach(builder.field("coerce", _))
+    if (field.copyTo.nonEmpty)
+      builder.array("copy_to", field.copyTo.toArray)
+    field.docValues.foreach(builder.field("doc_values", _))
+    field.enabled.foreach(builder.field("enabled", _))
+    field.fielddata.foreach(builder.field("fielddata", _))
+    if (field.fields.nonEmpty) {
+      builder.startObject("fields")
+      field.fields.foreach { field =>
+        builder.rawField(field.name, ElasticFieldBuilderFn(field))
+      }
+      builder.endObject()
+    }
+    field.format.foreach(builder.field("format", _))
+    field.ignoreAbove.foreach(builder.field("ignore_above", _))
+    field.ignoreMalformed.foreach(builder.field("ignore_malformed", _))
+    field.index.foreach(builder.field("index", _))
+    field.indexOptions.foreach(builder.field("index_options", _))
+    field.locale.foreach(builder.field("locale", _))
+    field.norms.foreach(builder.field("norms", _))
+    field.nullValue.foreach(builder.field("null_value", _))
+    field.scalingFactor.foreach(builder.field("scaling_factor", _))
+    field.similarity.foreach(builder.field("similarity", _))
+    field.store.foreach(builder.field("store", _))
+    field.termVector.foreach(builder.field("term_vector", _))
+
+    builder.endObject()
+  }
+}

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/ElasticFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/ElasticFieldBuilderFn.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.elastic4s.handlers.fields
 
-import com.sksamuel.elastic4s.fields.{AggregateMetricField, AliasField, AnnotatedTextField, BinaryField, BooleanField, CompletionField, ConstantKeywordField, DateField, DateNanosField, DenseVectorField, ElasticField, FlattenedField, GeoPointField, GeoShapeField, HistogramField, IpField, IpRangeField, JoinField, KeywordField, Murmur3Field, NestedField, NumberField, ObjectField, PercolatorField, RangeField, RankFeatureField, RankFeaturesField, SearchAsYouTypeField, TextField, TokenCountField, VersionField, WildcardField}
+import com.sksamuel.elastic4s.fields.{AggregateMetricField, AliasField, AnnotatedTextField, BinaryField, BooleanField, CompletionField, ConstantKeywordField, DateField, DateNanosField, DenseVectorField, DynamicField, ElasticField, FlattenedField, GeoPointField, GeoShapeField, HistogramField, IpField, IpRangeField, JoinField, KeywordField, Murmur3Field, NestedField, NumberField, ObjectField, PercolatorField, RangeField, RankFeatureField, RankFeaturesField, SearchAsYouTypeField, TextField, TokenCountField, VersionField, WildcardField}
 import com.sksamuel.elastic4s.json.XContentBuilder
 
 object ElasticFieldBuilderFn {
@@ -17,6 +17,7 @@ object ElasticFieldBuilderFn {
       case f: DateField => DateFieldBuilderFn.build(f)
       case f: DateNanosField => DateNanosFieldBuilderFn.build(f)
       case f: DenseVectorField => DenseVectorFieldBuilderFn.build(f)
+      case f: DynamicField => DynamicFieldBuilderFn.build(f)
       case f: FlattenedField => FlattenedFieldBuilderFn.build(f)
       case f: GeoPointField => GeoPointFieldBuilderFn.build(f)
       case f: GeoShapeField => GeoShapeFieldBuilderFn.build(f)

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/TextFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/TextFieldBuilderFn.scala
@@ -35,6 +35,7 @@ object TextFieldBuilderFn {
       builder.endObject()
     }
     field.indexPhrases.foreach(builder.field("index_phrases", _))
+    field.fielddata.foreach(builder.field("fielddata", _))
 
     field.fielddataFrequencyFilter.foreach { filter =>
       builder.startObject("fielddata_frequency_filter")
@@ -45,7 +46,6 @@ object TextFieldBuilderFn {
     }
 
     field.positionIncrementGap.foreach(builder.field("position_increment_gap", _))
-    field.fielddata.foreach(builder.field("fielddata", _))
     field.eagerGlobalOrdinals.foreach(builder.field("eager_global_ordinals", _))
     field.indexOptions.foreach(builder.field("index_options", _))
     field.searchAnalyzer.foreach(builder.field("search_analyzer", _))

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/TextFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/TextFieldBuilderFn.scala
@@ -35,7 +35,6 @@ object TextFieldBuilderFn {
       builder.endObject()
     }
     field.indexPhrases.foreach(builder.field("index_phrases", _))
-    field.fielddata.foreach(builder.field("fielddata", _))
 
     field.fielddataFrequencyFilter.foreach { filter =>
       builder.startObject("fielddata_frequency_filter")

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/index/mapping/DynamicTemplateBodyFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/index/mapping/DynamicTemplateBodyFn.scala
@@ -1,5 +1,6 @@
 package com.sksamuel.elastic4s.handlers.index.mapping
 
+import com.sksamuel.elastic4s.handlers.fields.ElasticFieldBuilderFn
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 import com.sksamuel.elastic4s.requests.mappings.dynamictemplate.DynamicTemplateRequest
 
@@ -17,7 +18,7 @@ object DynamicTemplateBodyFn {
     dyn.MatchPattern.foreach(builder.field("match_pattern", _))
     dyn.matchMappingType.foreach(builder.field("match_mapping_type", _))
 
-    //    builder.rawField("mapping", FieldBuilderFn(dyn.mapping))
+    builder.rawField("mapping", ElasticFieldBuilderFn(dyn.mapping))
 
     builder.endObject()
   }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/DynamicTemplateApiTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/DynamicTemplateApiTest.scala
@@ -1,29 +1,29 @@
-//package com.sksamuel.elastic4s.requests.mappings
-//
-//import com.sksamuel.elastic4s.requests.analyzers.SpanishLanguageAnalyzer
-//import com.sksamuel.elastic4s.requests.mappings.dynamictemplate.DynamicTemplateBodyFn
-//import com.sksamuel.elastic4s.{ElasticApi, JsonSugar}
-//import org.scalatest.matchers.should.Matchers
-//import org.scalatest.wordspec.AnyWordSpec
-//
-//class DynamicTemplateApiTest extends AnyWordSpec with Matchers with JsonSugar with ElasticApi {
-//
-//  "dynamic templates" should {
-//    "support match" in {
-//      val temp = dynamicTemplate("es").mapping(
-//        dynamicTextField().analyzer(SpanishLanguageAnalyzer)
-//      ) matchMappingType "string" `match` "*_es"
-//      DynamicTemplateBodyFn.build(temp).string() should matchJsonResource("/json/mappings/dynamic_template.json")
-//    }
-//    "support match pattern" in {
-//      val temp = dynamicTemplate("es").mapping(
-//        dynamicTextField().analyzer(SpanishLanguageAnalyzer)
-//      ).matchMappingType("string").matchPattern("*_es")
-//      DynamicTemplateBodyFn.build(temp).string() should matchJsonResource("/json/mappings/dynamic_template_match_pattern.json")
-//    }
+package com.sksamuel.elastic4s.requests.mappings
+
+import com.sksamuel.elastic4s.analysis.LanguageAnalyzers
+import com.sksamuel.elastic4s.fields.TextField
+import com.sksamuel.elastic4s.handlers.index.mapping.DynamicTemplateBodyFn
+import com.sksamuel.elastic4s.requests.mappings.dynamictemplate.DynamicTemplateRequest
+import com.sksamuel.elastic4s.{ElasticApi, JsonSugar}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class DynamicTemplateApiTest extends AnyWordSpec with Matchers with JsonSugar with ElasticApi {
+
+  "dynamic templates" should {
+    "support match" in {
+      val temp = DynamicTemplateRequest("es", TextField("match_*_es").analyzer(LanguageAnalyzers.spanish)) matchMappingType "string" `match` "*_es"
+      DynamicTemplateBodyFn.build(temp).string() should matchJsonResource("/json/mappings/dynamic_template.json")
+    }
+    "support match pattern" in {
+      val temp = DynamicTemplateRequest("es",
+        TextField("matchPattern_*_es").analyzer(LanguageAnalyzers.spanish)
+      ).matchMappingType("string").matchPattern("*_es")
+      DynamicTemplateBodyFn.build(temp).string() should matchJsonResource("/json/mappings/dynamic_template_match_pattern.json")
+    }
 //    "support dynamic type" in {
 //      val temp = dynamicTemplate("es", dynamicType.docValues(false)).matchPattern("*_es")
 //      DynamicTemplateBodyFn.build(temp).string() should matchJsonResource("/json/mappings/dynamic_template_dynamic_type.json")
 //    }
-//  }
-//}
+  }
+}

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/DynamicTemplateApiTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/DynamicTemplateApiTest.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.elastic4s.requests.mappings
 
 import com.sksamuel.elastic4s.analysis.LanguageAnalyzers
-import com.sksamuel.elastic4s.fields.TextField
+import com.sksamuel.elastic4s.fields.{DynamicField, TextField}
 import com.sksamuel.elastic4s.handlers.index.mapping.DynamicTemplateBodyFn
 import com.sksamuel.elastic4s.requests.mappings.dynamictemplate.DynamicTemplateRequest
 import com.sksamuel.elastic4s.{ElasticApi, JsonSugar}
@@ -21,9 +21,9 @@ class DynamicTemplateApiTest extends AnyWordSpec with Matchers with JsonSugar wi
       ).matchMappingType("string").matchPattern("*_es")
       DynamicTemplateBodyFn.build(temp).string() should matchJsonResource("/json/mappings/dynamic_template_match_pattern.json")
     }
-//    "support dynamic type" in {
-//      val temp = dynamicTemplate("es", dynamicType.docValues(false)).matchPattern("*_es")
-//      DynamicTemplateBodyFn.build(temp).string() should matchJsonResource("/json/mappings/dynamic_template_dynamic_type.json")
-//    }
+    "support dynamic type" in {
+      val temp = DynamicTemplateRequest("es", DynamicField("", docValues = Some(false))).matchPattern("*_es")
+      DynamicTemplateBodyFn.build(temp).string() should matchJsonResource("/json/mappings/dynamic_template_dynamic_type.json")
+    }
   }
 }


### PR DESCRIPTION
This also adds a DynamicType field, to support one of the commented-out tests, although I'm unfamiliar with its usage, so the fields I've made available for it may not be the most appropriate. There are other templates that this leaves unsupported (e.g. https://www.elastic.co/guide/en/elasticsearch/reference/current/dynamic-templates.html#dynamic-mapping-runtime-fields - with which I am also unfamiliar) but this seems to fix some common use cases...

Couple of unrelated things:
- fix the locale field name in DateFieldBuilderFns
- Remove duplicate setting of fielddata in TextFieldBuilderFn