### PR TITLE
Support hard bounds in HistogramAggregation

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/HistogramAggregation.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/HistogramAggregation.scala
@@ -12,6 +12,7 @@ case class HistogramAggregation(name: String,
                                 keyed: Option[Boolean] = None,
                                 offset: Option[Double] = None,
                                 extendedBounds: Option[ExtendedBounds] = None,
+                                hardBounds: Option[ExtendedBounds] = None,
                                 order: Option[HistogramOrder] = None,
                                 script: Option[Script] = None,
                                 subaggs: Seq[AbstractAggregation] = Nil,
@@ -36,4 +37,6 @@ case class HistogramAggregation(name: String,
   def offset(offset: Double): HistogramAggregation       = copy(offset = offset.some)
   def extendedBounds(min: Double, max: Double): HistogramAggregation =
     copy(extendedBounds = ExtendedBounds(min, max).some)
+  def hardBounds(min: Double, max: Double): HistogramAggregation =
+    copy(hardBounds = ExtendedBounds(min, max).some)
 }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/HistogramAggregationBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/HistogramAggregationBuilder.scala
@@ -25,6 +25,9 @@ object HistogramAggregationBuilder {
     agg.extendedBounds.foreach { bounds =>
       builder.rawField("extended_bounds", ExtendedBoundsBuilderFn(bounds))
     }
+    agg.hardBounds.foreach { bounds =>
+      builder.rawField("hard_bounds", ExtendedBoundsBuilderFn(bounds))
+    }
     builder.endObject()
 
     SubAggsBuilderFn(agg, builder)


### PR DESCRIPTION
should fix https://github.com/sksamuel/elastic4s/issues/2456

wasn't sure if to rename ExtendedBounds class to something more generic since it's used with HardBounds now as well