### PR TITLE
(WIP) Scala 3

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -108,7 +108,7 @@ jobs:
         run: docker run -d -it -p 39227:9200 -p 39337:9300 -e "discovery.type=single-node" -v /home/runner/work/elastic4s/elastic4s/elastic4s-tests/src/test/resources/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml docker.elastic.co/elasticsearch/elasticsearch:7.14.0
 
       - name: run tests
-        run: sbt ++3.0.1 `for i in json_builder domain handlers core clientcore clientesjava clientsSniffed cats_effect cats_effect_2 tests testkit jackson json4s; do echo $i/test; done | xargs`
+        run: sbt ++3.0.1 `for i in json_builder domain handlers core clientcore clientesjava clientsSniffed cats_effect cats_effect_2 zio tests testkit jackson json4s; do echo $i/test; done | xargs`
 
       - name: Import GPG key
         id: import_gpg
@@ -125,7 +125,7 @@ jobs:
           echo "email:       ${{ steps.import_gpg.outputs.email }}"
 
       - name: publish snapshot
-        run: sbt ++3.0.1 `for i in json_builder domain handlers core clientcore clientesjava clientsSniffed cats_effect cats_effect_2 tests testkit jackson json4s; do echo $i/publish; done | xargs`
+        run: sbt ++3.0.1 `for i in json_builder domain handlers core clientcore clientesjava clientsSniffed cats_effect cats_effect_2 zio tests testkit jackson json4s; do echo $i/publish; done | xargs`
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -105,7 +105,7 @@ jobs:
           java-version: 11
 
       - name: Launch elastic docker
-        run: docker run -d -it -p 39227:9200 -p 39337:9300 -e "discovery.type=single-node" -v /home/runner/work/elastic4s/elastic4s/elastic4s-tests/src/test/resources/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml docker.elastic.co/elasticsearch/elasticsearch:7.14.0
+        run: docker run -d -it -p 39227:9200 -p 39337:9300 -e "discovery.type=single-node" -v /home/runner/work/elastic4s/elastic4s/elastic4s-tests/src/test/resources/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml docker.elastic.co/elasticsearch/elasticsearch:7.15.1
 
       - name: run tests
         run: sbt ++3.0.1 `for i in json_builder domain handlers core clientcore clientesjava clientsSniffed cats_effect cats_effect_2 zio monix tests testkit jackson json4s; do echo $i/test; done | xargs`

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -108,7 +108,7 @@ jobs:
         run: docker run -d -it -p 39227:9200 -p 39337:9300 -e "discovery.type=single-node" -v /home/runner/work/elastic4s/elastic4s/elastic4s-tests/src/test/resources/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml docker.elastic.co/elasticsearch/elasticsearch:7.14.0
 
       - name: run tests
-        run: sbt ++3.0.1 `for i in json_builder domain handlers core clientcore clientesjava clientsSniffed cats_effect cats_effect_2 zio tests testkit jackson json4s; do echo $i/test; done | xargs`
+        run: sbt ++3.0.1 `for i in json_builder domain handlers core clientcore clientesjava clientsSniffed cats_effect cats_effect_2 zio monix tests testkit jackson json4s; do echo $i/test; done | xargs`
 
       - name: Import GPG key
         id: import_gpg
@@ -125,7 +125,7 @@ jobs:
           echo "email:       ${{ steps.import_gpg.outputs.email }}"
 
       - name: publish snapshot
-        run: sbt ++3.0.1 `for i in json_builder domain handlers core clientcore clientesjava clientsSniffed cats_effect cats_effect_2 zio tests testkit jackson json4s; do echo $i/publish; done | xargs`
+        run: sbt ++3.0.1 `for i in json_builder domain handlers core clientcore clientesjava clientsSniffed cats_effect cats_effect_2 zio monix tests testkit jackson json4s; do echo $i/publish; done | xargs`
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -89,3 +89,43 @@ jobs:
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+
+
+  scala-3_0:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout the repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Launch elastic docker
+        run: docker run -d -it -p 39227:9200 -p 39337:9300 -e "discovery.type=single-node" -v /home/runner/work/elastic4s/elastic4s/elastic4s-tests/src/test/resources/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml docker.elastic.co/elasticsearch/elasticsearch:7.14.0
+
+      - name: run tests
+        run: sbt ++3.0.1 `for i in json_builder domain handlers core clientcore clientesjava clientsSniffed cats_effect cats_effect_2 tests testkit jackson json4s; do echo $i/test; done | xargs`
+
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v3
+        with:
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PGP_PASSPHRASE }}
+
+      - name: GPG user IDs
+        run: |
+          echo "fingerprint: ${{ steps.import_gpg.outputs.fingerprint }}"
+          echo "keyid:       ${{ steps.import_gpg.outputs.keyid }}"
+          echo "name:        ${{ steps.import_gpg.outputs.name }}"
+          echo "email:       ${{ steps.import_gpg.outputs.email }}"
+
+      - name: publish snapshot
+        run: sbt ++3.0.1 `for i in json_builder domain handlers core clientcore clientesjava clientsSniffed cats_effect cats_effect_2 tests testkit jackson json4s; do echo $i/publish; done | xargs`
+        env:
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -60,7 +60,7 @@ jobs:
           java-version: 11
 
       - name: Launch elastic docker
-        run: docker run -d -it -p 39227:9200 -p 39337:9300 -e "discovery.type=single-node" -v /home/runner/work/elastic4s/elastic4s/elastic4s-tests/src/test/resources/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml docker.elastic.co/elasticsearch/elasticsearch:7.14.0
+        run: docker run -d -it -p 39227:9200 -p 39337:9300 -e "discovery.type=single-node" -v /home/runner/work/elastic4s/elastic4s/elastic4s-tests/src/test/resources/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml docker.elastic.co/elasticsearch/elasticsearch:7.15.1
 
       - name: run tests
         run: sbt ++3.0.1 `for i in json_builder domain handlers core clientcore clientesjava clientsSniffed cats_effect cats_effect_2 zio monix tests testkit jackson json4s; do echo $i/test; done | xargs`

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,3 +45,22 @@ jobs:
 
       - name: run tests
         run: sbt ++2.13.4 test
+
+  scala-3:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout the repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Launch elastic docker
+        run: docker run -d -it -p 39227:9200 -p 39337:9300 -e "discovery.type=single-node" -v /home/runner/work/elastic4s/elastic4s/elastic4s-tests/src/test/resources/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml docker.elastic.co/elasticsearch/elasticsearch:7.14.0
+
+      - name: run tests
+        run: sbt ++3.0.1 `for i in json_builder domain handlers core clientcore clientesjava clientsSniffed cats_effect cats_effect_2 tests testkit jackson json4s; do echo $i/test; done | xargs`

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -63,4 +63,4 @@ jobs:
         run: docker run -d -it -p 39227:9200 -p 39337:9300 -e "discovery.type=single-node" -v /home/runner/work/elastic4s/elastic4s/elastic4s-tests/src/test/resources/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml docker.elastic.co/elasticsearch/elasticsearch:7.14.0
 
       - name: run tests
-        run: sbt ++3.0.1 `for i in json_builder domain handlers core clientcore clientesjava clientsSniffed cats_effect cats_effect_2 tests testkit jackson json4s; do echo $i/test; done | xargs`
+        run: sbt ++3.0.1 `for i in json_builder domain handlers core clientcore clientesjava clientsSniffed cats_effect cats_effect_2 zio tests testkit jackson json4s; do echo $i/test; done | xargs`

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -63,4 +63,4 @@ jobs:
         run: docker run -d -it -p 39227:9200 -p 39337:9300 -e "discovery.type=single-node" -v /home/runner/work/elastic4s/elastic4s/elastic4s-tests/src/test/resources/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml docker.elastic.co/elasticsearch/elasticsearch:7.14.0
 
       - name: run tests
-        run: sbt ++3.0.1 `for i in json_builder domain handlers core clientcore clientesjava clientsSniffed cats_effect cats_effect_2 zio tests testkit jackson json4s; do echo $i/test; done | xargs`
+        run: sbt ++3.0.1 `for i in json_builder domain handlers core clientcore clientesjava clientsSniffed cats_effect cats_effect_2 zio monix tests testkit jackson json4s; do echo $i/test; done | xargs`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
 
       - name: publish 3.0 release
-        run: sbt ++3.0.1 `for i in json_builder domain handlers core clientcore clientesjava clientsSniffed cats_effect cats_effect_2 zio tests testkit jackson json4s; do echo $i/publishSigned; done | xargs`
+        run: sbt ++3.0.1 `for i in json_builder domain handlers core clientcore clientesjava clientsSniffed cats_effect cats_effect_2 zio monix tests testkit jackson json4s; do echo $i/publishSigned; done | xargs`
         env:
           RELEASE_VERSION: ${{ github.event.inputs.version }}
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
 
       - name: publish 3.0 release
-        run: sbt ++3.0.1 `for i in json_builder domain handlers core clientcore clientesjava clientsSniffed cats_effect cats_effect_2 tests testkit jackson json4s; do echo $i/publishSigned; done | xargs`
+        run: sbt ++3.0.1 `for i in json_builder domain handlers core clientcore clientesjava clientsSniffed cats_effect cats_effect_2 zio tests testkit jackson json4s; do echo $i/publishSigned; done | xargs`
         env:
           RELEASE_VERSION: ${{ github.event.inputs.version }}
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
 
       - name: publish 3.0 release
-        run: sbt ++3.0.1 `for i in json_builder domain handlers core clientcore clientesjava clientsSniffed cats_effect cats_effect_2 zio monix tests testkit jackson json4s; do echo $i/publishSigned; done | xargs`
+        run: sbt ++3.0.2 `for i in json_builder domain handlers core clientcore clientesjava clientsSniffed cats_effect cats_effect_2 zio monix tests testkit jackson json4s; do echo $i/publishSigned; done | xargs`
         env:
           RELEASE_VERSION: ${{ github.event.inputs.version }}
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,13 @@ jobs:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
 
+      - name: publish 3.0 release
+        run: sbt ++3.0.1 `for i in json_builder domain handlers core clientcore clientesjava clientsSniffed cats_effect cats_effect_2 tests testkit jackson json4s; do echo $i/publishSigned; done | xargs`
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.version }}
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+
       - name: tag release
         run: |
           git tag v${{ github.event.inputs.version }}

--- a/build.sbt
+++ b/build.sbt
@@ -207,7 +207,7 @@ lazy val cats_effect_2 = (project in file("elastic4s-effect-cats-2"))
 lazy val zio = (project in file("elastic4s-effect-zio"))
   .dependsOn(core, testkit % "test")
   .settings(name := "elastic4s-effect-zio")
-  .settings(scala2Settings)
+  .settings(scala3Settings)
   .settings(libraryDependencies ++= Dependencies.zio)
 
 lazy val scalaz = (project in file("elastic4s-effect-scalaz"))

