### PR TITLE
Add match-only-text field

### DIFF
--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/TextField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/TextField.scala
@@ -43,3 +43,7 @@ case class TextField(override val name: String,
 }
 
 case class IndexPrefixes(minChars: Int, maxChars: Int)
+
+case class MatchOnlyTextField(name: String, fields: List[ElasticField] = Nil) extends ElasticField {
+  override def `type`: String = "match_only_text"
+}

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/ElasticFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/ElasticFieldBuilderFn.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.elastic4s.handlers.fields
 
-import com.sksamuel.elastic4s.fields.{AggregateMetricField, AliasField, AnnotatedTextField, BinaryField, BooleanField, CompletionField, ConstantKeywordField, DateField, DateNanosField, DenseVectorField, DynamicField, ElasticField, FlattenedField, GeoPointField, GeoShapeField, HistogramField, IpField, IpRangeField, JoinField, KeywordField, Murmur3Field, NestedField, NumberField, ObjectField, PercolatorField, RangeField, RankFeatureField, RankFeaturesField, SearchAsYouTypeField, TextField, TokenCountField, VersionField, WildcardField}
+import com.sksamuel.elastic4s.fields.{AggregateMetricField, AliasField, AnnotatedTextField, BinaryField, BooleanField, CompletionField, ConstantKeywordField, DateField, DateNanosField, DenseVectorField, DynamicField, ElasticField, FlattenedField, GeoPointField, GeoShapeField, HistogramField, IpField, IpRangeField, JoinField, KeywordField, MatchOnlyTextField, Murmur3Field, NestedField, NumberField, ObjectField, PercolatorField, RangeField, RankFeatureField, RankFeaturesField, SearchAsYouTypeField, TextField, TokenCountField, VersionField, WildcardField}
 import com.sksamuel.elastic4s.json.XContentBuilder
 
 object ElasticFieldBuilderFn {
@@ -26,6 +26,7 @@ object ElasticFieldBuilderFn {
       case f: IpRangeField => IpRangeFieldBuilderFn.build(f)
       case f: JoinField => JoinFieldBuilderFn.build(f)
       case f: KeywordField => KeywordFieldBuilderFn.build(f)
+      case f: MatchOnlyTextField => MatchOnlyTextFieldBuilderFn.build(f)
       case f: Murmur3Field => Murmur3FieldBuilderFn.build(f)
       case f: NestedField => NestedFieldBuilderFn.build(f)
       case f: NumberField[_] => NumberFieldBuilderFn.build(f)

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/MatchOnlyTextFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/MatchOnlyTextFieldBuilderFn.scala
@@ -1,0 +1,21 @@
+package com.sksamuel.elastic4s.handlers.fields
+
+import com.sksamuel.elastic4s.fields.MatchOnlyTextField
+import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
+
+object MatchOnlyTextFieldBuilderFn {
+  def build(field: MatchOnlyTextField): XContentBuilder = {
+    val builder = XContentFactory.jsonBuilder()
+    builder.field("type", field.`type`)
+
+    if (field.fields.nonEmpty) {
+      builder.startObject("fields")
+      field.fields.foreach { field =>
+        builder.rawField(field.name, ElasticFieldBuilderFn(field))
+      }
+      builder.endObject()
+    }
+
+    builder.endObject()
+  }
+}


### PR DESCRIPTION
Applying this PR will add the match-only-text field, which was introduced in Elasticsearch 7.14 (https://www.elastic.co/guide/en/elasticsearch/reference/7.x/text.html#match-only-text-field-type).