### PR TITLE
extend AkkaHttpClientSettings to skip ssl certificate verification

### DIFF
--- a/docs/clients.md
+++ b/docs/clients.md
@@ -55,7 +55,7 @@ To use these, add the appropriate module to your build, and then pass an instanc
 For Akka HTTP, we use `AkkaHttpClient`:
 
 ```scala
-val client = ElasticClient(AkkaHttpClient(AkkaHttpClientSettings(List("http://host1:9200"))))
+val client = ElasticClient(AkkaHttpClient(AkkaHttpClientSettings(List("host1:9200"))))
 ```
 
 It's possible to create the `AkkaHttpClientSettings` from Typesafe configuration using `AkkaHttpClientSettings.defaults` or by passing in a `Config` instance using `AkkaHttpClientSettings(config)`.
@@ -66,6 +66,7 @@ The default configuration:
 com.sksamuel.elastic4s.akka {
   hosts: []
   https: false
+  verify-ssl-certificate : true
   queue-size: 1000
   blacklist {
     min-duration = 1m

--- a/elastic4s-client-akka/src/main/resources/reference.conf
+++ b/elastic4s-client-akka/src/main/resources/reference.conf
@@ -1,8 +1,11 @@
 com.sksamuel.elastic4s.akka {
-  hosts: []
-  https: false
-  verify-ssl-certificate: true
-  queue-size: 1000
+  hosts = []
+  https = false
+  verify-ssl-certificate = true
+  // optionally provide credentials
+  // username = ...
+  // password = ...
+  queue-size = 1000
   blacklist {
     min-duration = 1m
     max-duration = 30m

--- a/elastic4s-client-akka/src/main/resources/reference.conf
+++ b/elastic4s-client-akka/src/main/resources/reference.conf
@@ -1,6 +1,7 @@
 com.sksamuel.elastic4s.akka {
   hosts: []
   https: false
+  verify-ssl-certificate: true
   queue-size: 1000
   blacklist {
     min-duration = 1m

--- a/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClient.scala
+++ b/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClient.scala
@@ -294,7 +294,7 @@ object AkkaHttpClient {
       settings.blacklistMaxDuration
     )
 
-    val httpPoolFactory = new DefaultHttpPoolFactory(settings.poolSettings)
+    val httpPoolFactory = new DefaultHttpPoolFactory(settings.poolSettings, settings.verifySSLCertificate)
 
     new AkkaHttpClient(settings, blacklist, httpPoolFactory)
   }

--- a/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientSettings.scala
+++ b/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientSettings.scala
@@ -24,6 +24,7 @@ object AkkaHttpClientSettings {
     val password = Try(cfg.getString("password")).map(Some(_)).getOrElse(None)
     val queueSize = cfg.getInt("queue-size")
     val https = cfg.getBoolean("https")
+    val verifySslCertificate = Try(cfg.getBoolean("verify-ssl-certificate")).toOption.getOrElse(true)
     val blacklistMinDuration = Duration(
       cfg.getDuration("blacklist.min-duration", TimeUnit.MILLISECONDS),
       TimeUnit.MILLISECONDS
@@ -46,6 +47,7 @@ object AkkaHttpClientSettings {
       password,
       queueSize,
       poolSettings,
+      verifySslCertificate,
       blacklistMinDuration,
       blacklistMaxDuration,
       maxRetryTimeout
@@ -68,6 +70,7 @@ case class AkkaHttpClientSettings(
   password: Option[String],
   queueSize: Int,
   poolSettings: ConnectionPoolSettings,
+  verifySSLCertificate : Boolean,
   blacklistMinDuration: FiniteDuration =
     AkkaHttpClientSettings.default.blacklistMinDuration,
   blacklistMaxDuration: FiniteDuration =

--- a/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/DefaultHttpPoolFactory.scala
+++ b/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/DefaultHttpPoolFactory.scala
@@ -2,16 +2,18 @@ package com.sksamuel.elastic4s.akka
 
 import akka.NotUsed
 import akka.actor.ActorSystem
-import akka.http.scaladsl.Http
+import akka.http.scaladsl.{ConnectionContext, Http}
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
 import akka.http.scaladsl.settings.ConnectionPoolSettings
 import akka.stream.scaladsl.Flow
 
+import java.security.cert.X509Certificate
+import javax.net.ssl.{KeyManager, SSLContext, X509TrustManager}
 import scala.concurrent.Future
 import scala.concurrent.duration.Duration
 import scala.util.Try
 
-private[akka] class DefaultHttpPoolFactory(settings: ConnectionPoolSettings)(
+private[akka] class DefaultHttpPoolFactory(settings: ConnectionPoolSettings, verifySslCertificate : Boolean)(
   implicit system: ActorSystem)
   extends HttpPoolFactory {
 
@@ -20,13 +22,36 @@ private[akka] class DefaultHttpPoolFactory(settings: ConnectionPoolSettings)(
   private val poolSettings = settings.withResponseEntitySubscriptionTimeout(
     Duration.Inf) // we guarantee to consume consume data from all responses
 
+  // take from https://gist.github.com/iRevive/7d17144284a7a2227487635ec815860d
+  private val trustfulSslContext: SSLContext = {
+    object NoCheckX509TrustManager extends X509TrustManager {
+      override def checkClientTrusted(chain: Array[X509Certificate], authType: String) = ()
+
+      override def checkServerTrusted(chain: Array[X509Certificate], authType: String) = ()
+
+      override def getAcceptedIssuers = Array[X509Certificate]()
+    }
+
+    val context = SSLContext.getInstance("TLS")
+    context.init(Array[KeyManager](), Array(NoCheckX509TrustManager), null)
+    context
+  }
+
+  // https://doc.akka.io/docs/akka-http/current/client-side/client-https-support.html#disabling-hostname-verification
+  private val insecureConnectionContext = ConnectionContext.httpsClient {(host,port)=>
+    val engine = trustfulSslContext.createSSLEngine(host,port)
+    engine.setUseClientMode(true)
+    engine
+  }
+
   override def create[T]()
   : Flow[(HttpRequest, T), (HttpRequest, Try[HttpResponse], T), NotUsed] = {
     Flow[(HttpRequest, T)].map {
       case (request, state) => (request, (request, state))
     }.via{
       http.superPool[(HttpRequest, T)](
-        settings = poolSettings
+        settings = poolSettings,
+        connectionContext = if(verifySslCertificate) http.defaultClientHttpsContext else insecureConnectionContext
       ).map {
         case (response, (request, state)) => (request, response, state)
       }


### PR DESCRIPTION
useful when self signed certificates are used and the jwk truststore can't be changed