### PR TITLE
Add support for reindex conflicts field

### DIFF
--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/reindex/ReindexRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/reindex/ReindexRequest.scala
@@ -21,6 +21,7 @@ case class ReindexRequest(sourceIndexes: Indexes,
                           timeout: Option[FiniteDuration] = None,
                           retryBackoffInitialTime: Option[FiniteDuration] = None,
                           shouldStoreResult: Option[Boolean] = None,
+                          proceedOnConflicts: Option[Boolean] = None,
                           remoteHost: Option[String] = None,
                           remoteUser: Option[String] = None,
                           remotePass: Option[String] = None,
@@ -57,6 +58,9 @@ case class ReindexRequest(sourceIndexes: Indexes,
 
   def shouldStoreResult(shouldStoreResult: Boolean): ReindexRequest =
     copy(shouldStoreResult = shouldStoreResult.some)
+
+  def proceedOnConflicts(proceedOnConflicts: Boolean): ReindexRequest =
+    copy(proceedOnConflicts = proceedOnConflicts.some)
 
   def script(script: Script): ReindexRequest = copy(script = script.some)
 

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/reindex/ReindexBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/reindex/ReindexBuilderFn.scala
@@ -10,6 +10,11 @@ object ReindexBuilderFn {
   def apply(request: ReindexRequest): XContentBuilder = {
     val builder = XContentFactory.obj()
 
+    request.proceedOnConflicts.foreach {
+      case true => builder.field("conflicts", "proceed")
+      case false => builder.field("conflicts", "abort")
+    }
+
     request.size.foreach(builder.field("size", _))
 
     request.script.foreach { script =>
@@ -37,11 +42,6 @@ object ReindexBuilderFn {
 
     if (request.targetType.nonEmpty)
       builder.field("type", request.targetType.get)
-
-    request.proceedOnConflicts.foreach {
-      case true => builder.field("conflicts", "proceed")
-      case false => builder.field("conflicts", "abort")
-    }
 
     // end dest
     builder.endObject()

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/reindex/ReindexBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/reindex/ReindexBuilderFn.scala
@@ -38,6 +38,11 @@ object ReindexBuilderFn {
     if (request.targetType.nonEmpty)
       builder.field("type", request.targetType.get)
 
+    request.proceedOnConflicts.foreach {
+      case true => builder.field("conflicts", "proceed")
+      case false => builder.field("conflicts", "abort")
+    }
+
     // end dest
     builder.endObject()
   }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/reindex/ReindexTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/reindex/ReindexTest.scala
@@ -58,6 +58,21 @@ class ReindexTest extends AnyWordSpec with Matchers with DockerTests {
         search("reindextarget")
       }.await.result.hits.hits.flatMap(_.sourceAsMap.get("scripted")) shouldBe Array(42, 42, 42)
     }
+    "support proceed parameter" in {
+      deleteIdx("reindextarget")
+      createIdx("reindextarget")
+
+      client.execute {
+        reindex("reindex", "reindextarget").proceedOnConflicts(true).refresh(RefreshPolicy.IMMEDIATE)
+      }.await.result.left.get.created shouldBe 3
+
+      deleteIdx("reindextarget")
+      createIdx("reindextarget")
+
+      client.execute {
+        reindex("reindex", "reindextarget").proceedOnConflicts(false).refresh(RefreshPolicy.IMMEDIATE)
+      }.await.result.left.get.created shouldBe 3
+    }
     "support multiple sources" in {
 
       deleteIdx("reindextarget")


### PR DESCRIPTION
As described in the [docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-reindex.html#docs-reindex-api-request-body) `conflicts` field is part of the request body.