### PR TITLE
Add support for case-insensitive term queries.

### DIFF
--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/queries/TermQueryBodyFnTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/queries/TermQueryBodyFnTest.scala
@@ -1,0 +1,18 @@
+package com.sksamuel.elastic4s.requests.searches.queries
+
+import com.sksamuel.elastic4s.handlers.searches.queries.term
+import com.sksamuel.elastic4s.requests.searches.term.TermQuery
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class TermQueryBodyFnTest extends AnyFunSuite with Matchers {
+
+  test("term query should generate expected json") {
+    val q = TermQuery("mysearch", "myvalue")
+      .boost(1.2)
+      .queryName("myquery")
+      .caseInsensitive(true)
+    term.TermQueryBodyFn(q).string() shouldBe
+      """{"term":{"mysearch":{"boost":1.2,"_name":"myquery","value":"myvalue","case_insensitive":true}}}"""
+  }
+}

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/term/TermQuery.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/term/TermQuery.scala
@@ -3,9 +3,14 @@ package com.sksamuel.elastic4s.requests.searches.term
 import com.sksamuel.elastic4s.requests.searches.queries.Query
 import com.sksamuel.exts.OptionImplicits.RichOptionImplicits
 
-case class TermQuery(field: String, value: Any, boost: Option[Double] = None, queryName: Option[String] = None)
+case class TermQuery(field: String,
+                     value: Any,
+                     boost: Option[Double] = None,
+                     queryName: Option[String] = None,
+                     caseInsensitive: Option[Boolean] = None)
   extends Query {
 
   def boost(boost: Double): TermQuery = copy(boost = boost.some)
   def queryName(queryName: String): TermQuery = copy(queryName = queryName.some)
+  def caseInsensitive(caseInsensitive: Boolean): TermQuery = copy(caseInsensitive = caseInsensitive.some)
 }

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/searches/queries/term/TermQueryBodyFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/searches/queries/term/TermQueryBodyFn.scala
@@ -13,6 +13,7 @@ object TermQueryBodyFn {
     t.boost.foreach(builder.field("boost", _))
     t.queryName.foreach(builder.field("_name", _))
     builder.autofield("value", t.value)
+    t.caseInsensitive.foreach(builder.field("case_insensitive", _))
 
     builder.endObject().endObject().endObject()
   }


### PR DESCRIPTION
Also add a test for query body. Another field supported since 7.10.0 see https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-term-query.html#term-field-params