### PR TITLE
Add task support to DeleteByQuery in 7.9

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/delete/DeleteByQueryRequest.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/delete/DeleteByQueryRequest.scala
@@ -14,6 +14,7 @@ case class DeleteByQueryRequest(indexes: Indexes,
                                 proceedOnConflicts: Option[Boolean] = None,
                                 refresh: Option[RefreshPolicy] = None,
                                 waitForActiveShards: Option[Int] = None,
+                                waitForCompletion: Option[Boolean] = None,
                                 retryBackoffInitialTime: Option[FiniteDuration] = None,
                                 timeout: Option[FiniteDuration] = None,
                                 scrollSize: Option[Int] = None,
@@ -36,6 +37,9 @@ case class DeleteByQueryRequest(indexes: Indexes,
 
   def waitForActiveShards(waitForActiveShards: Int): DeleteByQueryRequest =
     copy(waitForActiveShards = waitForActiveShards.some)
+
+  def waitForCompletion(waitForCompletion: Boolean): DeleteByQueryRequest =
+    copy(waitForCompletion = waitForCompletion.some)
 
   def routing(r: String): DeleteByQueryRequest   = copy(routing = r.some)
   def retryBackoffInitialTime(retryBackoffInitialTime: FiniteDuration): DeleteByQueryRequest =

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/delete/DeleteHandlers.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/delete/DeleteHandlers.scala
@@ -43,6 +43,7 @@ trait DeleteHandlers {
       request.routing.map(_.toString).foreach(params.put("routing", _))
       request.size.map(_.toString).foreach(params.put("size", _))
       request.waitForActiveShards.map(_.toString).foreach(params.put("wait_for_active_shards", _))
+      request.waitForCompletion.map(_.toString).foreach(params.put("wait_for_completion", _))
 
       val body = DeleteByQueryBodyFn(request)
       logger.debug(s"Delete by query ${body.string()}")


### PR DESCRIPTION
We add `wait_for_completion` support to `Delete`.

To not break the 7.9 `Response` API, we don't touch `DeleteByQueryHandler`. Instead, to get the `taskId` of a `DeleteByQuery` that does not `wait_for_completion`, the consuming side can define a custom `DeleteByQueryHandler` and do the below:
```
def deleteUserByName(name: String) {
    implicit val handler: Handler[DeleteByQueryRequest, Either[DeleteByQueryResponse, CreateTaskResponse]] =
      DeleteByQueryHandlerWithTask
    client
      .execute {
        ElasticDsl.deleteIn("users").by(termQuery("name", name)).waitForCompletion(false)
      }
      ...
```

Special caution must be taken not to have the default `elastic4s` `DeleteByQueryHandler` implicitly in scope, for example:
```
import com.sksamuel.elastic4s.ElasticDsl.{ DeleteByQueryHandler => _, _ }
```