### PR TITLE
replace refs to deprecated parameters edgeNgram + nGram

### DIFF
--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/analysis/TokenFilter.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/analysis/TokenFilter.scala
@@ -341,7 +341,7 @@ case class EdgeNGramTokenFilter(override val name: String,
 
   override def build: XContentBuilder = {
     val b = XContentFactory.jsonBuilder()
-    b.field("type", "edgeNGram")
+    b.field("type", "edge_ngram")
     b.field("min_gram", minGram)
     b.field("max_gram", maxGram)
     side.foreach(b.field("side", _))
@@ -361,7 +361,7 @@ case class NGramTokenFilter(override val name: String,
 
   override def build: XContentBuilder = {
     val b = XContentFactory.jsonBuilder()
-    b.field("type", "nGram")
+    b.field("type", "ngram")
     minGram.foreach(b.field("min_gram", _))
     maxGram.foreach(b.field("max_gram", _))
     b

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/analysis/Tokenizer.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/analysis/Tokenizer.scala
@@ -104,7 +104,7 @@ case class EdgeNGramTokenizer(override val name: String,
 
   override def build: XContentBuilder = {
     val b = XContentFactory.jsonBuilder()
-    b.field("type", "edgeNGram")
+    b.field("type", "edge_ngram")
     b.field("min_gram", minGram)
     b.field("max_gram", maxGram)
     if (tokenChars.nonEmpty)

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/analysis/tokenizers/EdgeNGramTokenizerBuilderTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/analysis/tokenizers/EdgeNGramTokenizerBuilderTest.scala
@@ -9,7 +9,7 @@ class EdgeNGramTokenizerBuilderTest extends AnyWordSpec with Matchers with Elast
 
   "EdgeNGramTokenizer" should {
     "build json" in {
-      EdgeNGramTokenizer("testy").minMaxGrams(2, 3).tokenChars("a", "z").build.string shouldBe """{"type":"edgeNGram","min_gram":2,"max_gram":3,"token_chars":["a","z"]}"""
+      EdgeNGramTokenizer("testy").minMaxGrams(2, 3).tokenChars("a", "z").build.string shouldBe """{"type":"edge_ngram","min_gram":2,"max_gram":3,"token_chars":["a","z"]}"""
     }
   }
 }


### PR DESCRIPTION
This PR fixes references to deprecated type parameters
- `edgeNGram` -> `edge_ngram` in `EdgeNGramTokenFilter` and `EdgeNGramTokenizer`
- `nGram` -> `ngram` in `NGramTokenFilter`

[elasticsearch deprecation note re token filters](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html#deprecated-ngram-edgengram-token-filter-cannot-be-used
): 
> The nGram and edgeNGram token filter names have been deprecated in an earlier 6.x version. Indexes created using these token filters will still be readable in elasticsearch 7.0 but indexing documents using those filter names will issue a deprecation warning. Using the deprecated names on new indices starting with version 7.0.0 will be prohibited and throw an error when indexing or analyzing documents. Both names should be replaced by ngram or edge_ngram respectively.

[elasticsearch deprecation note re tokenizers](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.6.html#_disallow_use_of_the_ngram_and_edgengram_tokenizer_names):
> The nGram and edgeNGram tokenizer names haven been deprecated with 7.6. Mappings for indices created after 7.6 will continue to work but emit a deprecation warning. The tokenizer name should be changed to the fully equivalent ngram or edge_ngram names for new indices and in index templates.

**Note:** I only updated the references for tokenizer+token filter classes in the analysis package, I did not update the deprecated classes in the `requests/analyzers` package. Is that the right choice?

We also need this in 7.10.x. I'm happy to open a backport PR if this one merges!