### PR TITLE
sbt cleanup

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,3 +1,4 @@
 -J-Xmx4G
 -J-XX:MaxMetaspaceSize=1G
 -J-XX:+CMSClassUnloadingEnabled
+-J-XX:+UseG1GC

--- a/build.sbt
+++ b/build.sbt
@@ -1,30 +1,6 @@
-val org                    = "com.sksamuel.elastic4s"
-val AkkaVersion            = "2.6.14"
-val AkkaHttpVersion        = "10.2.3"
-val CatsVersion            = "2.0.0"
-val CatsEffectVersion      = "3.1.1"
-val CatsEffect2Version     = "2.5.0"
-val CirceVersion           = "0.14.1"
-val CommonsIoVersion       = "2.9.0"
-val ElasticsearchVersion   = "7.12.1"
-val ExtsVersion            = "1.61.1"
-val JacksonVersion         = "2.12.3"
-val Json4sVersion          = "3.6.11"
-val Log4jVersion           = "2.14.1"
-val MockitoVersion         = "3.11.0"
-val MonixVersion           = "3.4.0"
-val PlayJsonVersion        = "2.9.2"
-val ReactiveStreamsVersion = "1.0.3"
-val ScalatestVersion       = "3.2.9"
-val ScalatestPlusVersion   = "3.1.2.0"
-val ScalamockVersion       = "5.1.0"
-val ScalazVersion          = "7.2.32"
-val ZIOVersion             = "1.0.9"
-val ZIOJsonVersion         = "0.1.5"
-val SprayJsonVersion       = "1.3.6"
-val SttpVersion            = "1.7.2"
-val Slf4jVersion           = "1.7.30"
-val ScalatestPlusMockitoArtifactId = "mockito-3-2"
+import Dependencies._
+
+ThisBuild / organizationName := "com.sksamuel.elastic4s"
 
 def isGithubActions = sys.env.getOrElse("CI", "false") == "true"
 
