### PR TITLE
cherry-pick/getMappings should return meta (#2082)

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/MappingHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/indexes/MappingHandlers.scala
@@ -3,7 +3,7 @@ package com.sksamuel.elastic4s.requests.indexes
 import com.sksamuel.elastic4s._
 import com.sksamuel.elastic4s.requests.mappings.{GetFieldMappingRequest, GetMappingRequest, PutMappingRequest}
 
-case class IndexMappings(index: String, mappings: Map[String, Any])
+case class IndexMappings(index: String, mappings: Map[String, Any], meta: Map[String, Any] = Map.empty[String, Any])
 
 case class IndexFieldMapping(index: String, fieldMappings: Seq[FieldMapping])
 case class FieldMapping(fullName:String, mappings: Map[String, Any])
@@ -20,7 +20,8 @@ trait MappingHandlers {
           val raw2 = raw.map {
             case (index, types) =>
               val mappings = types("mappings").getOrElse("properties", Map.empty)
-              IndexMappings(index, mappings.asInstanceOf[Map[String, Any]])
+              val meta = types("mappings").getOrElse("_meta", Map.empty)
+              IndexMappings(index, mappings.asInstanceOf[Map[String, Any]], meta.asInstanceOf[Map[String, Any]])
           }.toSeq
           Right(raw2)
         case _              =>

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/PutMappingHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/mappings/PutMappingHttpTest.scala
@@ -18,8 +18,8 @@ class PutMappingHttpTest extends AnyFunSuite with Matchers with DockerTests {
     }
 
     client.execute {
-      createIndex("putmaptest").mappings(
-        mapping().fields(
+      createIndex("putmaptest").mapping(
+        properties().fields(
           keywordField("foo")
         )
       )
@@ -47,8 +47,8 @@ class PutMappingHttpTest extends AnyFunSuite with Matchers with DockerTests {
     }
 
     client.execute {
-      createIndex("putrawtest").mappings(
-        mapping().fields(
+      createIndex("putrawtest").mapping(
+        properties().fields(
           keywordField("foo")
         )
       )


### PR DESCRIPTION
Getting `_meta` from index mappings is possible only starting from 7.4.x

This PR is just cherry-pick of original merged commit specifically for 7.3.x 

