### PR TITLE
Add caseInsensitive to RegexQuery

### DIFF
--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/queries/RegexQueryBodyFnTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/queries/RegexQueryBodyFnTest.scala
@@ -13,7 +13,8 @@ class RegexQueryBodyFnTest extends AnyFunSuite with Matchers {
       .boost(1.2)
       .queryName("myquery")
       .maxDeterminedStates(10000)
+      .caseInsensitive(true)
     term.RegexQueryBodyFn(q).string() shouldBe
-      """{"regexp":{"mysearch":{"value":".*","flags":"ANYSTRING|COMPLEMENT|EMPTY|INTERSECTION|INTERVAL","max_determinized_states":10000,"boost":1.2,"_name":"myquery"}}}"""
+      """{"regexp":{"mysearch":{"value":".*","flags":"ANYSTRING|COMPLEMENT|EMPTY|INTERSECTION|INTERVAL","max_determinized_states":10000,"boost":1.2,"_name":"myquery","case_insensitive":true}}}"""
   }
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/RegexQuery.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/RegexQuery.scala
@@ -18,5 +18,5 @@ case class RegexQuery(field: String,
   def rewrite(rewrite: String): RegexQuery = copy(rewrite = rewrite.some)
   def flags(flags: RegexpFlag*): RegexQuery = copy(flags = flags)
   def flags(flags: Iterable[RegexpFlag]): RegexQuery = copy(flags = flags.toSeq)
-  def caseInsensitive(caseInsensitive: Boolean): RegexQuery = copy(caseInsensitive = Option(caseInsensitive))
+  def caseInsensitive(caseInsensitive: Boolean): RegexQuery = copy(caseInsensitive = caseInsensitive.some)
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/RegexQuery.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/RegexQuery.scala
@@ -8,7 +8,8 @@ case class RegexQuery(field: String,
                       boost: Option[Double] = None,
                       maxDeterminedStates: Option[Int] = None,
                       queryName: Option[String] = None,
-                      rewrite: Option[String] = None)
+                      rewrite: Option[String] = None,
+                      caseInsensitive: Option[Boolean] = None)
   extends MultiTermQuery {
 
   def maxDeterminedStates(max: Int): RegexQuery = copy(maxDeterminedStates = max.some)
@@ -17,4 +18,5 @@ case class RegexQuery(field: String,
   def rewrite(rewrite: String): RegexQuery = copy(rewrite = rewrite.some)
   def flags(flags: RegexpFlag*): RegexQuery = copy(flags = flags)
   def flags(flags: Iterable[RegexpFlag]): RegexQuery = copy(flags = flags.toSeq)
+  def caseInsensitive(caseInsensitive: Boolean): RegexQuery = copy(caseInsensitive = Option(caseInsensitive))
 }

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/searches/queries/term/RegexQueryBodyFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/searches/queries/term/RegexQueryBodyFn.scala
@@ -18,6 +18,7 @@ object RegexQueryBodyFn {
     q.rewrite.foreach(builder.field("rewrite", _))
     q.boost.foreach(builder.field("boost", _))
     q.queryName.foreach(builder.field("_name", _))
+    q.caseInsensitive.foreach(builder.field("case_insensitive", _))
 
     builder
   }


### PR DESCRIPTION
Supported since ElasticSearch 7.10.0. https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html