### PR TITLE
Add support for case-insensitive prefix queries.

### DIFF
--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/queries/PrefixQueryBodyFnTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/queries/PrefixQueryBodyFnTest.scala
@@ -1,0 +1,17 @@
+package com.sksamuel.elastic4s.requests.searches.queries
+
+import com.sksamuel.elastic4s.handlers.searches.queries.term
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class PrefixQueryBodyFnTest extends AnyFunSuite with Matchers {
+
+  test("prefix query should generate expected json") {
+    val q = PrefixQuery("mysearch", "starts")
+      .boost(1.2)
+      .queryName("myquery")
+      .caseInsensitive(true)
+    term.PrefixQueryBodyFn(q).string() shouldBe
+      """{"prefix":{"mysearch":{"value":"starts","boost":1.2,"_name":"myquery","case_insensitive":true}}}"""
+  }
+}

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/PrefixQuery.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/PrefixQuery.scala
@@ -6,10 +6,12 @@ case class PrefixQuery(field: String,
                        prefix: Any,
                        boost: Option[Double] = None,
                        queryName: Option[String] = None,
-                       rewrite: Option[String] = None)
+                       rewrite: Option[String] = None,
+                       caseInsensitive: Option[Boolean] = None)
   extends MultiTermQuery {
 
   def queryName(queryName: String): PrefixQuery = copy(queryName = queryName.some)
   def boost(boost: Double): PrefixQuery = copy(boost = boost.some)
   def rewrite(rewrite: String): PrefixQuery = copy(rewrite = rewrite.some)
+  def caseInsensitive(caseInsensitive: Boolean): PrefixQuery = copy(caseInsensitive = caseInsensitive.some)
 }

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/searches/queries/term/PrefixQueryBodyFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/searches/queries/term/PrefixQueryBodyFn.scala
@@ -13,6 +13,7 @@ object PrefixQueryBodyFn {
     q.rewrite.foreach(builder.field("rewrite", _))
     q.boost.foreach(builder.field("boost", _))
     q.queryName.foreach(builder.field("_name", _))
+    q.caseInsensitive.foreach(builder.field("case_insensitive", _))
 
     builder.endObject().endObject().endObject()
   }


### PR DESCRIPTION
 Also add a test for prefix query body. This has been available in Elasticsearch since 7.10.0. See https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-prefix-query.html#prefix-query-field-params