@@ -60,14 +36,14 @@ lazy val commonSettings = Seq(
   organization := "com.sksamuel.elastic4s",
   version := publishVersion,
   resolvers ++= Seq(Resolver.mavenLocal),
-  parallelExecution in Test := false,
+  Test / parallelExecution := false,
   scalacOptions in(Compile, doc) := (scalacOptions in(Compile, doc)).value.filter(_ != "-Xfatal-warnings"),
   scalacOptions ++= Seq("-unchecked", "-deprecation", "-encoding", "utf8")
 )
 
 lazy val publishSettings = Seq(
   publishMavenStyle := true,
-  publishArtifact in Test := false,
+  Test / publishArtifact := false,
   pomIncludeRepository := Function.const(false),
   releaseCrossBuild := true,
   releasePublishArtifactsAction := PgpKeys.publishSigned.value,
@@ -81,7 +57,7 @@ lazy val publishSettings = Seq(
 )
 
 lazy val commonJvmSettings = Seq(
-  testOptions in Test += {
+   Test / testOptions += {
     val flag = if (isGithubActions) "-oCI" else "-oDF"
     Tests.Argument(TestFrameworks.ScalaTest, flag)
   },
@@ -91,15 +67,6 @@ lazy val commonJvmSettings = Seq(
   javaOptions ++= Seq("-Xms512M", "-Xmx2048M", "-XX:+CMSClassUnloadingEnabled"),
 )
 
-lazy val commonDeps = Seq(
-  libraryDependencies ++= Seq(
-    "com.sksamuel.exts" %% "exts" % ExtsVersion,
-    "org.slf4j" % "slf4j-api" % Slf4jVersion,
-    "org.scalatest" %% "scalatest" % ScalatestVersion % "test",
-    "org.mockito" % "mockito-core" % MockitoVersion % "test",
-    "org.scalatestplus" %% ScalatestPlusMockitoArtifactId % ScalatestPlusVersion % "test"
-  )
-)
 
 lazy val pomSettings = Seq(
   homepage := Some(url("https://github.com/sksamuel/elastic4s")),
@@ -177,67 +144,38 @@ lazy val domain = (project in file("elastic4s-domain"))
   .settings(name := "elastic4s-domain")
   .dependsOn(json_builder)
   .settings(allSettings)
-  .settings(
-    libraryDependencies ++= Seq(
-      "com.fasterxml.jackson.core" % "jackson-core" % JacksonVersion,
-      "com.fasterxml.jackson.core" % "jackson-databind" % JacksonVersion,
-      "com.fasterxml.jackson.module" %% "jackson-module-scala" % JacksonVersion
-    )
-  )
+  .settings(libraryDependencies ++= fasterXmlJacksonScala)
 
 lazy val json_builder = (project in file("elastic4s-json-builder"))
   .settings(name := "elastic4s-json-builder")
   .settings(allSettings)
-  .settings(
-    libraryDependencies ++= Seq(
-      "com.fasterxml.jackson.core" % "jackson-core" % JacksonVersion,
-      "com.fasterxml.jackson.core" % "jackson-databind" % JacksonVersion,
-      "com.fasterxml.jackson.module" %% "jackson-module-scala" % JacksonVersion
-    )
-  )
+  .settings(libraryDependencies ++= fasterXmlJacksonScala)
 
 lazy val core = (project in file("elastic4s-core"))
   .settings(name := "elastic4s-core")
   .dependsOn(domain, clientcore, handlers, json_builder)
   .settings(allSettings)
-  .settings(
-    libraryDependencies ++= Seq(
-      "com.fasterxml.jackson.core" % "jackson-core" % JacksonVersion,
-      "com.fasterxml.jackson.core" % "jackson-databind" % JacksonVersion,
-      "com.fasterxml.jackson.module" %% "jackson-module-scala" % JacksonVersion
-    )
-  )
+  .settings(libraryDependencies ++= fasterXmlJacksonScala)
 
 lazy val handlers = (project in file("elastic4s-handlers"))
   .settings(name := "elastic4s-handlers")
   .dependsOn(domain, json_builder)
   .settings(allSettings)
-  .settings(
-    libraryDependencies ++= Seq(
-      "com.fasterxml.jackson.core" % "jackson-core" % JacksonVersion,
-      "com.fasterxml.jackson.core" % "jackson-databind" % JacksonVersion,
-      "com.fasterxml.jackson.module" %% "jackson-module-scala" % JacksonVersion
-    )
-  )
+  .settings(libraryDependencies ++= fasterXmlJacksonScala)
 
 lazy val clientcore = (project in file("elastic4s-client-core"))
   .settings(name := "elastic4s-client-core")
   .dependsOn(handlers)
   .settings(allSettings)
-  .settings(
-    libraryDependencies ++= Seq(
-      "org.apache.logging.log4j" % "log4j-api" % Log4jVersion % "test"
-    )
-  )
+  .settings(libraryDependencies ++= Seq(log4jApi))
 
 lazy val clientesjava = (project in file("elastic4s-client-esjava"))
   .settings(name := "elastic4s-client-esjava")
   .dependsOn(core)
   .settings(allSettings)
   .settings(
-    libraryDependencies ++= Seq(
-      "org.elasticsearch.client" % "elasticsearch-rest-client" % ElasticsearchVersion,
-      "org.apache.logging.log4j" % "log4j-api" % Log4jVersion % "test",
+    libraryDependencies ++= Seq(elasticsearchRestClient,
+      log4jApi,
       "com.fasterxml.jackson.core" % "jackson-core" % JacksonVersion,
       "com.fasterxml.jackson.core" % "jackson-databind" % JacksonVersion,
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % JacksonVersion exclude("org.scala-lang", "scala-library")
@@ -248,92 +186,62 @@ lazy val clientsSniffed = (project in file("elastic4s-client-sniffed"))
   .settings(name := "elastic4s-client-sniffed")
   .dependsOn(clientesjava)
   .settings(allSettings)
-  .settings(
-    libraryDependencies ++= Seq(
-      "org.elasticsearch.client" % "elasticsearch-rest-client-sniffer" % ElasticsearchVersion,
-    )
-  )
+  .settings(libraryDependencies ++= Seq(elasticsearchRestClientSniffer))
 
 lazy val cats_effect = (project in file("elastic4s-effect-cats"))
   .dependsOn(core)
   .settings(name := "elastic4s-effect-cats")
   .settings(allSettings)
-  .settings(
-    libraryDependencies ++= Seq(
-      "org.typelevel" %% "cats-effect" % CatsEffectVersion
-    )
-  )
+  .settings(libraryDependencies += cats)
 
 lazy val cats_effect_2 = (project in file("elastic4s-effect-cats-2"))
   .dependsOn(core)
   .settings(name := "elastic4s-effect-cats-2")
   .settings(allSettings)
-  .settings(
-    libraryDependencies ++= Seq(
-      "org.typelevel" %% "cats-effect" % CatsEffect2Version
-    )
-  )
+  .settings(libraryDependencies += cats2)
 
 lazy val zio = (project in file("elastic4s-effect-zio"))
   .dependsOn(core, testkit % "test")
   .settings(name := "elastic4s-effect-zio")
   .settings(allSettings)
-  .settings(
-    libraryDependencies ++= Seq(
-      "dev.zio" %% "zio" % ZIOVersion
-    )
-  )
+  .settings(libraryDependencies ++= Dependencies.zio)
 
 lazy val scalaz = (project in file("elastic4s-effect-scalaz"))
   .dependsOn(core)
   .settings(name := "elastic4s-effect-scalaz")
   .settings(allSettings)
-  .settings(
-    libraryDependencies ++= Seq(
-      "org.scalaz" %% "scalaz-core" % ScalazVersion,
-      "org.scalaz" %% "scalaz-concurrent" % ScalazVersion
-    )
-  )
+  .settings(libraryDependencies ++= Dependencies.scalaz)
 
 lazy val monix = (project in file("elastic4s-effect-monix"))
   .dependsOn(core)
   .settings(name := "elastic4s-effect-monix")
   .settings(allSettings)
-  .settings(
-    libraryDependencies ++= Seq(
-      "io.monix" %% "monix" % MonixVersion
-    )
-  )
+  .settings(libraryDependencies += Dependencies.monix)
 
 lazy val testkit = (project in file("elastic4s-testkit"))
   .dependsOn(core, clientesjava)
   .settings(name := "elastic4s-testkit")
   .settings(allSettings)
-  .settings(
-    libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % ScalatestVersion,
-      "org.scalatestplus" %% ScalatestPlusMockitoArtifactId % ScalatestPlusVersion
-    )
-  )
+  .settings(libraryDependencies ++= Seq(Dependencies.scalaTest, scalaTestPlusMokito))
 
 lazy val httpstreams = (project in file("elastic4s-http-streams"))
   .dependsOn(core, testkit % "test", jackson % "test")
   .settings(name := "elastic4s-http-streams")
   .settings(allSettings)
-  .settings(
-    libraryDependencies += "com.typesafe.akka"   %% "akka-actor"          % AkkaVersion,
-    libraryDependencies += "org.reactivestreams" % "reactive-streams"     % ReactiveStreamsVersion,
-    libraryDependencies += "org.reactivestreams" % "reactive-streams-tck" % ReactiveStreamsVersion % "test",
-    libraryDependencies += "org.scalatestplus" %% "testng-6-7" % ScalatestPlusVersion % "test"
+  .settings(libraryDependencies ++=
+    Seq(
+      Dependencies.akkaActor,
+      Dependencies.akkaStream,
+      Dependencies.reactiveStreamsTck,
+      Dependencies.scalaTestPlusTestng67
+    )
   )
 
 lazy val akkastreams = (project in file("elastic4s-streams-akka"))
   .dependsOn(core, testkit % "test", jackson % "test")
   .settings(name := "elastic4s-streams-akka")
   .settings(allSettings)
-  .settings(
-    libraryDependencies += "com.typesafe.akka" %% "akka-stream" % AkkaVersion
-  )
+  .settings(libraryDependencies += Dependencies.akkaStream)
 
 lazy val jackson = (project in file("elastic4s-json-jackson"))
   .dependsOn(core)
@@ -349,63 +257,43 @@ lazy val circe = (project in file("elastic4s-json-circe"))
   .dependsOn(core)
   .settings(name := "elastic4s-json-circe")
   .settings(allSettings)
-  .settings(
-    libraryDependencies += "io.circe" %% "circe-core" % CirceVersion,
-    libraryDependencies += "io.circe" %% "circe-generic" % CirceVersion,
-    libraryDependencies += "io.circe" %% "circe-parser" % CirceVersion
-  )
+  .settings(libraryDependencies ++= Dependencies.circe)
 
 lazy val json4s = (project in file("elastic4s-json-json4s"))
   .dependsOn(core)
   .settings(name := "elastic4s-json-json4s")
   .settings(allSettings)
-  .settings(
-    libraryDependencies += "org.json4s" %% "json4s-core" % Json4sVersion,
-    libraryDependencies += "org.json4s" %% "json4s-jackson" % Json4sVersion
-  )
+  .settings(libraryDependencies ++= Dependencies.json4s)
 
 lazy val playjson = (project in file("elastic4s-json-play"))
   .dependsOn(core)
   .settings(name := "elastic4s-json-play")
   .settings(allSettings)
-  .settings(
-    libraryDependencies += "com.typesafe.play" %% "play-json" % PlayJsonVersion
-  )
+  .settings(libraryDependencies ++= Dependencies.playJson)
 
 lazy val sprayjson = (project in file("elastic4s-json-spray"))
   .dependsOn(core)
   .settings(name := "elastic4s-json-spray")
   .settings(allSettings)
-  .settings(
-    libraryDependencies += "io.spray" %% "spray-json" % SprayJsonVersion
-  )
+  .settings(libraryDependencies ++= Dependencies.sprayJson)
 
 lazy val ziojson = (project in file("elastic4s-json-zio"))
   .dependsOn(core)
   .settings(name := "elastic4s-json-zio")
   .settings(allSettings)
-  .settings(
-    libraryDependencies += "dev.zio" %% "zio-json" % ZIOJsonVersion
-  )
+  .settings(libraryDependencies += Dependencies.zioJson)
 
 lazy val clientsttp = (project in file("elastic4s-client-sttp"))
   .dependsOn(core)
   .settings(name := "elastic4s-client-sttp")
   .settings(allSettings)
-  .settings(
-    libraryDependencies += "com.softwaremill.sttp" %% "core" % SttpVersion,
-    libraryDependencies += "com.softwaremill.sttp" %% "async-http-client-backend-future" % SttpVersion
-  )
+  .settings(libraryDependencies ++= Seq(sttp, asyncHttpClientBackendFuture))
 
 lazy val clientakka = (project in file("elastic4s-client-akka"))
   .dependsOn(core, testkit % "test")
   .settings(name := "elastic4s-client-akka")
   .settings(allSettings)
-  .settings(
-    libraryDependencies += "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
-    libraryDependencies += "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
-    libraryDependencies += "org.scalamock" %% "scalamock" % ScalamockVersion % "test"
-  )
+  .settings(libraryDependencies ++= Seq(akkaHTTP, akkaStream, scalaMock))
 
 lazy val tests = (project in file("elastic4s-tests"))
   .settings(name := "elastic4s-tests")
@@ -414,8 +302,8 @@ lazy val tests = (project in file("elastic4s-tests"))
   .settings(noPublishSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "commons-io" % "commons-io" % CommonsIoVersion % "test",
-      "org.mockito" % "mockito-core" % MockitoVersion % "test",
+      commonsIo,
+      mockitoCore,
       "com.fasterxml.jackson.core" % "jackson-core" % JacksonVersion % "test",
       "com.fasterxml.jackson.core" % "jackson-databind" % JacksonVersion % "test",
       "com.fasterxml.jackson.module" %% "jackson-module-scala" % JacksonVersion % "test" exclude("org.scala-lang", "scala-library"),
@@ -423,7 +311,7 @@ lazy val tests = (project in file("elastic4s-tests"))
       "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.12.0" % "test",
       "org.apache.logging.log4j" % "log4j-core" % "2.12.0" % "test"
     ),
-    fork in Test := false,
-    parallelExecution in Test := false,
-    testForkedParallel in Test := false
+    Test / fork := false,
+    Test / parallelExecution := false,
+    Test / testForkedParallel := false
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,0 +1,82 @@
+import sbt.Keys.libraryDependencies
+import sbt._
+
+object Dependencies {
+  val AkkaHttpVersion                = "10.2.3"
+  val AkkaVersion                    = "2.6.14"
+  val CatsEffect2Version             = "2.5.0"
+  val CatsEffectVersion              = "3.1.1"
+  val CatsVersion                    = "2.0.0"
+  val CirceVersion                   = "0.14.1"
+  val CommonsIoVersion               = "2.9.0"
+  val ElasticsearchVersion           = "7.12.1"
+  val ExtsVersion                    = "1.61.1"
+  val JacksonVersion                 = "2.12.3"
+  val Json4sVersion                  = "3.6.11"
+  val Log4jVersion                   = "2.14.1"
+  val MockitoVersion                 = "3.11.0"
+  val MonixVersion                   = "3.4.0"
+  val PlayJsonVersion                = "2.9.2"
+  val ReactiveStreamsVersion         = "1.0.3"
+  val ScalamockVersion               = "5.1.0"
+  val ScalatestPlusMockitoArtifactId = "mockito-3-2"
+  val ScalatestPlusVersion           = "3.1.2.0"
+  val ScalatestVersion               = "3.2.9"
+  val ScalazVersion                  = "7.2.32"
+  val Slf4jVersion                   = "1.7.30"
+  val SprayJsonVersion               = "1.3.6"
+  val SttpVersion                    = "1.7.2"
+  val ZIOJsonVersion                 = "0.1.5"
+  val ZIOVersion                     = "1.0.9"
+
+  lazy val commonDeps = Seq(
+    libraryDependencies ++= Seq(
+      "com.sksamuel.exts" %% "exts"                         % ExtsVersion,
+      "org.slf4j"          % "slf4j-api"                    % Slf4jVersion,
+      "org.scalatest"     %% "scalatest"                    % ScalatestVersion     % "test",
+      "org.mockito"        % "mockito-core"                 % MockitoVersion       % "test",
+      "org.scalatestplus" %% ScalatestPlusMockitoArtifactId % ScalatestPlusVersion % "test"
+    ))
+
+  lazy val fasterXmlJacksonScala = Seq(
+    "com.fasterxml.jackson.core"    % "jackson-core"         % JacksonVersion,
+    "com.fasterxml.jackson.core"    % "jackson-databind"     % JacksonVersion,
+    "com.fasterxml.jackson.module" %% "jackson-module-scala" % JacksonVersion
+  )
+
+  lazy val zio = Seq("dev.zio" %% "zio" % ZIOVersion)
+
+  lazy val scalaz =
+    Seq("org.scalaz" %% "scalaz-core" % ScalazVersion, "org.scalaz" %% "scalaz-concurrent" % ScalazVersion)
+
+  lazy val circe = Seq(
+    "io.circe" %% "circe-core"    % CirceVersion,
+    "io.circe" %% "circe-generic" % CirceVersion,
+    "io.circe" %% "circe-parser"  % CirceVersion)
+
+  lazy val akkaActor                    = "com.typesafe.akka"       %% "akka-actor"                       % AkkaVersion
+  lazy val akkaHTTP                     = "com.typesafe.akka"       %% "akka-http"                        % AkkaHttpVersion
+  lazy val akkaStream                   = "com.typesafe.akka"       %% "akka-stream"                      % AkkaVersion
+  lazy val asyncHttpClientBackendFuture = "com.softwaremill.sttp"   %% "async-http-client-backend-future" % SttpVersion
+  lazy val cats                         = "org.typelevel"           %% "cats-effect"                      % CatsEffectVersion
+  lazy val cats2                        = "org.typelevel"           %% "cats-effect"                      % CatsEffect2Version
+  lazy val elasticsearchRestClient      = "org.elasticsearch.client" % "elasticsearch-rest-client"        % ElasticsearchVersion
+  lazy val json4s                       = Seq("org.json4s" %% "json4s-core" % Json4sVersion, "org.json4s" %% "json4s-jackson" % Json4sVersion)
+  lazy val monix                        = "io.monix"                %% "monix"                            % MonixVersion
+  lazy val playJson                     = Seq("com.typesafe.play" %% "play-json" % PlayJsonVersion)
+  lazy val sprayJson                    = Seq("io.spray" %% "spray-json" % SprayJsonVersion)
+  lazy val sttp                         = "com.softwaremill.sttp"   %% "core"                             % SttpVersion
+  lazy val zioJson                      = "dev.zio"                 %% "zio-json"                         % ZIOJsonVersion
+  lazy val elasticsearchRestClientSniffer = "org.elasticsearch.client" % "elasticsearch-rest-client-sniffer" %
+    ElasticsearchVersion
+
+  lazy val commonsIo             = "commons-io"               % "commons-io"                   % CommonsIoVersion       % "test"
+  lazy val log4jApi              = "org.apache.logging.log4j" % "log4j-api"                    % Log4jVersion           % "test"
+  lazy val mockitoCore           = "org.mockito"              % "mockito-core"                 % MockitoVersion         % "test"
+  lazy val reactiveStreamsTck    = "org.reactivestreams"      % "reactive-streams-tck"         % ReactiveStreamsVersion % "test"
+  lazy val scalaMock             = "org.scalamock"           %% "scalamock"                    % ScalamockVersion       % "test"
+  lazy val scalaTest             = "org.scalatest"           %% "scalatest"                    % ScalatestVersion       % "test"
+  lazy val scalaTestPlusMokito   = "org.scalatestplus"       %% ScalatestPlusMockitoArtifactId % ScalatestPlusVersion
+  lazy val scalaTestPlusTestng67 = "org.scalatestplus"       %% "testng-6-7"                   % ScalatestPlusVersion   % "test"
+
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,5 +3,3 @@ resolvers += Classpaths.sbtPluginReleases
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 
 addSbtPlugin("com.github.sbt" % "sbt-release" % "1.0.15")
-
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.5.5")


### PR DESCRIPTION
* move deps to separate file
* address some of the sbt warnings on outdated syntax
* use G1 GC for sbt run
* remove "sbt-dotty" plug-in