--- a/build.sbt
+++ b/build.sbt
@@ -58,7 +58,7 @@ lazy val publishSettings = Seq(
 )
 
 lazy val commonJvmSettings = Seq(
-   Test / testOptions += {
+  Test / testOptions += {
     val flag = if (isGithubActions) "-oCI" else "-oDF"
     Tests.Argument(TestFrameworks.ScalaTest, flag)
   },

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ def ossrhPassword = sys.env.getOrElse("OSSRH_PASSWORD", "")
 
 lazy val commonScalaVersionSettings = Seq(
   scalaVersion := "2.12.15",
-  crossScalaVersions := Seq("2.12.15", "2.13.6")
+  crossScalaVersions := Seq("2.12.15", "2.13.6", "3.0.2")
 )
 
 lazy val warnUnusedImport = Seq(
@@ -120,24 +120,24 @@ lazy val root = Project("elastic4s", file("."))
     core,
     clientcore,
     clientesjava,
-    clientsSniffed,
+//    clientsSniffed,
     cats_effect,
-    cats_effect_2,
-    zio,
-    scalaz,
-    monix,
+//    cats_effect_2,
+//    zio,
+//    scalaz,
+//    monix,
     tests,
     testkit,
     circe,
     jackson,
-    json4s,
-    playjson,
-    sprayjson,
-    ziojson,
-    clientsttp,
-    clientakka,
-    httpstreams,
-    akkastreams
+//    json4s,
+//    playjson,
+//    sprayjson,
+//    ziojson,
+//    clientsttp,
+//    clientakka,
+//    httpstreams,
+//    akkastreams
   )
 
 lazy val domain = (project in file("elastic4s-domain"))
@@ -194,54 +194,54 @@ lazy val cats_effect = (project in file("elastic4s-effect-cats"))
   .settings(allSettings)
   .settings(libraryDependencies += cats)
 
-lazy val cats_effect_2 = (project in file("elastic4s-effect-cats-2"))
-  .dependsOn(core, testkit % "test")
-  .settings(name := "elastic4s-effect-cats-2")
-  .settings(allSettings)
-  .settings(libraryDependencies += cats2)
-
-lazy val zio = (project in file("elastic4s-effect-zio"))
-  .dependsOn(core, testkit % "test")
-  .settings(name := "elastic4s-effect-zio")
-  .settings(allSettings)
-  .settings(libraryDependencies ++= Dependencies.zio)
-
-lazy val scalaz = (project in file("elastic4s-effect-scalaz"))
-  .dependsOn(core)
-  .settings(name := "elastic4s-effect-scalaz")
-  .settings(allSettings)
-  .settings(libraryDependencies ++= Dependencies.scalaz)
-
-lazy val monix = (project in file("elastic4s-effect-monix"))
-  .dependsOn(core)
-  .settings(name := "elastic4s-effect-monix")
-  .settings(allSettings)
-  .settings(libraryDependencies += Dependencies.monix)
+//lazy val cats_effect_2 = (project in file("elastic4s-effect-cats-2"))
+//  .dependsOn(core, testkit % "test")
+//  .settings(name := "elastic4s-effect-cats-2")
+//  .settings(allSettings)
+//  .settings(libraryDependencies += cats2)
+//
+//lazy val zio = (project in file("elastic4s-effect-zio"))
+//  .dependsOn(core, testkit % "test")
+//  .settings(name := "elastic4s-effect-zio")
+//  .settings(allSettings)
+//  .settings(libraryDependencies ++= Dependencies.zio)
+//
+//lazy val scalaz = (project in file("elastic4s-effect-scalaz"))
+//  .dependsOn(core)
+//  .settings(name := "elastic4s-effect-scalaz")
+//  .settings(allSettings)
+//  .settings(libraryDependencies ++= Dependencies.scalaz)
+//
+//lazy val monix = (project in file("elastic4s-effect-monix"))
+//  .dependsOn(core)
+//  .settings(name := "elastic4s-effect-monix")
+//  .settings(allSettings)
+//  .settings(libraryDependencies += Dependencies.monix)
 
 lazy val testkit = (project in file("elastic4s-testkit"))
   .dependsOn(core, clientesjava)
   .settings(name := "elastic4s-testkit")
   .settings(allSettings)
-  .settings(libraryDependencies ++= Seq(Dependencies.scalaTest, scalaTestPlusMokito))
+  .settings(libraryDependencies ++= Seq(Dependencies.scalaTestMain, scalaTestPlusMokito))
 
-lazy val httpstreams = (project in file("elastic4s-http-streams"))
-  .dependsOn(core, testkit % "test", jackson % "test")
-  .settings(name := "elastic4s-http-streams")
-  .settings(allSettings)
-  .settings(libraryDependencies ++=
-    Seq(
-      Dependencies.akkaActor,
-      Dependencies.akkaStream,
-      Dependencies.reactiveStreamsTck,
-      Dependencies.scalaTestPlusTestng67
-    )
-  )
-
-lazy val akkastreams = (project in file("elastic4s-streams-akka"))
-  .dependsOn(core, testkit % "test", jackson % "test")
-  .settings(name := "elastic4s-streams-akka")
-  .settings(allSettings)
-  .settings(libraryDependencies += Dependencies.akkaStream)
+//lazy val httpstreams = (project in file("elastic4s-http-streams"))
+//  .dependsOn(core, testkit % "test", jackson % "test")
+//  .settings(name := "elastic4s-http-streams")
+//  .settings(allSettings)
+//  .settings(libraryDependencies ++=
+//    Seq(
+//      Dependencies.akkaActor,
+//      Dependencies.akkaStream,
+//      Dependencies.reactiveStreamsTck,
+//      Dependencies.scalaTestPlusTestng67
+//    )
+//  )
+//
+//lazy val akkastreams = (project in file("elastic4s-streams-akka"))
+//  .dependsOn(core, testkit % "test", jackson % "test")
+//  .settings(name := "elastic4s-streams-akka")
+//  .settings(allSettings)
+//  .settings(libraryDependencies += Dependencies.akkaStream)
 
 lazy val jackson = (project in file("elastic4s-json-jackson"))
   .dependsOn(core)
@@ -259,41 +259,41 @@ lazy val circe = (project in file("elastic4s-json-circe"))
   .settings(allSettings)
   .settings(libraryDependencies ++= Dependencies.circe)
 
-lazy val json4s = (project in file("elastic4s-json-json4s"))
-  .dependsOn(core)
-  .settings(name := "elastic4s-json-json4s")
-  .settings(allSettings)
-  .settings(libraryDependencies ++= Dependencies.json4s)
-
-lazy val playjson = (project in file("elastic4s-json-play"))
-  .dependsOn(core)
-  .settings(name := "elastic4s-json-play")
-  .settings(allSettings)
-  .settings(libraryDependencies ++= Dependencies.playJson)
-
-lazy val sprayjson = (project in file("elastic4s-json-spray"))
-  .dependsOn(core)
-  .settings(name := "elastic4s-json-spray")
-  .settings(allSettings)
-  .settings(libraryDependencies ++= Dependencies.sprayJson)
-
-lazy val ziojson = (project in file("elastic4s-json-zio"))
-  .dependsOn(core)
-  .settings(name := "elastic4s-json-zio")
-  .settings(allSettings)
-  .settings(libraryDependencies += Dependencies.zioJson)
-
-lazy val clientsttp = (project in file("elastic4s-client-sttp"))
-  .dependsOn(core)
-  .settings(name := "elastic4s-client-sttp")
-  .settings(allSettings)
-  .settings(libraryDependencies ++= Seq(sttp, asyncHttpClientBackendFuture))
-
-lazy val clientakka = (project in file("elastic4s-client-akka"))
-  .dependsOn(core, testkit % "test")
-  .settings(name := "elastic4s-client-akka")
-  .settings(allSettings)
-  .settings(libraryDependencies ++= Seq(akkaHTTP, akkaStream, scalaMock))
+//lazy val json4s = (project in file("elastic4s-json-json4s"))
+//  .dependsOn(core)
+//  .settings(name := "elastic4s-json-json4s")
+//  .settings(allSettings)
+//  .settings(libraryDependencies ++= Dependencies.json4s)
+//
+//lazy val playjson = (project in file("elastic4s-json-play"))
+//  .dependsOn(core)
+//  .settings(name := "elastic4s-json-play")
+//  .settings(allSettings)
+//  .settings(libraryDependencies ++= Dependencies.playJson)
+//
+//lazy val sprayjson = (project in file("elastic4s-json-spray"))
+//  .dependsOn(core)
+//  .settings(name := "elastic4s-json-spray")
+//  .settings(allSettings)
+//  .settings(libraryDependencies ++= Dependencies.sprayJson)
+//
+//lazy val ziojson = (project in file("elastic4s-json-zio"))
+//  .dependsOn(core)
+//  .settings(name := "elastic4s-json-zio")
+//  .settings(allSettings)
+//  .settings(libraryDependencies += Dependencies.zioJson)
+//
+//lazy val clientsttp = (project in file("elastic4s-client-sttp"))
+//  .dependsOn(core)
+//  .settings(name := "elastic4s-client-sttp")
+//  .settings(allSettings)
+//  .settings(libraryDependencies ++= Seq(sttp, asyncHttpClientBackendFuture))
+//
+//lazy val clientakka = (project in file("elastic4s-client-akka"))
+//  .dependsOn(core, testkit % "test")
+//  .settings(name := "elastic4s-client-akka")
+//  .settings(allSettings)
+//  .settings(libraryDependencies ++= Seq(akkaHTTP, akkaStream, scalaMock))
 
 lazy val tests = (project in file("elastic4s-tests"))
   .settings(name := "elastic4s-tests")

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,8 @@ def githubRunNumber = sys.env.getOrElse("GITHUB_RUN_NUMBER", "local")
 def ossrhUsername = sys.env.getOrElse("OSSRH_USERNAME", "")
 def ossrhPassword = sys.env.getOrElse("OSSRH_PASSWORD", "")
 
-
+val scala2Versions = Seq("2.12.15", "2.13.6")
+val scalaAllVersions = scala2Versions :+ "3.0.1"
 lazy val commonScalaVersionSettings = Seq(
   scalaVersion := "2.12.15",
   crossScalaVersions := Seq("2.12.15", "2.13.6", "3.0.2")
@@ -107,6 +108,9 @@ lazy val allSettings = commonScalaVersionSettings ++
   warnUnusedImport ++
   publishSettings
 
+lazy val scala2Settings = allSettings :+ (crossScalaVersions := scala2Versions)
+lazy val scala3Settings = allSettings :+ (crossScalaVersions := scalaAllVersions)
+
 
 
 lazy val root = Project("elastic4s", file("."))
@@ -120,59 +124,59 @@ lazy val root = Project("elastic4s", file("."))
     core,
     clientcore,
     clientesjava,
-//    clientsSniffed,
+    clientsSniffed,
     cats_effect,
-//    cats_effect_2,
-//    zio,
-//    scalaz,
-//    monix,
+    cats_effect_2,
+    zio,
+    scalaz,
+    monix,
     tests,
     testkit,
     circe,
     jackson,
-//    json4s,
-//    playjson,
-//    sprayjson,
-//    ziojson,
-//    clientsttp,
-//    clientakka,
-//    httpstreams,
-//    akkastreams
+    json4s,
+    playjson,
+    sprayjson,
+    ziojson,
+    clientsttp,
+    clientakka,
+    httpstreams,
+    akkastreams
   )
 
 lazy val domain = (project in file("elastic4s-domain"))
   .settings(name := "elastic4s-domain")
   .dependsOn(json_builder)
-  .settings(allSettings)
+  .settings(scala3Settings)
   .settings(libraryDependencies ++= fasterXmlJacksonScala)
 
 lazy val json_builder = (project in file("elastic4s-json-builder"))
   .settings(name := "elastic4s-json-builder")
-  .settings(allSettings)
+  .settings(scala3Settings)
   .settings(libraryDependencies ++= fasterXmlJacksonScala)
 
 lazy val core = (project in file("elastic4s-core"))
   .settings(name := "elastic4s-core")
   .dependsOn(domain, clientcore, handlers, json_builder)
-  .settings(allSettings)
+  .settings(scala3Settings)
   .settings(libraryDependencies ++= fasterXmlJacksonScala)
 
 lazy val handlers = (project in file("elastic4s-handlers"))
   .settings(name := "elastic4s-handlers")
   .dependsOn(domain, json_builder)
-  .settings(allSettings)
+  .settings(scala3Settings)
   .settings(libraryDependencies ++= fasterXmlJacksonScala)
 
 lazy val clientcore = (project in file("elastic4s-client-core"))
   .settings(name := "elastic4s-client-core")
   .dependsOn(handlers)
-  .settings(allSettings)
+  .settings(scala3Settings)
   .settings(libraryDependencies ++= Seq(log4jApi))
 
 lazy val clientesjava = (project in file("elastic4s-client-esjava"))
   .settings(name := "elastic4s-client-esjava")
   .dependsOn(core)
-  .settings(allSettings)
+  .settings(scala3Settings)
   .settings(
     libraryDependencies ++= Seq(elasticsearchRestClient,
       log4jApi,
@@ -185,68 +189,68 @@ lazy val clientesjava = (project in file("elastic4s-client-esjava"))
 lazy val clientsSniffed = (project in file("elastic4s-client-sniffed"))
   .settings(name := "elastic4s-client-sniffed")
   .dependsOn(clientesjava)
-  .settings(allSettings)
+  .settings(scala3Settings)
   .settings(libraryDependencies ++= Seq(elasticsearchRestClientSniffer))
 
 lazy val cats_effect = (project in file("elastic4s-effect-cats"))
   .dependsOn(core, testkit % "test")
   .settings(name := "elastic4s-effect-cats")
-  .settings(allSettings)
+  .settings(scala3Settings)
   .settings(libraryDependencies += cats)
 
-//lazy val cats_effect_2 = (project in file("elastic4s-effect-cats-2"))
-//  .dependsOn(core, testkit % "test")
-//  .settings(name := "elastic4s-effect-cats-2")
-//  .settings(allSettings)
-//  .settings(libraryDependencies += cats2)
-//
-//lazy val zio = (project in file("elastic4s-effect-zio"))
-//  .dependsOn(core, testkit % "test")
-//  .settings(name := "elastic4s-effect-zio")
-//  .settings(allSettings)
-//  .settings(libraryDependencies ++= Dependencies.zio)
-//
-//lazy val scalaz = (project in file("elastic4s-effect-scalaz"))
-//  .dependsOn(core)
-//  .settings(name := "elastic4s-effect-scalaz")
-//  .settings(allSettings)
-//  .settings(libraryDependencies ++= Dependencies.scalaz)
-//
-//lazy val monix = (project in file("elastic4s-effect-monix"))
-//  .dependsOn(core)
-//  .settings(name := "elastic4s-effect-monix")
-//  .settings(allSettings)
-//  .settings(libraryDependencies += Dependencies.monix)
+lazy val cats_effect_2 = (project in file("elastic4s-effect-cats-2"))
+  .dependsOn(core, testkit % "test")
+  .settings(name := "elastic4s-effect-cats-2")
+  .settings(scala3Settings)
+  .settings(libraryDependencies += cats2)
+
+lazy val zio = (project in file("elastic4s-effect-zio"))
+  .dependsOn(core, testkit % "test")
+  .settings(name := "elastic4s-effect-zio")
+  .settings(scala2Settings)
+  .settings(libraryDependencies ++= Dependencies.zio)
+
+lazy val scalaz = (project in file("elastic4s-effect-scalaz"))
+  .dependsOn(core)
+  .settings(name := "elastic4s-effect-scalaz")
+  .settings(scala2Settings)
+  .settings(libraryDependencies ++= Dependencies.scalaz)
+
+lazy val monix = (project in file("elastic4s-effect-monix"))
+  .dependsOn(core)
+  .settings(name := "elastic4s-effect-monix")
+  .settings(scala2Settings)
+  .settings(libraryDependencies += Dependencies.monix)
 
 lazy val testkit = (project in file("elastic4s-testkit"))
   .dependsOn(core, clientesjava)
   .settings(name := "elastic4s-testkit")
-  .settings(allSettings)
+  .settings(scala3Settings)
   .settings(libraryDependencies ++= Seq(Dependencies.scalaTestMain, scalaTestPlusMokito))
 
-//lazy val httpstreams = (project in file("elastic4s-http-streams"))
-//  .dependsOn(core, testkit % "test", jackson % "test")
-//  .settings(name := "elastic4s-http-streams")
-//  .settings(allSettings)
-//  .settings(libraryDependencies ++=
-//    Seq(
-//      Dependencies.akkaActor,
-//      Dependencies.akkaStream,
-//      Dependencies.reactiveStreamsTck,
-//      Dependencies.scalaTestPlusTestng67
-//    )
-//  )
-//
-//lazy val akkastreams = (project in file("elastic4s-streams-akka"))
-//  .dependsOn(core, testkit % "test", jackson % "test")
-//  .settings(name := "elastic4s-streams-akka")
-//  .settings(allSettings)
-//  .settings(libraryDependencies += Dependencies.akkaStream)
+lazy val httpstreams = (project in file("elastic4s-http-streams"))
+  .dependsOn(core, testkit % "test", jackson % "test")
+  .settings(name := "elastic4s-http-streams")
+  .settings(scala2Settings)
+  .settings(libraryDependencies ++=
+    Seq(
+      Dependencies.akkaActor,
+      Dependencies.akkaStream,
+      Dependencies.reactiveStreamsTck,
+      Dependencies.scalaTestPlusTestng67
+    )
+  )
+
+lazy val akkastreams = (project in file("elastic4s-streams-akka"))
+  .dependsOn(core, testkit % "test", jackson % "test")
+  .settings(name := "elastic4s-streams-akka")
+  .settings(scala2Settings)
+  .settings(libraryDependencies += Dependencies.akkaStream)
 
 lazy val jackson = (project in file("elastic4s-json-jackson"))
   .dependsOn(core)
   .settings(name := "elastic4s-json-jackson")
-  .settings(allSettings)
+  .settings(scala3Settings)
   .settings(
     libraryDependencies += "com.fasterxml.jackson.core" % "jackson-core" % JacksonVersion,
     libraryDependencies += "com.fasterxml.jackson.core" % "jackson-databind" % JacksonVersion,
@@ -256,49 +260,49 @@ lazy val jackson = (project in file("elastic4s-json-jackson"))
 lazy val circe = (project in file("elastic4s-json-circe"))
   .dependsOn(core)
   .settings(name := "elastic4s-json-circe")
-  .settings(allSettings)
+  .settings(scala2Settings)
   .settings(libraryDependencies ++= Dependencies.circe)
 
-//lazy val json4s = (project in file("elastic4s-json-json4s"))
-//  .dependsOn(core)
-//  .settings(name := "elastic4s-json-json4s")
-//  .settings(allSettings)
-//  .settings(libraryDependencies ++= Dependencies.json4s)
-//
-//lazy val playjson = (project in file("elastic4s-json-play"))
-//  .dependsOn(core)
-//  .settings(name := "elastic4s-json-play")
-//  .settings(allSettings)
-//  .settings(libraryDependencies ++= Dependencies.playJson)
-//
-//lazy val sprayjson = (project in file("elastic4s-json-spray"))
-//  .dependsOn(core)
-//  .settings(name := "elastic4s-json-spray")
-//  .settings(allSettings)
-//  .settings(libraryDependencies ++= Dependencies.sprayJson)
-//
-//lazy val ziojson = (project in file("elastic4s-json-zio"))
-//  .dependsOn(core)
-//  .settings(name := "elastic4s-json-zio")
-//  .settings(allSettings)
-//  .settings(libraryDependencies += Dependencies.zioJson)
-//
-//lazy val clientsttp = (project in file("elastic4s-client-sttp"))
-//  .dependsOn(core)
-//  .settings(name := "elastic4s-client-sttp")
-//  .settings(allSettings)
-//  .settings(libraryDependencies ++= Seq(sttp, asyncHttpClientBackendFuture))
-//
-//lazy val clientakka = (project in file("elastic4s-client-akka"))
-//  .dependsOn(core, testkit % "test")
-//  .settings(name := "elastic4s-client-akka")
-//  .settings(allSettings)
-//  .settings(libraryDependencies ++= Seq(akkaHTTP, akkaStream, scalaMock))
+lazy val json4s = (project in file("elastic4s-json-json4s"))
+  .dependsOn(core)
+  .settings(name := "elastic4s-json-json4s")
+  .settings(scala3Settings)
+  .settings(libraryDependencies ++= Dependencies.json4s)
+
+lazy val playjson = (project in file("elastic4s-json-play"))
+  .dependsOn(core)
+  .settings(name := "elastic4s-json-play")
+  .settings(scala2Settings)
+  .settings(libraryDependencies ++= Dependencies.playJson)
+
+lazy val sprayjson = (project in file("elastic4s-json-spray"))
+  .dependsOn(core)
+  .settings(name := "elastic4s-json-spray")
+  .settings(scala2Settings)
+  .settings(libraryDependencies ++= Dependencies.sprayJson)
+
+lazy val ziojson = (project in file("elastic4s-json-zio"))
+  .dependsOn(core)
+  .settings(name := "elastic4s-json-zio")
+  .settings(scala2Settings)
+  .settings(libraryDependencies += Dependencies.zioJson)
+
+lazy val clientsttp = (project in file("elastic4s-client-sttp"))
+  .dependsOn(core)
+  .settings(name := "elastic4s-client-sttp")
+  .settings(scala2Settings)
+  .settings(libraryDependencies ++= Seq(sttp, asyncHttpClientBackendFuture))
+
+lazy val clientakka = (project in file("elastic4s-client-akka"))
+  .dependsOn(core, testkit % "test")
+  .settings(name := "elastic4s-client-akka")
+  .settings(scala2Settings)
+  .settings(libraryDependencies ++= Seq(akkaHTTP, akkaStream, scalaMock))
 
 lazy val tests = (project in file("elastic4s-tests"))
   .settings(name := "elastic4s-tests")
   .dependsOn(core, jackson, testkit % "test")
-  .settings(allSettings)
+  .settings(scala3Settings)
   .settings(noPublishSettings)
   .settings(
     libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -219,7 +219,7 @@ lazy val scalaz = (project in file("elastic4s-effect-scalaz"))
 lazy val monix = (project in file("elastic4s-effect-monix"))
   .dependsOn(core)
   .settings(name := "elastic4s-effect-monix")
-  .settings(scala2Settings)
+  .settings(scala3Settings)
   .settings(libraryDependencies += Dependencies.monix)
 
 lazy val testkit = (project in file("elastic4s-testkit"))

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticClient.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticClient.scala
@@ -1,5 +1,6 @@
 package com.sksamuel.elastic4s
 
+import com.fasterxml.jackson.module.scala.JavaTypeable
 import com.sksamuel.exts.Logging
 
 import scala.concurrent.duration.{Duration, _}
@@ -30,7 +31,7 @@ case class ElasticClient(client: HttpClient) extends Logging {
                                 executor: Executor[F],
                                 functor: Functor[F],
                                 handler: Handler[T, U],
-                                manifest: Manifest[U],
+                                javaTypeable: JavaTypeable[U],
                                 options: CommonRequestOptions): F[Response[U]] = {
     val request = handler.build(t)
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticProperties.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticProperties.scala
@@ -25,7 +25,7 @@ object ElasticProperties {
         val options = StringOption(query)
           .map(_.drop(1))
           .map(_.split('&'))
-          .getOrElse(Array.empty)
+          .getOrElse(Array.empty[String])
           .map(_.split('='))
           .collect {
             case Array(key, value) => (key, value)

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticsearchClientUri.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticsearchClientUri.scala
@@ -29,7 +29,7 @@ object ElasticsearchClientUri {
         val options = StringOption(query)
           .map(_.drop(1))
           .map(_.split('&'))
-          .getOrElse(Array.empty)
+          .getOrElse(Array.empty[String])
           .map(_.split('='))
           .collect {
             case Array(key, value) => (key, value)

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/SearchBodyBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/SearchBodyBuilderFn.scala
@@ -24,9 +24,9 @@ object SearchBodyBuilderFn {
     request.version.map(_.toString).foreach(builder.field("version", _))
     request.seqNoPrimaryTerm.map(_.toString).foreach(builder.field("seq_no_primary_term", _))
 
-    request.query.map(QueryBuilderFn.apply).foreach(x => builder.rawField("query", x.string))
-    request.postFilter.map(QueryBuilderFn.apply).foreach(x => builder.rawField("post_filter", x.string))
-    request.collapse.map(CollapseBuilderFn.apply).foreach(x => builder.rawField("collapse", x.string))
+    request.query.map(QueryBuilderFn.apply).foreach(x => builder.rawField("query", x.string()))
+    request.postFilter.map(QueryBuilderFn.apply).foreach(x => builder.rawField("post_filter", x.string()))
+    request.collapse.map(CollapseBuilderFn.apply).foreach(x => builder.rawField("collapse", x.string()))
 
     request.from.foreach(builder.field("from", _))
     request.size.foreach(builder.field("size", _))
@@ -75,7 +75,7 @@ object SearchBodyBuilderFn {
     if (request.sorts.nonEmpty) {
       builder.startArray("sort")
       // Workaround for bug where separator is not added with rawValues
-      val arrayBody = request.sorts.map(s => SortBuilderFn(s).string).mkString(",")
+      val arrayBody = request.sorts.map(s => SortBuilderFn(s).string()).mkString(",")
       builder.rawValue(arrayBody)
       builder.endArray()
     }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/DateRangeAggregationBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/DateRangeAggregationBuilder.scala
@@ -9,7 +9,7 @@ object DateRangeAggregationBuilder {
 
   def apply(agg: DateRangeAggregation): XContentBuilder = {
 
-    val builder = XContentFactory.obj.startObject("date_range")
+    val builder = XContentFactory.obj().startObject("date_range")
 
     agg.field.foreach(builder.field("field", _))
     agg.missing.foreach(builder.autofield("missing", _))

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/FiltersAggregationBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/FiltersAggregationBuilder.scala
@@ -11,7 +11,7 @@ object FiltersAggregationBuilder {
 
     val filters = {
       builder.startArray("filters")
-      val filters = agg.filters.map(QueryBuilderFn.apply).map(_.string).mkString(",")
+      val filters = agg.filters.map(QueryBuilderFn.apply).map(_.string()).mkString(",")
       builder.rawValue(filters)
       builder.endArray()
     }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/GeoBoundsAggregationBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/GeoBoundsAggregationBuilder.scala
@@ -8,7 +8,7 @@ import com.sksamuel.elastic4s.requests.searches.aggs.{AggMetaDataFn, GeoBoundsAg
 object GeoBoundsAggregationBuilder {
   def apply(agg: GeoBoundsAggregation): XContentBuilder = {
 
-    val builder = XContentFactory.obj.startObject("geo_bounds")
+    val builder = XContentFactory.obj().startObject("geo_bounds")
 
     agg.field.foreach(builder.field("field", _))
     agg.format.foreach(builder.field("format", _))

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/GeoCentroidAggregationBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/GeoCentroidAggregationBuilder.scala
@@ -8,7 +8,7 @@ import com.sksamuel.elastic4s.requests.searches.aggs.{AggMetaDataFn, GeoCentroid
 object GeoCentroidAggregationBuilder {
   def apply(agg: GeoCentroidAggregation): XContentBuilder = {
 
-    val builder = XContentFactory.obj.startObject("geo_centroid")
+    val builder = XContentFactory.obj().startObject("geo_centroid")
 
     agg.field.foreach(builder.field("field", _))
     agg.format.foreach(builder.field("format", _))

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/GeoHashGridAggregationBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/GeoHashGridAggregationBuilder.scala
@@ -6,7 +6,7 @@ import com.sksamuel.elastic4s.requests.searches.aggs.{AggMetaDataFn, GeoHashGrid
 object GeoHashGridAggregationBuilder {
   def apply(agg: GeoHashGridAggregation): XContentBuilder = {
 
-    val builder = XContentFactory.obj.startObject("geohash_grid")
+    val builder = XContentFactory.obj().startObject("geohash_grid")
 
     agg.field.foreach(builder.field("field", _))
     agg.precision.foreach(builder.field("precision", _))

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/GeoTileGridAggregationBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/GeoTileGridAggregationBuilder.scala
@@ -6,7 +6,7 @@ import com.sksamuel.elastic4s.requests.searches.aggs.{AggMetaDataFn, GeoTileGrid
 object GeoTileGridAggregationBuilder {
   def apply(agg: GeoTileGridAggregation): XContentBuilder = {
 
-    val builder = XContentFactory.obj.startObject("geotile_grid")
+    val builder = XContentFactory.obj().startObject("geotile_grid")
 
     agg.field.foreach(builder.field("field", _))
     agg.precision.foreach(builder.field("precision", _))

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/GlobalAggregationBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/GlobalAggregationBuilder.scala
@@ -6,7 +6,7 @@ import com.sksamuel.elastic4s.requests.searches.aggs.{AggMetaDataFn, GlobalAggre
 object GlobalAggregationBuilder {
   def apply(agg: GlobalAggregation): XContentBuilder = {
 
-    val builder = XContentFactory.obj.startObject("global")
+    val builder = XContentFactory.obj().startObject("global")
 
     builder.endObject()
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/RangeAggregationBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/RangeAggregationBuilder.scala
@@ -8,7 +8,7 @@ import com.sksamuel.elastic4s.requests.searches.aggs.{AggMetaDataFn, RangeAggreg
 object RangeAggregationBuilder {
   def apply(agg: RangeAggregation): XContentBuilder = {
 
-    val builder = XContentFactory.obj.startObject("range")
+    val builder = XContentFactory.obj().startObject("range")
 
     agg.field.foreach(builder.field("field", _))
     agg.missing.foreach(builder.autofield("missing", _))

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/JsonSugar.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/JsonSugar.scala
@@ -1,14 +1,13 @@
 package com.sksamuel.elastic4s
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import com.fasterxml.jackson.module.scala.{ClassTagExtensions, DefaultScalaModule}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.matchers.{MatchResult, Matcher}
 
 trait JsonSugar extends Matchers {
 
-  private val mapper = new ObjectMapper with ScalaObjectMapper
+  private val mapper = new ObjectMapper with ClassTagExtensions
   mapper.registerModule(DefaultScalaModule)
 
   def matchJsonResource(resourceName: String) = new JsonResourceMatcher(resourceName)

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/ScriptBuilderFnTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/ScriptBuilderFnTest.scala
@@ -9,32 +9,32 @@ import org.scalatest.matchers.should.Matchers
 class ScriptBuilderFnTest extends AnyFunSuite with Matchers {
 
   test("should handle recursive maps") {
-    ScriptBuilderFn(Script("myscript", params = Map("a" -> 1.2, "b" -> Map("c" -> true, "d" -> List(Map("e" -> 3)))))).string shouldBe
+    ScriptBuilderFn(Script("myscript", params = Map("a" -> 1.2, "b" -> Map("c" -> true, "d" -> List(Map("e" -> 3)))))).string() shouldBe
       """{"source":"myscript","params":{"a":1.2,"b":{"c":true,"d":[{"e":3}]}}}"""
   }
 
   test("should handle lists of maps") {
-    script.ScriptBuilderFn(Script("myscript", params = Map("a" -> 1.2, "b" -> Map("c" -> true, "d" -> List(Map("e" -> 3)))))).string shouldBe
+    script.ScriptBuilderFn(Script("myscript", params = Map("a" -> 1.2, "b" -> Map("c" -> true, "d" -> List(Map("e" -> 3)))))).string() shouldBe
       """{"source":"myscript","params":{"a":1.2,"b":{"c":true,"d":[{"e":3}]}}}"""
   }
 
   test("should handle recursive lists") {
-    script.ScriptBuilderFn(Script("myscript", params = Map("a" -> List(List(List("foo")))))).string shouldBe
+    script.ScriptBuilderFn(Script("myscript", params = Map("a" -> List(List(List("foo")))))).string() shouldBe
       """{"source":"myscript","params":{"a":[[["foo"]]]}}"""
   }
 
   test("should handle maps of lists") {
-    script.ScriptBuilderFn(Script("myscript", params = Map("a" -> List(3, 2, 1)))).string shouldBe
+    script.ScriptBuilderFn(Script("myscript", params = Map("a" -> List(3, 2, 1)))).string() shouldBe
       """{"source":"myscript","params":{"a":[3,2,1]}}"""
   }
 
   test("should handle mixed lists") {
-    script.ScriptBuilderFn(Script("myscript", params = Map("a" -> List(List(true, 1.2, List("foo"), Map("w" -> "wibble")))))).string shouldBe
+    script.ScriptBuilderFn(Script("myscript", params = Map("a" -> List(List(true, 1.2, List("foo"), Map("w" -> "wibble")))))).string() shouldBe
       """{"source":"myscript","params":{"a":[[true,1.2,["foo"],{"w":"wibble"}]]}}"""
   }
 
   test("should handle stored scripts") {
-    script.ScriptBuilderFn(Script("convert_currency", scriptType = ScriptType.Stored, params = Map("field" -> "price", "conversion_rate" -> 0.835526591))).string shouldBe
+    script.ScriptBuilderFn(Script("convert_currency", scriptType = ScriptType.Stored, params = Map("field" -> "price", "conversion_rate" -> 0.835526591))).string() shouldBe
       """{"id":"convert_currency","params":{"field":"price","conversion_rate":0.835526591}}"""
   }
 
@@ -50,7 +50,7 @@ class ScriptBuilderFnTest extends AnyFunSuite with Matchers {
         .params("testParam" -> 100)
         .paramsRaw("testRawParam" -> """{"abc":"def"}""")
         .paramsObject("testObjectParam" -> TestParam(4.5d))
-    ).string shouldBe
+    ).string() shouldBe
       """{"source":"mix_script","params":{"testParam":100,"testRawParam":{"abc":"def"},"testObjectParam":{"x":4.5}}}"""
   }
 }

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/index/CreateIndexContentBuilderTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/index/CreateIndexContentBuilderTest.scala
@@ -11,7 +11,7 @@ class CreateIndexContentBuilderTest extends AnyFunSuite with Matchers {
 
   test("create index should include aliases when set") {
     val create = CreateIndexRequest("myindex", aliases = Set(IndexAliasRequest("alias1", None), IndexAliasRequest("alias2", Option(PrefixQuery("myfield", "pre")))))
-    CreateIndexContentBuilder(create).string shouldBe
+    CreateIndexContentBuilder(create).string() shouldBe
       """{"aliases":{"alias1":{},"alias2":{"filter":{"prefix":{"myfield":{"value":"pre"}}}}}}"""
   }
 
@@ -36,6 +36,6 @@ class CreateIndexContentBuilderTest extends AnyFunSuite with Matchers {
     )
 
     val create = CreateIndexRequest("myindex").analysis(analysis)
-    CreateIndexContentBuilder(create).string shouldBe """{"settings":{"analysis":{"normalizer":{"my_normalizer":{"type":"custom","filter":["my_unique_filter","my_truncate_filter"],"char_filter":["my_pattern_replace"]}},"char_filter":{"my_pattern_replace":{"type":"pattern_replace","pattern":"qwe","replacement":"ert"}},"filter":{"my_truncate_filter":{"type":"truncate","length":123},"my_unique_filter":{"type":"unique","only_on_same_position":true}}}}}"""
+    CreateIndexContentBuilder(create).string() shouldBe """{"settings":{"analysis":{"normalizer":{"my_normalizer":{"type":"custom","filter":["my_unique_filter","my_truncate_filter"],"char_filter":["my_pattern_replace"]}},"char_filter":{"my_pattern_replace":{"type":"pattern_replace","pattern":"qwe","replacement":"ert"}},"filter":{"my_truncate_filter":{"type":"truncate","length":123},"my_unique_filter":{"type":"unique","only_on_same_position":true}}}}}"""
   }
 }

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/collapse/CollapseBuilderFnTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/collapse/CollapseBuilderFnTest.scala
@@ -9,14 +9,14 @@ class CollapseBuilderFnTest extends AnyFunSuite with Matchers {
 
   test("collapse builder should generate simple collapse json") {
     val c = CollapseRequest("something")
-    CollapseBuilderFn.apply(c).string shouldBe """{"field":"something"}"""
+    CollapseBuilderFn.apply(c).string() shouldBe """{"field":"something"}"""
   }
 
   test("collapse builder should support inner hits and max searches") {
     val c = CollapseRequest("something")
       .inner(InnerHit("name").size(1))
       .maxConcurrentGroupSearches(8)
-    CollapseBuilderFn.apply(c).string shouldBe
+    CollapseBuilderFn.apply(c).string() shouldBe
       """{"field":"something","max_concurrent_group_searches":8,"inner_hits":{"name":"name","size":1}}"""
   }
 }

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/queries/InnerHitQueryBodyFnTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/queries/InnerHitQueryBodyFnTest.scala
@@ -21,7 +21,7 @@ class InnerHitQueryBodyFnTest extends AnyFunSuite with Matchers {
       .storedFieldNames(List("field1", "field2"))
       .highlighting(HighlightField("hlField"))
 
-    new XContentBuilder(InnerHitQueryBodyBuilder.toJson(q)).string shouldBe
+    new XContentBuilder(InnerHitQueryBodyBuilder.toJson(q)).string() shouldBe
       """{"name":"inners","from":2,"explain":false,"track_scores":true,"version":true,"size":2,"docvalue_fields":["df1","df2"],"sort":[{"sortField":{"order":"asc"}}],"stored_fields":["field1","field2"],"highlight":{"fields":{"hlField":{}}}}"""
   }
 }

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/queries/SearchBodyBuilderFnTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/queries/SearchBodyBuilderFnTest.scala
@@ -50,7 +50,7 @@ class SearchBodyBuilderFnTest extends AnyFunSuite with Matchers {
       unit = Some(DistanceUnit.KILOMETERS)
     )
 
-    SearchBodyBuilderFn(req).string shouldBe
+    SearchBodyBuilderFn(req).string() shouldBe
       """{"query":{"geo_distance":{"distance":"100km","location":[-79.38871,43.65435]}},"size":100,"sort":[{"_geo_distance":{"location":[[-79.38871,43.65435]],"order":"asc","unit":"km"}}]}"""
   }
 }

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/security/roles/CreateOrUpdateRoleContentBuilderTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/security/roles/CreateOrUpdateRoleContentBuilderTest.scala
@@ -46,7 +46,7 @@ class CreateOrUpdateRoleContentBuilderTest extends AnyFunSuite with Matchers {
 		}
 		""".filterNot(c => c.isWhitespace)
 
-		val result = CreateOrUpdateRoleContentBuilder(create).string
+		val result = CreateOrUpdateRoleContentBuilder(create).string()
 		result shouldBe expected
 	}
 }

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/security/users/CreateOrUpdateUserContentBuilderTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/security/users/CreateOrUpdateUserContentBuilderTest.scala
@@ -24,7 +24,7 @@ class CreateOrUpdateUserContentBuilderTest extends AnyFunSuite with Matchers {
 		}
 		""".replace("\n", "").replace("\t", "")
 		val formattedJson = spaceBetweenPunctuation.replaceAllIn(expectedJson, "$1$2")
-		val result = CreateOrUpdateUserContentBuilder(create).string
+		val result = CreateOrUpdateUserContentBuilder(create).string()
 		result shouldBe formattedJson
 	}
 
@@ -44,7 +44,7 @@ class CreateOrUpdateUserContentBuilderTest extends AnyFunSuite with Matchers {
 		}
 		""".replace("\n", "").replace("\t", "")
 		val formattedJson = spaceBetweenPunctuation.replaceAllIn(expectedJson, "$1$2")
-		val result = users.CreateOrUpdateUserContentBuilder(create).string
+		val result = users.CreateOrUpdateUserContentBuilder(create).string()
 		result shouldBe formattedJson
 	}
 
@@ -70,7 +70,7 @@ class CreateOrUpdateUserContentBuilderTest extends AnyFunSuite with Matchers {
 		}
 		""".replace("\n", "").replace("\t", "")
 		val formattedJson = spaceBetweenPunctuation.replaceAllIn(expectedJson, "$1$2")
-		val result = users.CreateOrUpdateUserContentBuilder(create).string
+		val result = users.CreateOrUpdateUserContentBuilder(create).string()
 		result shouldBe formattedJson
 	}
 
@@ -91,7 +91,7 @@ class CreateOrUpdateUserContentBuilderTest extends AnyFunSuite with Matchers {
 		}
 		""".replace("\n", "").replace("\t", "")
 		val formattedJson = spaceBetweenPunctuation.replaceAllIn(expectedJson, "$1$2")
-		val result = users.CreateOrUpdateUserContentBuilder(create).string
+		val result = users.CreateOrUpdateUserContentBuilder(create).string()
 		result shouldBe formattedJson
 	}
 
@@ -102,6 +102,6 @@ class CreateOrUpdateUserContentBuilderTest extends AnyFunSuite with Matchers {
 			password=None,
 			roles=Seq("test-role")
 		)
-		a [IllegalArgumentException] should be thrownBy users.CreateOrUpdateUserContentBuilder(create).string
+		a [IllegalArgumentException] should be thrownBy users.CreateOrUpdateUserContentBuilder(create).string()
 	}
 }

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/testutils/StringExtensionsTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/testutils/StringExtensionsTest.scala
@@ -2,9 +2,9 @@ package com.sksamuel.elastic4s.testutils
 
 import com.sksamuel.elastic4s.testutils.StringExtensions.StringOps
 import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers.convertToStringShouldWrapper
+import org.scalatest.matchers.should.Matchers
 
-class StringExtensionsTest extends AnyFlatSpec {
+class StringExtensionsTest extends AnyFlatSpec with Matchers {
 
   it should "convert line endings to Windows style" in {
     "one\r\ntwo\nthree\n".withWindowsLineEndings shouldBe "one\r\ntwo\r\nthree\r\n"

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/analyzers/AnalyzerDefinition.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/analyzers/AnalyzerDefinition.scala
@@ -26,7 +26,7 @@ abstract class AnalyzerDefinition(val name: String) {
   def build(source: XContentBuilder): Unit
 
   def json: XContentBuilder = {
-    val builder = XContentFactory.jsonBuilder
+    val builder = XContentFactory.jsonBuilder()
     build(builder)
     builder.endObject()
   }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/analyzers/NormalizerDefinition.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/analyzers/NormalizerDefinition.scala
@@ -26,7 +26,7 @@ abstract class NormalizerDefinition(val name: String) {
   def build(source: XContentBuilder): Unit
 
   def json: XContentBuilder = {
-    val builder = XContentFactory.jsonBuilder
+    val builder = XContentFactory.jsonBuilder()
     build(builder)
     builder.endObject()
   }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/analyzers/Tokenizer.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/analyzers/Tokenizer.scala
@@ -8,7 +8,7 @@ abstract class Tokenizer(val name: String) {
   def build(source: XContentBuilder): Unit = {}
 
   def json: XContentBuilder = {
-    val builder = XContentFactory.jsonBuilder
+    val builder = XContentFactory.jsonBuilder()
     build(builder)
     builder.endObject()
   }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/analyzers/analyzerFilters.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/analyzers/analyzerFilters.scala
@@ -18,7 +18,7 @@ trait AnalyzerFilterDefinition {
   def filterType: String
   protected[elastic4s] def build(source: XContentBuilder): Unit
   def json: XContentBuilder = {
-    val builder = XContentFactory.jsonBuilder
+    val builder = XContentFactory.jsonBuilder()
     builder.field("type", filterType)
     build(builder)
     builder.endObject()

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/responses/JacksonSupport.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/responses/JacksonSupport.scala
@@ -3,11 +3,11 @@ package com.sksamuel.elastic4s.requests.searches.aggs.responses
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
-import com.fasterxml.jackson.module.scala.{DefaultScalaModule, ScalaObjectMapper}
+import com.fasterxml.jackson.module.scala.{ClassTagExtensions, DefaultScalaModule}
 
 object JacksonSupport {
 
-  val mapper: ObjectMapper with ScalaObjectMapper = new ObjectMapper with ScalaObjectMapper
+  val mapper: ObjectMapper with ClassTagExtensions = new ObjectMapper with ClassTagExtensions
   mapper.registerModule(DefaultScalaModule)
 
   mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)

--- a/elastic4s-effect-zio/src/test/scala/com/sksamuel/elastic4s/zio/ZIOTaskTest.scala
+++ b/elastic4s-effect-zio/src/test/scala/com/sksamuel/elastic4s/zio/ZIOTaskTest.scala
@@ -15,13 +15,13 @@ class ZIOTaskTest extends AnyFlatSpec with Matchers with DockerTests with Before
     }
   }
 
-  override def beforeAll: Unit = {
+  override def beforeAll(): Unit = {
     client.execute {
       deleteIndex("testindex")
     }.unsafeRun
   }
 
-  override def afterAll: Unit = {
+  override def afterAll(): Unit = {
     client.execute {
       deleteIndex("testindex")
     }.unsafeRun
@@ -31,7 +31,7 @@ class ZIOTaskTest extends AnyFlatSpec with Matchers with DockerTests with Before
     val r = client.execute {
       indexInto("testindex").doc("""{ "text":"Buna ziua!" }""")
     }.unsafeRun
-    r shouldBe 'right
+    r shouldBe Symbol("right")
     r.right.get.result.result shouldBe "created"
   }
 

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/Handler.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/Handler.scala
@@ -1,5 +1,6 @@
 package com.sksamuel.elastic4s
 
+import com.fasterxml.jackson.module.scala.JavaTypeable
 import com.sksamuel.exts.Logging
 
 /**
@@ -11,7 +12,7 @@ import com.sksamuel.exts.Logging
   * @tparam T the type of the request object handled by this handler
   * @tparam U the type of the response object returned by this handler
   */
-abstract class Handler[T, U: Manifest] extends Logging {
+abstract class Handler[T, U: JavaTypeable] extends Logging {
 
   protected val TaskRegex = """\{"task":"(.*):(.*)"\}""".r
 

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/ResponseHandler.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/ResponseHandler.scala
@@ -1,6 +1,8 @@
 package com.sksamuel.elastic4s
 
 import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.`type`.TypeFactory
+import com.fasterxml.jackson.module.scala.JavaTypeable
 import com.sksamuel.elastic4s.handlers.ElasticErrorParser
 import com.sksamuel.exts.Logging
 import com.sksamuel.exts.OptionImplicits.RichOption
@@ -28,26 +30,26 @@ object ResponseHandler extends Logging {
 
   def json(entity: HttpEntity.StringEntity): JsonNode = fromEntity[JsonNode](entity)
 
-  def fromNode[U: Manifest](node: JsonNode): U = {
-    logger.debug(s"Attempting to unmarshall json node to ${manifest.runtimeClass.getName}")
+  def fromNode[U: JavaTypeable](node: JsonNode): U = {
+    logger.debug(s"Attempting to unmarshall json node to ${implicitly[JavaTypeable[U]].asJavaType(TypeFactory.defaultInstance).getRawClass.getName}")
     JacksonSupport.mapper.readValue[U](JacksonSupport.mapper.writeValueAsBytes(node))
   }
 
-  def fromResponse[U: Manifest](response: HttpResponse): U =
+  def fromResponse[U: JavaTypeable](response: HttpResponse): U =
     fromEntity(response.entity.getOrError("No entity defined but was expected"))
 
-  def fromEntity[U: Manifest](entity: HttpEntity.StringEntity): U = {
-    logger.debug(s"Attempting to unmarshall response to ${manifest.runtimeClass.getName}")
+  def fromEntity[U: JavaTypeable](entity: HttpEntity.StringEntity): U = {
+    logger.debug(s"Attempting to unmarshall response to ${implicitly[JavaTypeable[U]].asJavaType(TypeFactory.defaultInstance).getRawClass.getName}")
     logger.debug(entity.content)
     JacksonSupport.mapper.readValue[U](entity.content)
   }
 
-  def default[U: Manifest] = new DefaultResponseHandler[U]
-  def failure404[U: Manifest] = new NotFound404ResponseHandler[U]
+  def default[U: JavaTypeable] = new DefaultResponseHandler[U]
+  def failure404[U: JavaTypeable] = new NotFound404ResponseHandler[U]
 }
 
 // standard response handler, 200-204s are ok, and everything else is marhalled into an error
-class DefaultResponseHandler[U: Manifest] extends ResponseHandler[U] {
+class DefaultResponseHandler[U: JavaTypeable] extends ResponseHandler[U] {
   self =>
 
   override def handle(response: HttpResponse): Either[ElasticError, U] = response.statusCode match {
@@ -59,7 +61,7 @@ class DefaultResponseHandler[U: Manifest] extends ResponseHandler[U] {
   }
 }
 
-class NotFound404ResponseHandler[U: Manifest] extends DefaultResponseHandler[U] {
+class NotFound404ResponseHandler[U: JavaTypeable] extends DefaultResponseHandler[U] {
   override def handle(response: HttpResponse): Either[ElasticError, U] =
     response.statusCode match {
       case 404 | 500 => sys.error(response.toString)

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/JacksonSupport.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/JacksonSupport.scala
@@ -3,12 +3,11 @@ package com.sksamuel.elastic4s.handlers
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import com.fasterxml.jackson.module.scala.ScalaObjectMapper
+import com.fasterxml.jackson.module.scala.{ClassTagExtensions, DefaultScalaModule}
 
 object JacksonSupport {
 
-  val mapper: ObjectMapper with ScalaObjectMapper = new ObjectMapper with ScalaObjectMapper
+  val mapper: ObjectMapper with ClassTagExtensions = new ObjectMapper with ClassTagExtensions
   mapper.registerModule(DefaultScalaModule)
 
   mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/bulk/BulkBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/bulk/BulkBuilderFn.scala
@@ -32,7 +32,7 @@ object BulkBuilderFn {
         builder.endObject()
         builder.endObject()
 
-        rows += builder.string
+        rows += builder.string()
         rows += IndexContentBuilder(index)
 
       case delete: DeleteByIdRequest =>
@@ -49,7 +49,7 @@ object BulkBuilderFn {
         builder.endObject()
         builder.endObject()
 
-        rows += builder.string
+        rows += builder.string()
 
       case update: UpdateRequest =>
         val builder = XContentFactory.jsonBuilder()
@@ -72,7 +72,7 @@ object BulkBuilderFn {
         builder.endObject()
         builder.endObject()
 
-        rows += builder.string
+        rows += builder.string()
         rows += UpdateBuilderFn(update).string()
     }
     rows.result()

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/cluster/ClusterHandlers.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/cluster/ClusterHandlers.scala
@@ -28,7 +28,7 @@ trait ClusterHandlers {
   implicit object ClusterSettingsHandler extends Handler[ClusterSettingsRequest, ClusterSettingsResponse] {
     override def build(request: ClusterSettingsRequest): ElasticRequest = {
       val builder = ClusterSettingsBodyBuilderFn(request)
-      val entity = HttpEntity(builder.string, "application/json")
+      val entity = HttpEntity(builder.string(), "application/json")
       ElasticRequest("PUT", "/_cluster/settings", Map("flat_settings" -> true), entity)
     }
   }

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/common/FetchSourceContextBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/common/FetchSourceContextBuilderFn.scala
@@ -6,7 +6,7 @@ import com.sksamuel.elastic4s.requests.common.FetchSourceContext
 // takes a FetchSourceContext and returns the appropriate json
 // https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-request-source-filtering.html
 object FetchSourceContextBuilderFn {
-  def apply(builder: XContentBuilder, context: FetchSourceContext) {
+  def apply(builder: XContentBuilder, context: FetchSourceContext) = {
     if (context.fetchSource)
       if (context.includes.nonEmpty || context.excludes.nonEmpty) {
         builder.startObject("_source")

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/index/AnalysisBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/index/AnalysisBuilderFn.scala
@@ -6,7 +6,7 @@ import com.sksamuel.elastic4s.requests.indexes.AnalysisDefinition
 @deprecated("use new analysis package", "7.0.1")
 object AnalysisBuilderFn {
 
-  def build(ad: AnalysisDefinition, source: XContentBuilder) {
+  def build(ad: AnalysisDefinition, source: XContentBuilder) = {
     source.startObject("analysis")
 
     val charFilterDefinitions = ad.charFilterDefinitions

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/index/IndexAdminHandlers.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/index/IndexAdminHandlers.scala
@@ -30,7 +30,7 @@ trait IndexAdminHandlers {
         builder.endObject()
       }
 
-      val entity = HttpEntity(builder.string, "application/json")
+      val entity = HttpEntity(builder.string(), "application/json")
       ElasticRequest("POST", endpoint, params.toMap, entity)
     }
   }

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/index/RolloverHandlers.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/index/RolloverHandlers.scala
@@ -32,7 +32,7 @@ trait RolloverHandlers {
       request.maxSize.foreach(builder.field("max_size", _))
       builder.endObject()
 
-      val entity = HttpEntity(builder.string, "application/json")
+      val entity = HttpEntity(builder.string(), "application/json")
       ElasticRequest("POST", endpoint2, params.toMap, entity)
     }
   }

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/index/mapping/MappingBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/index/mapping/MappingBuilderFn.scala
@@ -22,11 +22,11 @@ object MappingBuilderFn {
     d.rawSource match {
       //user raw source if provided, ignore other mapping settings
       case Some(rs) =>
-        val builder = XContentFactory.jsonBuilder
+        val builder = XContentFactory.jsonBuilder()
         builder.rawField(tpe, XContentFactory.parse(rs))
         builder
       case None =>
-        val builder = XContentFactory.jsonBuilder
+        val builder = XContentFactory.jsonBuilder()
         builder.startObject(tpe)
         build(d, builder)
         builder.endObject()

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/searches/queries/compound/BoolQueryBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/searches/queries/compound/BoolQueryBuilderFn.scala
@@ -11,28 +11,28 @@ object BoolQueryBuilderFn {
 
     if (bool.must.nonEmpty) {
       builder.startArray("must")
-      val musts = bool.must.map(QueryBuilderFn.apply).map(_.string).mkString(",")
+      val musts = bool.must.map(QueryBuilderFn.apply).map(_.string()).mkString(",")
       builder.rawValue(musts)
       builder.endArray()
     }
 
     if (bool.should.nonEmpty) {
       builder.startArray("should")
-      val should = bool.should.map(QueryBuilderFn.apply).map(_.string).mkString(",")
+      val should = bool.should.map(QueryBuilderFn.apply).map(_.string()).mkString(",")
       builder.rawValue(should)
       builder.endArray()
     }
 
     if (bool.not.nonEmpty) {
       builder.startArray("must_not")
-      val nots = bool.not.map(QueryBuilderFn.apply).map(_.string).mkString(",")
+      val nots = bool.not.map(QueryBuilderFn.apply).map(_.string()).mkString(",")
       builder.rawValue(nots)
       builder.endArray()
     }
 
     if (bool.filters.nonEmpty) {
       builder.startArray("filter")
-      val filters = bool.filters.map(QueryBuilderFn.apply).map(_.string).mkString(",")
+      val filters = bool.filters.map(QueryBuilderFn.apply).map(_.string()).mkString(",")
       builder.rawValue(filters)
       builder.endArray()
     }

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/snapshot/SnapshotHandlers.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/snapshot/SnapshotHandlers.scala
@@ -23,7 +23,7 @@ trait SnapshotHandlers {
           body.field(key, value.toString)
       }
       body.endObject()
-      val entity = HttpEntity(body.string, "application/json")
+      val entity = HttpEntity(body.string(), "application/json")
 
       ElasticRequest("PUT", endpoint, params.toMap, entity)
     }
@@ -44,7 +44,7 @@ trait SnapshotHandlers {
       request.ignoreUnavailable.foreach(body.field("ignore_unavailable", _))
       request.includeGlobalState.foreach(body.field("include_global_state", _))
       request.partial.foreach(body.field("partial", _))
-      val entity = HttpEntity(body.string, "application/json")
+      val entity = HttpEntity(body.string(), "application/json")
 
       ElasticRequest("PUT", endpoint, params.toMap, entity)
     }
@@ -83,7 +83,7 @@ trait SnapshotHandlers {
       request.includeAliases.foreach(body.field("include_aliases", _))
       request.renamePattern.foreach(body.field("rename_pattern", _))
       request.renameReplacement.foreach(body.field("rename_replacement", _))
-      val entity = HttpEntity(body.string, "application/json")
+      val entity = HttpEntity(body.string(), "application/json")
 
       ElasticRequest("POST", endpoint, params.toMap, entity)
     }

--- a/elastic4s-json-builder/src/main/scala/com/sksamuel/elastic4s/JacksonSupport.scala
+++ b/elastic4s-json-builder/src/main/scala/com/sksamuel/elastic4s/JacksonSupport.scala
@@ -2,14 +2,12 @@ package com.sksamuel.elastic4s
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import com.fasterxml.jackson.module.scala.{ClassTagExtensions, DefaultScalaModule}
 
 object JacksonSupport {
 
-  val mapper: ObjectMapper with ScalaObjectMapper = new ObjectMapper with ScalaObjectMapper
+  val mapper: ObjectMapper with ClassTagExtensions = new ObjectMapper with ClassTagExtensions
   mapper.registerModule(DefaultScalaModule)
 
   mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)

--- a/elastic4s-json-circe/src/main/scala/com/sksamuel/elastic4s/circe/package.scala
+++ b/elastic4s-json-circe/src/main/scala/com/sksamuel/elastic4s/circe/package.scala
@@ -54,6 +54,6 @@ package object circe {
     "No Encoder for type ${T} found. Use 'import io.circe.generic.auto._' or provide an implicit Encoder instance "
   )
   implicit def paramSerializerWithCirce[T](implicit encoder: Encoder[T],
-                                     printer: Json => String = Printer.noSpaces.print): ParamSerializer[T] =
+                                           printer: Json => String = Printer.noSpaces.print): ParamSerializer[T] =
     (t: T) => printer(encoder(t))
 }

--- a/elastic4s-json-jackson/src/main/scala/com/sksamuel/elastic4s/jackson/ElasticJackson.scala
+++ b/elastic4s-json-jackson/src/main/scala/com/sksamuel/elastic4s/jackson/ElasticJackson.scala
@@ -2,7 +2,7 @@ package com.sksamuel.elastic4s.jackson
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.node.ObjectNode
-import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import com.fasterxml.jackson.module.scala.{ClassTagExtensions, JavaTypeable}
 import com.sksamuel.elastic4s._
 import com.sksamuel.exts.Logging
 
@@ -18,8 +18,8 @@ object ElasticJackson {
     implicit def JacksonJsonParamSerializer[T](implicit mapper: ObjectMapper = JacksonSupport.mapper): ParamSerializer[T] =
       (t: T) => mapper.writeValueAsString(t)
 
-    implicit def JacksonJsonHitReader[T](implicit mapper: ObjectMapper with ScalaObjectMapper = JacksonSupport.mapper,
-                                         manifest: Manifest[T]): HitReader[T] = (hit: Hit) => Try {
+    implicit def JacksonJsonHitReader[T](implicit mapper: ObjectMapper with ClassTagExtensions = JacksonSupport.mapper,
+                                         javaTypeable: JavaTypeable[T]): HitReader[T] = (hit: Hit) => Try {
       val node = mapper.readTree(mapper.writeValueAsBytes(hit.sourceAsMap)).asInstanceOf[ObjectNode]
       if (!node.has("_id")) node.put("_id", hit.id)
       if (!node.has("_type")) node.put("_type", hit.`type`)

--- a/elastic4s-json-jackson/src/main/scala/com/sksamuel/elastic4s/jackson/JacksonSupport.scala
+++ b/elastic4s-json-jackson/src/main/scala/com/sksamuel/elastic4s/jackson/JacksonSupport.scala
@@ -5,13 +5,12 @@ import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.databind.ser.std.NumberSerializers
 import com.fasterxml.jackson.databind.{DeserializationFeature, ObjectMapper}
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import com.fasterxml.jackson.module.scala.{ClassTagExtensions, DefaultScalaModule}
 import com.sksamuel.elastic4s.requests.searches.Total
 
 object JacksonSupport {
 
-  val mapper: ObjectMapper with ScalaObjectMapper = new ObjectMapper with ScalaObjectMapper
+  val mapper: ObjectMapper with ClassTagExtensions = new ObjectMapper with ClassTagExtensions
   mapper.registerModule(DefaultScalaModule)
 
   mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL)

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/JsonSugar.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/JsonSugar.scala
@@ -1,14 +1,13 @@
 package com.sksamuel.elastic4s
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import com.fasterxml.jackson.module.scala.{ClassTagExtensions, DefaultScalaModule}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.matchers.{MatchResult, Matcher}
 
 trait JsonSugar extends Matchers {
 
-  private val mapper = new ObjectMapper with ScalaObjectMapper
+  private val mapper = new ObjectMapper with ClassTagExtensions
   mapper.registerModule(DefaultScalaModule)
 
   def matchJsonResource(resourceName: String) = new JsonResourceMatcher(resourceName)

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/analysis/analyzers/FingerprintAnalyzerBuilderTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/analysis/analyzers/FingerprintAnalyzerBuilderTest.scala
@@ -8,7 +8,7 @@ class FingerprintAnalyzerBuilderTest extends AnyWordSpec with Matchers {
 
   "FingerprintAnalyzer" should {
     "build json" in {
-      FingerprintAnalyzer("testy").separator("-").maxOutputSize(123).stopwords("a", "z").build.string shouldBe """{"type":"fingerprint","separator":"-","stopwords":["a","z"],"max_output_size":123}"""
+      FingerprintAnalyzer("testy").separator("-").maxOutputSize(123).stopwords("a", "z").build.string() shouldBe """{"type":"fingerprint","separator":"-","stopwords":["a","z"],"max_output_size":123}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/analysis/analyzers/PatternAnalyzerBuilderTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/analysis/analyzers/PatternAnalyzerBuilderTest.scala
@@ -8,7 +8,7 @@ class PatternAnalyzerBuilderTest extends AnyWordSpec with Matchers {
 
   "PatternAnalyzer" should {
     "build json" in {
-      PatternAnalyzer("testy", regex = "21.*").lowercase(true).build.string shouldBe """{"type":"pattern","lowercase":true,"pattern":"21.*"}"""
+      PatternAnalyzer("testy", regex = "21.*").lowercase(true).build.string() shouldBe """{"type":"pattern","lowercase":true,"pattern":"21.*"}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/analysis/tokenizers/ClassicTokenizerBuilderTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/analysis/tokenizers/ClassicTokenizerBuilderTest.scala
@@ -8,7 +8,7 @@ class ClassicTokenizerBuilderTest extends AnyWordSpec with Matchers {
 
   "ClassicTokenizer" should {
     "build json" in {
-      ClassicTokenizer("testy", 123).build.string shouldBe """{"type":"classic","max_token_length":123}"""
+      ClassicTokenizer("testy", 123).build.string() shouldBe """{"type":"classic","max_token_length":123}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/analysis/tokenizers/EdgeNGramTokenizerBuilderTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/analysis/tokenizers/EdgeNGramTokenizerBuilderTest.scala
@@ -9,7 +9,7 @@ class EdgeNGramTokenizerBuilderTest extends AnyWordSpec with Matchers with Elast
 
   "EdgeNGramTokenizer" should {
     "build json" in {
-      EdgeNGramTokenizer("testy").minMaxGrams(2, 3).tokenChars("a", "z").build.string shouldBe """{"type":"edge_ngram","min_gram":2,"max_gram":3,"token_chars":["a","z"]}"""
+      EdgeNGramTokenizer("testy").minMaxGrams(2, 3).tokenChars("a", "z").build.string() shouldBe """{"type":"edge_ngram","min_gram":2,"max_gram":3,"token_chars":["a","z"]}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/analysis/tokenizers/KeywordTokenizerBuilderTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/analysis/tokenizers/KeywordTokenizerBuilderTest.scala
@@ -8,7 +8,7 @@ class KeywordTokenizerBuilderTest extends AnyWordSpec with Matchers {
 
   "KeywordTokenizer" should {
     "build json" in {
-      KeywordTokenizer("testy").bufferSize(123).build.string shouldBe """{"type":"keyword","bufferSize":123}"""
+      KeywordTokenizer("testy").bufferSize(123).build.string() shouldBe """{"type":"keyword","bufferSize":123}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/analysis/tokenizers/WhitespaceTokenizerBuilderTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/analysis/tokenizers/WhitespaceTokenizerBuilderTest.scala
@@ -8,7 +8,7 @@ class WhitespaceTokenizerBuilderTest extends AnyWordSpec with Matchers {
 
   "WhitespaceTokenizer" should {
     "build json" in {
-      WhitespaceTokenizer("testy", 123).build.string shouldBe """{"type":"whitespace","max_token_length":123}"""
+      WhitespaceTokenizer("testy", 123).build.string() shouldBe """{"type":"whitespace","max_token_length":123}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/jackson/ElasticJacksonIndexableTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/jackson/ElasticJacksonIndexableTest.scala
@@ -3,7 +3,7 @@ package com.sksamuel.elastic4s.jackson
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.databind.{DeserializationContext, JsonDeserializer, JsonMappingException, ObjectMapper}
-import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
+import com.fasterxml.jackson.module.scala.ClassTagExtensions
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.matchers.should.Matchers
@@ -46,7 +46,7 @@ class ElasticJacksonIndexableTest extends AnyWordSpec with Matchers with DockerT
     }
     "support custom mapper" in {
 
-     implicit val custom: ObjectMapper with ScalaObjectMapper = new ObjectMapper with ScalaObjectMapper
+      implicit val custom: ObjectMapper with ClassTagExtensions = new ObjectMapper with ClassTagExtensions
 
       val module = new SimpleModule
       module.addDeserializer(classOf[String], new JsonDeserializer[String] {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/json/XContentBuilderTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/json/XContentBuilderTest.scala
@@ -25,63 +25,63 @@ class XContentBuilderTest extends AnyFunSuite with Matchers {
   }
 
   test("should support raw fields in objects") {
-    XContentFactory.obj().rawField("nested", """{"test":true,"name":"foo"}""").string shouldBe """{"nested":{"test":true,"name":"foo"}}"""
+    XContentFactory.obj().rawField("nested", """{"test":true,"name":"foo"}""").string() shouldBe """{"nested":{"test":true,"name":"foo"}}"""
   }
 
   test("should support raw values in arrays") {
-    XContentFactory.array().rawValue("""{"test":true,"name":"foo"}""").string shouldBe """[{"test":true,"name":"foo"}]"""
+    XContentFactory.array().rawValue("""{"test":true,"name":"foo"}""").string() shouldBe """[{"test":true,"name":"foo"}]"""
   }
 
   test("should support boolean arrays") {
-    XContentFactory.obj().array("booleans", Array(true, false, true)).string shouldBe """{"booleans":[true,false,true]}"""
+    XContentFactory.obj().array("booleans", Array(true, false, true)).string() shouldBe """{"booleans":[true,false,true]}"""
   }
 
   test("should support double arrays") {
-    XContentFactory.obj().array("doubles", Array(124.45, 962.23)).string shouldBe """{"doubles":[124.45,962.23]}"""
+    XContentFactory.obj().array("doubles", Array(124.45, 962.23)).string() shouldBe """{"doubles":[124.45,962.23]}"""
   }
 
   test("should support biginteger arrays") {
-    XContentFactory.obj().autoarray("bigintegers", Seq(new BigInteger("123"), new BigInteger("456"))).string shouldBe """{"bigintegers":[123,456]}"""
+    XContentFactory.obj().autoarray("bigintegers", Seq(new BigInteger("123"), new BigInteger("456"))).string() shouldBe """{"bigintegers":[123,456]}"""
   }
 
   test("should support long arrays") {
-    XContentFactory.obj().array("longs", Array(345345435345L, 3257059014L)).string shouldBe """{"longs":[345345435345,3257059014]}"""
+    XContentFactory.obj().array("longs", Array(345345435345L, 3257059014L)).string() shouldBe """{"longs":[345345435345,3257059014]}"""
   }
 
   test("should support string arrays") {
-    XContentFactory.obj().array("strings", Array("foo", "boo")).string shouldBe """{"strings":["foo","boo"]}"""
+    XContentFactory.obj().array("strings", Array("foo", "boo")).string() shouldBe """{"strings":["foo","boo"]}"""
   }
 
   test("should support double fields") {
-    XContentFactory.obj().field("double", 5612.3734).string shouldBe """{"double":5612.3734}"""
+    XContentFactory.obj().field("double", 5612.3734).string() shouldBe """{"double":5612.3734}"""
   }
 
   test("should support bigdecimal fields") {
-    XContentFactory.obj().field("dec", BigDecimal("291839123.12321312")).string shouldBe """{"dec":291839123.12321312}"""
+    XContentFactory.obj().field("dec", BigDecimal("291839123.12321312")).string() shouldBe """{"dec":291839123.12321312}"""
   }
 
   test("should support bigint fields") {
-    XContentFactory.obj().field("bigint", BigInt("98123981231982361893619")).string shouldBe """{"bigint":98123981231982361893619}"""
+    XContentFactory.obj().field("bigint", BigInt("98123981231982361893619")).string() shouldBe """{"bigint":98123981231982361893619}"""
   }
 
   test("should support biginteger fields") {
-    XContentFactory.obj().autofield("biginteger", new BigInteger("98123981231982361893619")).string shouldBe """{"biginteger":98123981231982361893619}"""
+    XContentFactory.obj().autofield("biginteger", new BigInteger("98123981231982361893619")).string() shouldBe """{"biginteger":98123981231982361893619}"""
   }
 
   test("should support int fields") {
-    XContentFactory.obj().field("int", 3242365).string shouldBe """{"int":3242365}"""
+    XContentFactory.obj().field("int", 3242365).string() shouldBe """{"int":3242365}"""
   }
 
   test("should support long fields") {
-    XContentFactory.obj().field("long", 91118592743568234L).string shouldBe """{"long":91118592743568234}"""
+    XContentFactory.obj().field("long", 91118592743568234L).string() shouldBe """{"long":91118592743568234}"""
   }
 
   test("should support boolean fields") {
-    XContentFactory.obj().field("boolean", true).string shouldBe """{"boolean":true}"""
+    XContentFactory.obj().field("boolean", true).string() shouldBe """{"boolean":true}"""
   }
 
   test("should support str fields") {
-    XContentFactory.obj().field("str", "ewrewr").string shouldBe
+    XContentFactory.obj().field("str", "ewrewr").string() shouldBe
       """{"str":"ewrewr"}"""
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/CommonGramsTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/CommonGramsTokenFilterTest.scala
@@ -8,31 +8,31 @@ class CommonGramsTokenFilterTest extends AnyWordSpec with TokenFilterApi with Ma
 
   "CommonGramsTokenFilter builder" should {
     "not set any defaults" in {
-      commonGramsTokenFilter("testy").json.string shouldBe """{"type":"common_grams"}"""
+      commonGramsTokenFilter("testy").json.string() shouldBe """{"type":"common_grams"}"""
     }
     "set common words" in {
       commonGramsTokenFilter("testy")
         .commonWords("the", "and")
         .json
-        .string shouldBe """{"type":"common_grams","common_words":["the","and"]}"""
+        .string() shouldBe """{"type":"common_grams","common_words":["the","and"]}"""
     }
     "set common words path" in {
       commonGramsTokenFilter("testy")
         .commonWordsPath("some/file.txt")
         .json
-        .string shouldBe """{"type":"common_grams","common_words_path":"some/file.txt"}"""
+        .string() shouldBe """{"type":"common_grams","common_words_path":"some/file.txt"}"""
     }
     "set ignore case" in {
       commonGramsTokenFilter("testy")
         .ignoreCase(true)
         .json
-        .string shouldBe """{"type":"common_grams","ignore_case":true}"""
+        .string() shouldBe """{"type":"common_grams","ignore_case":true}"""
     }
     "set query mode" in {
       commonGramsTokenFilter("testy")
         .queryMode(true)
         .json
-        .string shouldBe """{"type":"common_grams","query_mode":true}"""
+        .string() shouldBe """{"type":"common_grams","query_mode":true}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/CompoundWordTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/CompoundWordTokenFilterTest.scala
@@ -8,28 +8,28 @@ class CompoundWordTokenFilterTest extends AnyWordSpec with TokenFilterApi with M
 
   "CompoundWordTokenFilter builder" should {
     "set type" in {
-      compoundWordTokenFilter("testy", DictionaryDecompounder).json.string shouldBe """{"type":"dictionary_decompounder"}"""
+      compoundWordTokenFilter("testy", DictionaryDecompounder).json.string() shouldBe """{"type":"dictionary_decompounder"}"""
     }
     "set word list" in {
-      compoundWordTokenFilter("testy", HyphenationDecompounder).wordList("boo", "foo").json.string shouldBe """{"type":"hyphenation_decompounder","word_list":["boo","foo"]}"""
+      compoundWordTokenFilter("testy", HyphenationDecompounder).wordList("boo", "foo").json.string() shouldBe """{"type":"hyphenation_decompounder","word_list":["boo","foo"]}"""
     }
     "set word list path" in {
-      compoundWordTokenFilter("testy", HyphenationDecompounder).wordListPath("config/word.txt").json.string shouldBe """{"type":"hyphenation_decompounder","word_list_path":"config/word.txt"}"""
+      compoundWordTokenFilter("testy", HyphenationDecompounder).wordListPath("config/word.txt").json.string() shouldBe """{"type":"hyphenation_decompounder","word_list_path":"config/word.txt"}"""
     }
     "set hyphenation patterns path" in {
-      compoundWordTokenFilter("testy", HyphenationDecompounder).wordListPath("config/hyphens.txt").json.string shouldBe """{"type":"hyphenation_decompounder","word_list_path":"config/hyphens.txt"}"""
+      compoundWordTokenFilter("testy", HyphenationDecompounder).wordListPath("config/hyphens.txt").json.string() shouldBe """{"type":"hyphenation_decompounder","word_list_path":"config/hyphens.txt"}"""
     }
     "set min word size" in {
-      compoundWordTokenFilter("testy", HyphenationDecompounder).minWordSize(7).json.string shouldBe """{"type":"hyphenation_decompounder","min_word_size":7}"""
+      compoundWordTokenFilter("testy", HyphenationDecompounder).minWordSize(7).json.string() shouldBe """{"type":"hyphenation_decompounder","min_word_size":7}"""
     }
     "set min subword size" in {
-      compoundWordTokenFilter("testy", HyphenationDecompounder).minSubwordSize(3).json.string shouldBe """{"type":"hyphenation_decompounder","min_subword_size":3}"""
+      compoundWordTokenFilter("testy", HyphenationDecompounder).minSubwordSize(3).json.string() shouldBe """{"type":"hyphenation_decompounder","min_subword_size":3}"""
     }
     "set max subword size" in {
-      compoundWordTokenFilter("testy", HyphenationDecompounder).maxSubwordSize(18).json.string shouldBe """{"type":"hyphenation_decompounder","max_subword_size":18}"""
+      compoundWordTokenFilter("testy", HyphenationDecompounder).maxSubwordSize(18).json.string() shouldBe """{"type":"hyphenation_decompounder","max_subword_size":18}"""
     }
     "set only longest match" in {
-      compoundWordTokenFilter("testy", HyphenationDecompounder).onlyLongestMatch(true).json.string shouldBe """{"type":"hyphenation_decompounder","only_longest_match":true}"""
+      compoundWordTokenFilter("testy", HyphenationDecompounder).onlyLongestMatch(true).json.string() shouldBe """{"type":"hyphenation_decompounder","only_longest_match":true}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/CustomAnalyzerTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/CustomAnalyzerTest.scala
@@ -14,7 +14,7 @@ class CustomAnalyzerTest extends AnyFlatSpec with Matchers {
       PredefinedTokenFilter("german_keywords"),
       PredefinedTokenFilter("german_normalization"),
       PredefinedTokenFilter("german_stemmer")
-    ).buildWithName().string shouldBe
+    ).buildWithName().string() shouldBe
       """{"mygerman":{"type":"custom","tokenizer":"standard","filter":["lowercase","german_stop","german_keywords","german_normalization","german_stemmer"]}}"""
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/CustomNormalizerTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/CustomNormalizerTest.scala
@@ -14,7 +14,7 @@ class CustomNormalizerTest extends AnyFlatSpec with Matchers {
       PredefinedTokenFilter("german_normalization"),
       PredefinedTokenFilter("german_stemmer"),
       PredefinedCharFilter("german_charfilter")
-    ).buildWithName().string shouldBe
+    ).buildWithName().string() shouldBe
       """{"mygerman":{"type":"custom","filter":["lowercase","german_stop","german_keywords","german_normalization","german_stemmer"],"char_filter":["german_charfilter"]}}"""
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/EdgeNGramTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/EdgeNGramTokenFilterTest.scala
@@ -8,19 +8,19 @@ class EdgeNGramTokenFilterTest extends AnyWordSpec with TokenFilterApi with Matc
 
   "EdgeNGramTokenFilter builder" should {
     "not set any defaults" in {
-      edgeNGramTokenFilter("testy").json.string shouldBe """{"type":"edgeNGram"}"""
+      edgeNGramTokenFilter("testy").json.string() shouldBe """{"type":"edgeNGram"}"""
     }
     "set min and max ngrams" in {
       edgeNGramTokenFilter("testy")
         .minMaxGrams(3, 4)
         .json
-        .string shouldBe """{"type":"edgeNGram","min_gram":3,"max_gram":4}"""
+        .string() shouldBe """{"type":"edgeNGram","min_gram":3,"max_gram":4}"""
     }
     "set token chars" in {
       edgeNGramTokenFilter("testy")
         .side("backside")
         .json
-        .string shouldBe """{"type":"edgeNGram","side":"backside"}"""
+        .string() shouldBe """{"type":"edgeNGram","side":"backside"}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/EdgeNGramTokenizerTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/EdgeNGramTokenizerTest.scala
@@ -8,16 +8,16 @@ class EdgeNGramTokenizerTest extends AnyWordSpec with TokenizerApi with Matchers
 
   "EdgeNGramTokenizer builder" should {
     "set min and max ngrams" in {
-      edgeNGramTokenizer("testy").minMaxGrams(3, 4).json.string shouldBe """{"type":"edgeNGram","min_gram":3,"max_gram":4}"""
+      edgeNGramTokenizer("testy").minMaxGrams(3, 4).json.string() shouldBe """{"type":"edgeNGram","min_gram":3,"max_gram":4}"""
     }
     "set token chars" in {
       edgeNGramTokenizer("testy")
         .tokenChars("a", "b")
         .json
-        .string shouldBe """{"type":"edgeNGram","min_gram":1,"max_gram":2,"token_chars":["a","b"]}"""
+        .string() shouldBe """{"type":"edgeNGram","min_gram":1,"max_gram":2,"token_chars":["a","b"]}"""
     }
     "not set token chars if not specified" in {
-      edgeNGramTokenizer("testy").json.string shouldBe """{"type":"edgeNGram","min_gram":1,"max_gram":2}"""
+      edgeNGramTokenizer("testy").json.string() shouldBe """{"type":"edgeNGram","min_gram":1,"max_gram":2}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/ElisionTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/ElisionTokenFilterTest.scala
@@ -11,7 +11,7 @@ class ElisionTokenFilterTest extends AnyWordSpec with TokenFilterApi with Matche
       elisionTokenFilter("testy")
         .articles("a", "b")
         .json
-        .string shouldBe
+        .string() shouldBe
         """{"type":"elision","articles":["a","b"]}"""
     }
   }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/KeywordMarkerTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/KeywordMarkerTokenFilterTest.scala
@@ -8,19 +8,19 @@ class KeywordMarkerTokenFilterTest extends AnyWordSpec with TokenFilterApi with 
 
   "KeywordMarkerTokenFilter builder" should {
     "not set any defaults" in {
-      keywordMarkerTokenFilter("testy").json.string shouldBe """{"type":"keyword_marker"}"""
+      keywordMarkerTokenFilter("testy").json.string() shouldBe """{"type":"keyword_marker"}"""
     }
     "set keywords" in {
-      keywordMarkerTokenFilter("testy").keywords("foo", "bar").json.string shouldBe """{"type":"keyword_marker","keywords":["foo","bar"]}"""
+      keywordMarkerTokenFilter("testy").keywords("foo", "bar").json.string() shouldBe """{"type":"keyword_marker","keywords":["foo","bar"]}"""
     }
     "set keywords path" in {
-     keywordMarkerTokenFilter("testy").keywordsPath("config/keywords.txt").json.string shouldBe """{"type":"keyword_marker","keywords_path":"config/keywords.txt"}"""
+     keywordMarkerTokenFilter("testy").keywordsPath("config/keywords.txt").json.string() shouldBe """{"type":"keyword_marker","keywords_path":"config/keywords.txt"}"""
     }
     "set keywords pattern" in {
-      keywordMarkerTokenFilter("testy").keywordsPattern("pattern").json.string shouldBe """{"type":"keyword_marker","keywords_pattern":"pattern"}"""
+      keywordMarkerTokenFilter("testy").keywordsPattern("pattern").json.string() shouldBe """{"type":"keyword_marker","keywords_pattern":"pattern"}"""
     }
     "set ignore case" in {
-      keywordMarkerTokenFilter("testy").ignoreCase(true).json.string shouldBe """{"type":"keyword_marker","ignore_case":true}"""
+      keywordMarkerTokenFilter("testy").ignoreCase(true).json.string() shouldBe """{"type":"keyword_marker","ignore_case":true}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/KeywordTokenizerTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/KeywordTokenizerTest.scala
@@ -9,7 +9,7 @@ class KeywordTokenizerTest extends AnyWordSpec with TokenizerApi with Matchers w
 
   "KeywordTokenizer builder" should {
     "set buffer size" in {
-      keywordTokenizer("testy").bufferSize(123).json.string shouldBe """{"type":"keyword","bufferSize":123}"""
+      keywordTokenizer("testy").bufferSize(123).json.string() shouldBe """{"type":"keyword","bufferSize":123}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/LengthTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/LengthTokenFilterTest.scala
@@ -8,13 +8,13 @@ class LengthTokenFilterTest extends AnyWordSpec with TokenFilterApi with Matcher
 
   "LengthTokenFilter builder" should {
     "not set defaults" in {
-      lengthTokenFilter("testy").json.string shouldBe """{"type":"length"}"""
+      lengthTokenFilter("testy").json.string() shouldBe """{"type":"length"}"""
     }
     "set min" in {
-      lengthTokenFilter("testy").min(2).json.string shouldBe """{"type":"length","min":2}"""
+      lengthTokenFilter("testy").min(2).json.string() shouldBe """{"type":"length","min":2}"""
     }
     "set max" in {
-      lengthTokenFilter("testy").max(55).json.string shouldBe """{"type":"length","max":55}"""
+      lengthTokenFilter("testy").max(55).json.string() shouldBe """{"type":"length","max":55}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/LimitTokenCountTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/LimitTokenCountTokenFilterTest.scala
@@ -8,13 +8,13 @@ class LimitTokenCountTokenFilterTest extends AnyWordSpec with TokenFilterApi wit
 
   "LimitTokenCountTokenFilter builder" should {
     "not set any defaults" in {
-      limitTokenCountTokenFilter("testy").json.string shouldBe """{"type":"limit"}"""
+      limitTokenCountTokenFilter("testy").json.string() shouldBe """{"type":"limit"}"""
     }
     "set max token count" in {
-      limitTokenCountTokenFilter("testy").maxTokenCount(7).json.string shouldBe """{"type":"limit","max_token_count":7}"""
+      limitTokenCountTokenFilter("testy").maxTokenCount(7).json.string() shouldBe """{"type":"limit","max_token_count":7}"""
     }
     "set consume all tokens" in {
-      limitTokenCountTokenFilter("testy").consumeAllTokens(true).json.string shouldBe """{"type":"limit","consume_all_tokens":true}"""
+      limitTokenCountTokenFilter("testy").consumeAllTokens(true).json.string() shouldBe """{"type":"limit","consume_all_tokens":true}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/NGramTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/NGramTokenFilterTest.scala
@@ -8,10 +8,10 @@ class NGramTokenFilterTest extends AnyWordSpec with TokenFilterApi with Matchers
 
   "NGramTokenFilter builder" should {
     "not set any defaults" in {
-      ngramTokenFilter("testy").json.string shouldBe """{"type":"nGram"}"""
+      ngramTokenFilter("testy").json.string() shouldBe """{"type":"nGram"}"""
     }
     "set min and max ngrams" in {
-      ngramTokenFilter("testy").minMaxGrams(3, 4).json.string shouldBe """{"type":"nGram","min_gram":3,"max_gram":4}"""
+      ngramTokenFilter("testy").minMaxGrams(3, 4).json.string() shouldBe """{"type":"nGram","min_gram":3,"max_gram":4}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/NGramTokenizerTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/NGramTokenizerTest.scala
@@ -8,16 +8,16 @@ class NGramTokenizerTest extends AnyWordSpec with TokenizerApi with Matchers {
 
   "NGramTokenizer builder" should {
     "set min and max ngrams" in {
-      nGramTokenizer("testy").minMaxGrams(3, 4).json.string shouldBe """{"type":"nGram","min_gram":3,"max_gram":4}"""
+      nGramTokenizer("testy").minMaxGrams(3, 4).json.string() shouldBe """{"type":"nGram","min_gram":3,"max_gram":4}"""
     }
     "set token chars" in {
       nGramTokenizer("testy")
         .tokenChars("a", "b")
         .json
-        .string shouldBe """{"type":"nGram","min_gram":1,"max_gram":2,"token_chars":["a","b"]}"""
+        .string() shouldBe """{"type":"nGram","min_gram":1,"max_gram":2,"token_chars":["a","b"]}"""
     }
     "not set token chars if not specified" in {
-      nGramTokenizer("testy").json.string shouldBe """{"type":"nGram","min_gram":1,"max_gram":2}"""
+      nGramTokenizer("testy").json.string() shouldBe """{"type":"nGram","min_gram":1,"max_gram":2}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/PatternAnalyzerTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/PatternAnalyzerTest.scala
@@ -11,16 +11,16 @@ class PatternAnalyzerTest extends AnyWordSpec with AnalyzerApi with Matchers {
       snowballAnalyzer("testy")
         .language("klingon")
         .json
-        .string shouldBe """{"type":"snowball","language":"klingon"}"""
+        .string() shouldBe """{"type":"snowball","language":"klingon"}"""
     }
     "set stopwords" in {
       snowballAnalyzer("testy")
         .stopwords("a", "b")
         .json
-        .string shouldBe """{"type":"snowball","language":"English","stopwords":["a","b"]}"""
+        .string() shouldBe """{"type":"snowball","language":"English","stopwords":["a","b"]}"""
     }
     "not set stopwords if not specified" in {
-      snowballAnalyzer("testy").json.string shouldBe """{"type":"snowball","language":"English"}"""
+      snowballAnalyzer("testy").json.string() shouldBe """{"type":"snowball","language":"English"}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/PatternCaptureTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/PatternCaptureTokenFilterTest.scala
@@ -11,18 +11,18 @@ class PatternCaptureTokenFilterTest extends AnyWordSpec with TokenFilterApi with
       patternCaptureTokenFilter("testy")
         .patterns("a", "b")
         .json
-        .string shouldBe
+        .string() shouldBe
         """{"type":"pattern_capture","patterns":["a","b"],"preserve_original":true}"""
     }
     "set preserveOriginal" in {
       patternCaptureTokenFilter("testy")
         .preserveOriginal(false)
         .json
-        .string shouldBe
+        .string() shouldBe
         """{"type":"pattern_capture","preserve_original":false}"""
     }
     "not set patterns if not specified" in {
-      patternCaptureTokenFilter("testy").json.string shouldBe """{"type":"pattern_capture","preserve_original":true}"""
+      patternCaptureTokenFilter("testy").json.string() shouldBe """{"type":"pattern_capture","preserve_original":true}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/PatternTokenizerTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/PatternTokenizerTest.scala
@@ -8,19 +8,19 @@ class PatternTokenizerTest extends AnyWordSpec with TokenizerApi with Matchers {
 
   "PatternTokenizer builder" should {
     "set flags" in {
-      patternTokenizer("testy").flags("abc").json.string shouldBe """{"type":"pattern","flags":"abc","pattern":"\\W+"}"""
+      patternTokenizer("testy").flags("abc").json.string() shouldBe """{"type":"pattern","flags":"abc","pattern":"\\W+"}"""
     }
     "not set flags if not specified" in {
-      patternTokenizer("testy").json.string shouldBe """{"type":"pattern","pattern":"\\W+"}"""
+      patternTokenizer("testy").json.string() shouldBe """{"type":"pattern","pattern":"\\W+"}"""
     }
     "set pattern" in {
       patternTokenizer("testy")
         .pattern("aRRgh")
         .json
-        .string shouldBe """{"type":"pattern","pattern":"aRRgh"}"""
+        .string() shouldBe """{"type":"pattern","pattern":"aRRgh"}"""
     }
     "set group if > 0" in {
-      patternTokenizer("testy").group(3).json.string shouldBe """{"type":"pattern","pattern":"\\W+","group":3}"""
+      patternTokenizer("testy").group(3).json.string() shouldBe """{"type":"pattern","pattern":"\\W+","group":3}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/ShingleTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/ShingleTokenFilterTest.scala
@@ -8,25 +8,25 @@ class ShingleTokenFilterTest extends AnyWordSpec with TokenFilterApi with Matche
 
   "ShingleTokenFilter builder" should {
     "not set any defaults" in {
-      shingleTokenFilter("testy").json.string shouldBe """{"type":"shingle"}"""
+      shingleTokenFilter("testy").json.string() shouldBe """{"type":"shingle"}"""
     }
     "set max shingle size" in {
-      shingleTokenFilter("testy").maxShingleSize(10).json.string shouldBe """{"type":"shingle","max_shingle_size":10}"""
+      shingleTokenFilter("testy").maxShingleSize(10).json.string() shouldBe """{"type":"shingle","max_shingle_size":10}"""
     }
     "set min shingle size" in {
-      shingleTokenFilter("testy").minShingleSize(11).json.string shouldBe """{"type":"shingle","min_shingle_size":11}"""
+      shingleTokenFilter("testy").minShingleSize(11).json.string() shouldBe """{"type":"shingle","min_shingle_size":11}"""
     }
     "set output unigrams" in {
-      shingleTokenFilter("testy").outputUnigrams(false).json.string shouldBe """{"type":"shingle","output_unigrams":false}"""
+      shingleTokenFilter("testy").outputUnigrams(false).json.string() shouldBe """{"type":"shingle","output_unigrams":false}"""
     }
     "set output unigrams if no shingles" in {
-      shingleTokenFilter("testy").outputUnigramsIfNoShingles(true).json.string shouldBe """{"type":"shingle","output_unigrams_if_no_shingles":true}"""
+      shingleTokenFilter("testy").outputUnigramsIfNoShingles(true).json.string() shouldBe """{"type":"shingle","output_unigrams_if_no_shingles":true}"""
     }
     "set token separator" in {
-      shingleTokenFilter("testy").tokenSeparator("/").json.string shouldBe """{"type":"shingle","token_separator":"/"}"""
+      shingleTokenFilter("testy").tokenSeparator("/").json.string() shouldBe """{"type":"shingle","token_separator":"/"}"""
     }
     "set filler token" in {
-      shingleTokenFilter("testy").fillerToken("-").json.string shouldBe """{"type":"shingle","filler_token":"-"}"""
+      shingleTokenFilter("testy").fillerToken("-").json.string() shouldBe """{"type":"shingle","filler_token":"-"}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/SnowballAnalyzerTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/SnowballAnalyzerTest.scala
@@ -11,13 +11,13 @@ class SnowballAnalyzerTest extends AnyWordSpec with AnalyzerApi with Matchers {
       standardAnalyzer("testy")
         .stopwords("a", "b")
         .json
-        .string shouldBe """{"type":"standard","stopwords":["a","b"],"max_token_length":255}"""
+        .string() shouldBe """{"type":"standard","stopwords":["a","b"],"max_token_length":255}"""
     }
     "set maxTokenLength" in {
       standardAnalyzer("testy")
         .maxTokenLength(34)
         .json
-        .string shouldBe """{"type":"standard","stopwords":[],"max_token_length":34}"""
+        .string() shouldBe """{"type":"standard","stopwords":[],"max_token_length":34}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/SnowballTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/SnowballTokenFilterTest.scala
@@ -8,7 +8,7 @@ class SnowballTokenFilterTest extends AnyWordSpec with TokenFilterApi with Match
 
   "SnowballTokenFilter builder" should {
     "set language" in {
-      snowballTokenFilter("testy", "vulcan").json.string shouldBe """{"type":"snowball","language":"vulcan"}"""
+      snowballTokenFilter("testy", "vulcan").json.string() shouldBe """{"type":"snowball","language":"vulcan"}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/StandardAnalyzerTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/StandardAnalyzerTest.scala
@@ -11,13 +11,13 @@ class StandardAnalyzerTest extends AnyWordSpec with AnalyzerApi with Matchers {
       standardAnalyzer("testy")
         .stopwords("a", "b")
         .json
-        .string shouldBe """{"type":"standard","stopwords":["a","b"],"max_token_length":255}"""
+        .string() shouldBe """{"type":"standard","stopwords":["a","b"],"max_token_length":255}"""
     }
     "set maxTokenLength" in {
       standardAnalyzer("testy")
         .maxTokenLength(34)
         .json
-        .string shouldBe """{"type":"standard","stopwords":[],"max_token_length":34}"""
+        .string() shouldBe """{"type":"standard","stopwords":[],"max_token_length":34}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/StandardTokenizerTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/StandardTokenizerTest.scala
@@ -8,7 +8,7 @@ class StandardTokenizerTest extends AnyWordSpec with TokenizerApi with Matchers 
 
   "StandardTokenizer builder" should {
     "set max token length" in {
-      standardTokenizer("testy").maxTokenLength(14).json.string shouldBe """{"type":"standard","max_token_length":14}"""
+      standardTokenizer("testy").maxTokenLength(14).json.string() shouldBe """{"type":"standard","max_token_length":14}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/StemmerTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/StemmerTokenFilterTest.scala
@@ -8,7 +8,7 @@ class StemmerTokenFilterTest extends AnyWordSpec with TokenFilterApi with Matche
 
   "StemmerTokenFilter builder" should {
     "set language" in {
-      stemmerTokenFilter("testy", "vulcan").json.string shouldBe """{"type":"stemmer","name":"vulcan"}"""
+      stemmerTokenFilter("testy", "vulcan").json.string() shouldBe """{"type":"stemmer","name":"vulcan"}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/StopAnalyzerTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/StopAnalyzerTest.scala
@@ -8,7 +8,7 @@ class StopAnalyzerTest extends AnyWordSpec with AnalyzerApi with Matchers {
 
   "StopAnalyzer builder" should {
     "set stopwords" in {
-      stopAnalyzer("testy").stopwords("a", "b").json.string shouldBe """{"type":"stop","stopwords":["a","b"]}"""
+      stopAnalyzer("testy").stopwords("a", "b").json.string() shouldBe """{"type":"stop","stopwords":["a","b"]}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/StopTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/StopTokenFilterTest.scala
@@ -8,13 +8,13 @@ class StopTokenFilterTest extends AnyWordSpec with TokenFilterApi with Matchers 
 
   "StopTokenFilter builder" should {
     "set stop words" in {
-      stopTokenFilter("testy").stopwords("boo", "foo").json.string shouldBe """{"type":"stop","stopwords":["boo","foo"]}"""
+      stopTokenFilter("testy").stopwords("boo", "foo").json.string() shouldBe """{"type":"stop","stopwords":["boo","foo"]}"""
     }
     "set ignore case" in {
-      stopTokenFilter("testy").ignoreCase(true).json.string shouldBe """{"type":"stop","ignore_case":true}"""
+      stopTokenFilter("testy").ignoreCase(true).json.string() shouldBe """{"type":"stop","ignore_case":true}"""
     }
     "set remove trailing" in {
-      stopTokenFilter("testy").removeTrailing(true).json.string shouldBe """{"type":"stop","remove_trailing":true}"""
+      stopTokenFilter("testy").removeTrailing(true).json.string() shouldBe """{"type":"stop","remove_trailing":true}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/TruncateTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/TruncateTokenFilterTest.scala
@@ -8,10 +8,10 @@ class TruncateTokenFilterTest extends AnyWordSpec with TokenFilterApi with Match
 
   "TruncateTokenFilter builder" should {
     "not set any defaults" in {
-      truncateTokenFilter("testy").json.string shouldBe """{"type":"truncate"}"""
+      truncateTokenFilter("testy").json.string() shouldBe """{"type":"truncate"}"""
     }
     "set length" in {
-      truncateTokenFilter("testy").length(5).json.string shouldBe """{"type":"truncate","length":5}"""
+      truncateTokenFilter("testy").length(5).json.string() shouldBe """{"type":"truncate","length":5}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/UaxUrlEmailTokenizerTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/UaxUrlEmailTokenizerTest.scala
@@ -11,7 +11,7 @@ class UaxUrlEmailTokenizerTest extends AnyWordSpec with TokenizerApi with Matche
       uaxUrlEmailTokenizer("testy")
         .maxTokenLength(14)
         .json
-        .string shouldBe """{"type":"uax_url_email","max_token_length":14}"""
+        .string() shouldBe """{"type":"uax_url_email","max_token_length":14}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/UniqueTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/UniqueTokenFilterTest.scala
@@ -8,10 +8,10 @@ class UniqueTokenFilterTest extends AnyWordSpec with AnalyzerApi with Matchers w
 
   "UniqueTokenFilter builder" should {
     "not set any defaults" in {
-      uniqueTokenFilter("testy").json.string shouldBe """{"type":"unique"}"""
+      uniqueTokenFilter("testy").json.string() shouldBe """{"type":"unique"}"""
     }
     "set only same position" in {
-      uniqueTokenFilter("testy").onlyOnSamePosition(true).json.string shouldBe """{"type":"unique","only_on_same_position":true}"""
+      uniqueTokenFilter("testy").onlyOnSamePosition(true).json.string() shouldBe """{"type":"unique","only_on_same_position":true}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/WordDelimiterTokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/analyzers/WordDelimiterTokenFilterTest.scala
@@ -11,55 +11,55 @@ class WordDelimiterTokenFilterTest extends AnyWordSpec with TokenFilterApi with 
       wordDelimiterTokenFilter("testy")
         .generateNumberParts(true)
         .json
-        .string shouldBe """{"type":"word_delimiter","generate_number_parts":true}"""
+        .string() shouldBe """{"type":"word_delimiter","generate_number_parts":true}"""
     }
     "set generateWordParts" in {
       wordDelimiterTokenFilter("testy")
         .generateWordParts(true)
         .json
-        .string shouldBe """{"type":"word_delimiter","generate_word_parts":true}"""
+        .string() shouldBe """{"type":"word_delimiter","generate_word_parts":true}"""
     }
     "set splitOnCaseChange" in {
       wordDelimiterTokenFilter("testy")
         .splitOnCaseChange(true)
         .json
-        .string shouldBe """{"type":"word_delimiter","split_on_case_change":true}"""
+        .string() shouldBe """{"type":"word_delimiter","split_on_case_change":true}"""
     }
     "set splitOnNumerics" in {
       wordDelimiterTokenFilter("testy")
         .splitOnNumerics(true)
         .json
-        .string shouldBe """{"type":"word_delimiter","split_on_numerics":true}"""
+        .string() shouldBe """{"type":"word_delimiter","split_on_numerics":true}"""
     }
     "set stemEnglishPossesive" in {
       wordDelimiterTokenFilter("testy")
         .stemEnglishPossesive(true)
         .json
-        .string shouldBe """{"type":"word_delimiter","stem_english_possessive":true}"""
+        .string() shouldBe """{"type":"word_delimiter","stem_english_possessive":true}"""
     }
     "set catenateAll" in {
       wordDelimiterTokenFilter("testy")
         .catenateAll(true)
         .json
-        .string shouldBe """{"type":"word_delimiter","catenate_all":true}"""
+        .string() shouldBe """{"type":"word_delimiter","catenate_all":true}"""
     }
     "set catenateNumbers" in {
       wordDelimiterTokenFilter("testy")
         .catenateNumbers(true)
         .json
-        .string shouldBe """{"type":"word_delimiter","catenate_numbers":true}"""
+        .string() shouldBe """{"type":"word_delimiter","catenate_numbers":true}"""
     }
     "set catenateWords" in {
       wordDelimiterTokenFilter("testy")
         .catenateWords(true)
         .json
-        .string shouldBe """{"type":"word_delimiter","catenate_words":true}"""
+        .string() shouldBe """{"type":"word_delimiter","catenate_words":true}"""
     }
     "set preserveOriginal" in {
       wordDelimiterTokenFilter("testy")
         .preserveOriginal(true)
         .json
-        .string shouldBe """{"type":"word_delimiter","preserve_original":true}"""
+        .string() shouldBe """{"type":"word_delimiter","preserve_original":true}"""
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/cluster/ClusterInfoTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/cluster/ClusterInfoTest.scala
@@ -28,18 +28,18 @@ class ClusterInfoTest extends AnyWordSpec with Matchers with DockerTests with Be
       }.await.result
 
       info.valueAt("cluster_one") should have(
-        'seeds (Seq("127.0.0.1:9300", "127.0.0.2:9300")),
-        'maxConnectionsPerCluster (3),
-        'initialConnectTimeout ("30s"),
-        'skipUnavailable (false)
+        Symbol("seeds") (Seq("127.0.0.1:9300", "127.0.0.2:9300")),
+        Symbol("maxConnectionsPerCluster") (3),
+        Symbol("initialConnectTimeout") ("30s"),
+        Symbol("skipUnavailable") (false)
       )
 
       info.valueAt("cluster_two") should have(
-      //  'connected (false),
-      //  'numNodesConnected (0),
-        'maxConnectionsPerCluster (3),
-        'initialConnectTimeout ("30s"),
-        'skipUnavailable (false))
+      //  Symbol("connected") (false),
+      //  Symbol("numNodesConnected") (0),
+        Symbol("maxConnectionsPerCluster") (3),
+        Symbol("initialConnectTimeout") ("30s"),
+        Symbol("skipUnavailable") (false))
     }
   }
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/script/ScriptTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/script/ScriptTest.scala
@@ -46,7 +46,7 @@ class ScriptTest extends AnyFreeSpec with ElasticMatchers with DockerTests {
           scriptField("a", Script("doc['zone'].value * params.fare") params Map("fare" -> 4.50))
         )
       }.await.result
-      result.hits.hits.head.storedField("a").value shouldBe 9.0
+      result.hits.hits.head.storedField("a").value.asInstanceOf[Double] shouldBe 9.0
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/PercentilesAggregationTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/PercentilesAggregationTest.scala
@@ -58,15 +58,15 @@ class PercentilesAggregationTest extends AnyFreeSpec with DockerTests with Match
       val agg = resp.aggs.percentiles("agg1")
       agg.values shouldBe Map("50.0" -> 1707.5, "80.0" -> 2062.8)
     }
-  "should support keyed=false" in {
-  val resp = client.execute {
-  search ("percentilesagg").matchAllQuery ().aggs {
-  percentilesAgg ("agg1", "height").percents (50, 80).keyed (false)
-}
-}.await.result
-  resp.totalHits shouldBe 8
-  val agg = resp.aggs.percentiles ("agg1")
-  agg.values shouldBe Map ("50.0" -> 1707.5, "80.0" -> 2062.8)
-}
+    "should support keyed=false" in {
+      val resp = client.execute {
+        search("percentilesagg").matchAllQuery().aggs {
+          percentilesAgg("agg1", "height").percents(50, 80).keyed(false)
+        }
+      }.await.result
+      resp.totalHits shouldBe 8
+      val agg = resp.aggs.percentiles("agg1")
+      agg.values shouldBe Map("50.0" -> 1707.5, "80.0" -> 2062.8)
+    }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/PercolateDslTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/PercolateDslTest.scala
@@ -14,11 +14,11 @@
 //
 //  it should "should generate fields json for a percolate request" in {
 //    val req = percolate in "captains" doc "name" -> "cook" query { termQuery("color" -> "blue") }
-//    req._doc.string should matchJsonResource("/json/percolate/percolate_request.json")
+//    req._doc.string() should matchJsonResource("/json/percolate/percolate_request.json")
 //  }
 //
 //  it should "should use raw doc for a percolate request" in {
 //    val req = percolate in "captains" rawDoc { """{ "name": "cook" }""" } query { termQuery("color" -> "blue") }
-//    req._doc.string should matchJsonResource("/json/percolate/percolate_request.json")
+//    req._doc.string() should matchJsonResource("/json/percolate/percolate_request.json")
 //  }
 //}

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
@@ -191,7 +191,7 @@ class SearchDslTest extends AnyFlatSpec with MockitoSugar with JsonSugar with On
 
   it should "generate json for a match all query" in {
     val req = search("*") limit 5 query {
-      matchAllQuery boost 4
+      matchAllQuery() boost 4
     }
     req.request.entity.get.get should matchJsonResource("/json/search/search_match_all.json")
   }
@@ -853,7 +853,7 @@ class SearchDslTest extends AnyFlatSpec with MockitoSugar with JsonSugar with On
 
   it should "generate correct json for script fields" in {
     val req =
-      search("sesportfolio") query matchAllQuery scriptfields(
+      search("sesportfolio") query matchAllQuery() scriptfields(
         scriptField("balance", script("portfolioscript") lang "native" params Map("fieldName" -> "rate_of_return")),
         scriptField("date", script("doc['date'].value") lang "groovy")
     )
@@ -957,7 +957,7 @@ class SearchDslTest extends AnyFlatSpec with MockitoSugar with JsonSugar with On
   }
 
   it should "generate json for docvalue fields" in {
-    val req = search("music").matchAllQuery docValues ("field1", "field2")
+    val req = search("music").matchAllQuery() docValues ("field1", "field2")
     req.request.entity.get.get should matchJsonResource("/json/search/search_doc_values.json")
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/TermsSetQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/TermsSetQueryTest.scala
@@ -43,7 +43,7 @@ class TermsSetQueryTest
     }.await.result
     val map = resp.hits.hits.head.sourceAsMap
     map("names") shouldBe List("nelson", "edmure", "john")
-    map("required_matches") shouldBe 2
+    map("required_matches").asInstanceOf[Int] shouldBe 2
   }
 
   // Test: Satisfying the requirements only one 'minimum should match' field (second one)
@@ -53,7 +53,7 @@ class TermsSetQueryTest
     }.await.result
     val map = resp.hits.hits.head.sourceAsMap
     map("names") shouldBe List("umber", "rudolfus", "byron")
-    map("required_matches") shouldBe 1
+    map("required_matches").asInstanceOf[Int] shouldBe 1
   }
 
   // Test: Satisfying the requirements of both 'minimum should match' fields
@@ -62,9 +62,9 @@ class TermsSetQueryTest
       search("randompeople") query termsSetQuery("names", Set("nelson", "edmure", "rudolfus", "christofer"), "required_matches")
     }.await.result
     resp.hits.hits.head.sourceAsMap("names") shouldBe List("nelson", "edmure", "john")
-    resp.hits.hits.head.sourceAsMap("required_matches") shouldBe 2
+    resp.hits.hits.head.sourceAsMap("required_matches").asInstanceOf[Int] shouldBe 2
     resp.hits.hits.apply(1).sourceAsMap("names") shouldBe List("umber", "rudolfus", "byron")
-    resp.hits.hits.apply(1).sourceAsMap("required_matches") shouldBe 1
+    resp.hits.hits.apply(1).sourceAsMap("required_matches").asInstanceOf[Int] shouldBe 1
   }
 
   // Test: Satisfying the requirements of the 'minimum should match' script for one document (first one)
@@ -73,7 +73,7 @@ class TermsSetQueryTest
       search("randompeople") query termsSetQuery("names", Set("nelson", "edmure", "pete"), script("Math.min(params.num_terms,doc['required_matches'].value)"))
     }.await.result
     resp.hits.hits.head.sourceAsMap("names") shouldBe List("nelson","edmure","john")
-    resp.hits.hits.head.sourceAsMap("required_matches") shouldBe 2
+    resp.hits.hits.head.sourceAsMap("required_matches").asInstanceOf[Int] shouldBe 2
   }
 
   // Test: Satisfying the requirements of the 'minimum should match' script for both documents
@@ -82,8 +82,8 @@ class TermsSetQueryTest
       search("randompeople") query termsSetQuery("names", Set("nelson", "edmure", "byron", "pete"), script("Math.min(params.num_terms,doc['required_matches'].value)"))
     }.await.result
     resp.hits.hits.head.sourceAsMap("names") shouldBe List("nelson","edmure","john")
-    resp.hits.hits.head.sourceAsMap("required_matches") shouldBe 2
+    resp.hits.hits.head.sourceAsMap("required_matches").asInstanceOf[Int] shouldBe 2
     resp.hits.hits.apply(1).sourceAsMap("names") shouldBe List("umber","rudolfus","byron")
-    resp.hits.hits.apply(1).sourceAsMap("required_matches") shouldBe 1
+    resp.hits.hits.apply(1).sourceAsMap("required_matches").asInstanceOf[Int] shouldBe 1
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/sort/ScriptSortTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/sort/ScriptSortTest.scala
@@ -34,7 +34,7 @@ class ScriptSortTest extends AnyFreeSpec with ElasticMatchers with DockerTests {
   "script sort" - {
     "sort by name length" in {
       val sorted = client.execute {
-        search("scriptsort") query matchAllQuery sortBy {
+        search("scriptsort") query matchAllQuery() sortBy {
           scriptSort(
             script(""" doc['name'].value.length() """)
           ) typed ScriptSortType.NUMBER

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,7 +31,7 @@ object Dependencies {
 
   lazy val commonDeps = Seq(
     libraryDependencies ++= Seq(
-      "com.sksamuel.exts" %% "exts"                         % ExtsVersion,
+      "com.sksamuel.exts" %% "exts"                         % ExtsVersion cross CrossVersion.for3Use2_13,
       "org.slf4j"          % "slf4j-api"                    % Slf4jVersion,
       "org.scalatest"     %% "scalatest"                    % ScalatestVersion     % "test",
       "org.mockito"        % "mockito-core"                 % MockitoVersion       % "test",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,8 +19,8 @@ object Dependencies {
   val PlayJsonVersion                = "2.9.2"
   val ReactiveStreamsVersion         = "1.0.3"
   val ScalamockVersion               = "5.1.0"
-  val ScalatestPlusMockitoArtifactId = "mockito-3-2"
-  val ScalatestPlusVersion           = "3.1.2.0"
+  val ScalatestPlusMockitoArtifactId = "mockito-3-4"
+  val ScalatestPlusVersion           = "3.2.9.0"
   val ScalatestVersion               = "3.2.10"
   val ScalazVersion                  = "7.2.32"
   val Slf4jVersion                   = "1.7.32"
@@ -75,7 +75,8 @@ object Dependencies {
   lazy val mockitoCore           = "org.mockito"              % "mockito-core"                 % MockitoVersion         % "test"
   lazy val reactiveStreamsTck    = "org.reactivestreams"      % "reactive-streams-tck"         % ReactiveStreamsVersion % "test"
   lazy val scalaMock             = "org.scalamock"           %% "scalamock"                    % ScalamockVersion       % "test"
-  lazy val scalaTest             = "org.scalatest"           %% "scalatest"                    % ScalatestVersion       % "test"
+  lazy val scalaTestMain             = "org.scalatest"           %% "scalatest"                    % ScalatestVersion
+  lazy val scalaTest             = scalaTestMain       % "test"
   lazy val scalaTestPlusMokito   = "org.scalatestplus"       %% ScalatestPlusMockitoArtifactId % ScalatestPlusVersion
   lazy val scalaTestPlusTestng67 = "org.scalatestplus"       %% "testng-6-7"                   % ScalatestPlusVersion   % "test"
 


### PR DESCRIPTION
Had a look at how far we could get supporting scala 3. There's a release candidate for scala-modules-jackson which seems to work, although a lot of the subprojects depend on libs that aren't yet published.

Other issues:
- circe _should_ work, but for some reason the default implicit printer params in `indexableWithCirce` and `paramSerializerWithCirce` aren't being picked up. I can't yet minimise this -- _in general_ implicit defaults still work with scala 3 🤷 
- My sbt-fu isn't good enough to avoid some weird warts in the github workflows (seems like running `sbt ++$scalaVersion $command` runs the command against every aggregated subproject, even when they're not explicitly crossbuilt for that version. There _must_ be a way around this...)
- Some of the other required dependencies for other modules are already available as release candidates / milestones (e.g. zio-json and play-json); other than jackson, they're all pretty independent of each other, so I've left them alone for now until a release version is out.
- It's all dependent on the `exts` lib being crosspublished, which is why I made a [pr for that](https://github.com/sksamuel/exts/pull/27)