### PR TITLE
Add task support to DeleteByQuery in master

### DIFF
--- a/docs/version8migration.md
+++ b/docs/version8migration.md
@@ -21,3 +21,5 @@ removed boost from double field
 match queries renamed to include query suffix
 
 suggestion response classes moved to newpackage
+
+DeleteByQueryRequest returns Either[DeleteByQueryResponse, CreateTaskResponse] instead of DeleteByQueryResponse

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/delete/DeleteByQueryRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/delete/DeleteByQueryRequest.scala
@@ -14,6 +14,7 @@ case class DeleteByQueryRequest(indexes: Indexes,
                                 proceedOnConflicts: Option[Boolean] = None,
                                 refresh: Option[RefreshPolicy] = None,
                                 waitForActiveShards: Option[Int] = None,
+                                waitForCompletion: Option[Boolean] = None,
                                 retryBackoffInitialTime: Option[FiniteDuration] = None,
                                 timeout: Option[FiniteDuration] = None,
                                 scrollSize: Option[Int] = None,
@@ -36,6 +37,9 @@ case class DeleteByQueryRequest(indexes: Indexes,
 
   def waitForActiveShards(waitForActiveShards: Int): DeleteByQueryRequest =
     copy(waitForActiveShards = waitForActiveShards.some)
+
+  def waitForCompletion(waitForCompletion: Boolean): DeleteByQueryRequest =
+    copy(waitForCompletion = waitForCompletion.some)
 
   def routing(r: String): DeleteByQueryRequest = copy(routing = r.some)
   def retryBackoffInitialTime(retryBackoffInitialTime: FiniteDuration): DeleteByQueryRequest =

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/delete/DeleteHandlers.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/delete/DeleteHandlers.scala
@@ -43,6 +43,7 @@ trait DeleteHandlers {
       request.routing.map(_.toString).foreach(params.put("routing", _))
       request.size.map(_.toString).foreach(params.put("size", _))
       request.waitForActiveShards.map(_.toString).foreach(params.put("wait_for_active_shards", _))
+      request.waitForCompletion.map(_.toString).foreach(params.put("wait_for_completion", _))
 
       val body = DeleteByQueryBodyFn(request)
       logger.debug(s"Delete by query ${body.string()}")

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/delete/DeleteHandlers.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/delete/DeleteHandlers.scala
@@ -7,6 +7,8 @@ import com.sksamuel.elastic4s.requests.common.RefreshPolicyHttpValue
 import com.sksamuel.elastic4s.requests.delete.{DeleteByIdRequest, DeleteByQueryRequest, DeleteByQueryResponse, DeleteResponse}
 import com.sksamuel.elastic4s.{ElasticError, ElasticRequest, ElasticUrlEncoder, Handler, HttpEntity, HttpResponse, ResponseHandler}
 import com.sksamuel.elastic4s.handlers.ElasticErrorParser
+import com.sksamuel.elastic4s.requests.task.CreateTaskResponse
+import com.sksamuel.exts.OptionImplicits.RichOption
 
 object DeleteByQueryBodyFn {
   def apply(request: DeleteByQueryRequest): XContentBuilder = {
@@ -19,13 +21,20 @@ object DeleteByQueryBodyFn {
 
 trait DeleteHandlers {
 
-  implicit object DeleteByQueryHandler extends Handler[DeleteByQueryRequest, DeleteByQueryResponse] {
+  implicit object DeleteByQueryHandler extends Handler[DeleteByQueryRequest, Either[DeleteByQueryResponse, CreateTaskResponse]] {
 
-    override def responseHandler: ResponseHandler[DeleteByQueryResponse] = new ResponseHandler[DeleteByQueryResponse] {
-      override def handle(response: HttpResponse): Either[ElasticError, DeleteByQueryResponse] =
+    private val TaskRegex = """\{"task":"(.*):(.*)"\}""".r
+
+    override def responseHandler: ResponseHandler[Either[DeleteByQueryResponse, CreateTaskResponse]] = new ResponseHandler[Either[DeleteByQueryResponse, CreateTaskResponse]] {
+      override def handle(response: HttpResponse): Either[ElasticError, Either[DeleteByQueryResponse, CreateTaskResponse]] =
         response.statusCode match {
-          case 200 | 201 => Right(ResponseHandler.fromResponse[DeleteByQueryResponse](response))
-          case _         => Left(ElasticErrorParser.parse(response))
+          case 200 | 201 =>
+            val entity = response.entity.getOrError("No entity defined but was expected")
+            entity.get match {
+              case TaskRegex(nodeId, taskId) => Right(Right(CreateTaskResponse(nodeId, taskId)))
+              case _ => Right(Left(ResponseHandler.fromResponse[DeleteByQueryResponse](response)))
+            }
+          case _ => Left(ElasticErrorParser.parse(response))
         }
     }
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/delete/DeleteByQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/delete/DeleteByQueryTest.scala
@@ -43,7 +43,7 @@ class DeleteByQueryTest extends AnyWordSpec with Matchers with DockerTests {
 
       client.execute {
         deleteByQuery(indexname, matchQuery("name", "bumbles")).refresh(RefreshPolicy.Immediate)
-      }.await.result.deleted shouldBe 2
+      }.await.result.left.get.deleted shouldBe 2
 
       client.execute {
         search(indexname).matchAllQuery()
@@ -65,7 +65,7 @@ class DeleteByQueryTest extends AnyWordSpec with Matchers with DockerTests {
 
       client.execute {
         deleteByQuery(indexname, matchAllQuery()).refresh(RefreshPolicy.Immediate).size(3)
-      }.await.result.deleted shouldBe 3
+      }.await.result.left.get.deleted shouldBe 3
 
       client.execute {
         search(indexname).matchAllQuery()
@@ -76,6 +76,14 @@ class DeleteByQueryTest extends AnyWordSpec with Matchers with DockerTests {
       client.execute {
         deleteByQuery(",", matchQuery("name", "bumbles"))
       }.await.error.`type` shouldBe "action_request_validation_exception"
+    }
+
+    "return a task when setting wait_for_completion to false" in {
+      val result = client.execute {
+        deleteByQuery(indexname, matchQuery("name",  "michael douglas")).waitForCompletion(false)
+      }.await.result.right.get
+      result.nodeId should not be null
+      result.taskId should not be null
     }
   }
 }


### PR DESCRIPTION
We add `wait_for_completion` support to `Delete`.

The project I'm on is using 7.9. The same PR but to the `release/7.9.x` branch can be found here: https://github.com/sksamuel/elastic4s/pull/2472

Edit: **The below does not apply anymore** as per @sksamuel's comment below.

To not break the existing `Response` API, we don't touch `DeleteByQueryHandler`. Instead, to get the `taskId` of a `DeleteByQuery` that does not `wait_for_completion`, the consuming side can define a custom `DeleteByQueryHandler` and do the below:
```
def deleteUserByName(name: String) {
    implicit val handler: Handler[DeleteByQueryRequest, Either[DeleteByQueryResponse, CreateTaskResponse]] =
      DeleteByQueryHandlerWithTask
    client
      .execute {
        ElasticDsl.deleteIn("users").by(termQuery("name", name)).waitForCompletion(false)
      }
      ...
```

Special caution must be taken not to have the default `elastic4s` `DeleteByQueryHandler` implicitly in scope, for example:
```
import com.sksamuel.elastic4s.ElasticDsl.{ DeleteByQueryHandler => _, _ }
```