### PR TITLE
Uncomment code for `aggregationsAsString`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -646,15 +646,20 @@ Check for the latest released versions on [maven central](http://search.maven.or
 
 ## Building and Testing
 
-This project is built with SBT. So to build
+This project is built with SBT. So to build with:
+
 ```scala
 sbt compile
 ```
 
-And to test
+And to test:
+
 ```scala
 sbt test
 ```
+The project is currently [cross-built](https://www.scala-sbt.org/1.x/docs/Cross-Build.html) against Scala 2.12 and
+2.13, when preparing a pull request the above commands should be run with the `sbt` `+` modifier to compile and test
+against both versions. For example: `sbt +compile`.
 
 For the tests to work you will need to run a local elastic instance on port 39227, _with security enabled_. One easy way of doing this is to use docker (via docker-compose):
 `docker-compose up`

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/SearchResponse.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/SearchResponse.scala
@@ -52,11 +52,11 @@ case class SearchResponse(
       .toMap
 
   def termSuggestion(name: String): Map[String, TermSuggestionResult] =
-    suggestion(name).mapValues(_.toTerm)
+    suggestion(name).mapValues(_.toTerm).toMap
   def completionSuggestion(name: String): Map[String, CompletionSuggestionResult] =
-    suggestion(name).mapValues(_.toCompletion)
+    suggestion(name).mapValues(_.toCompletion).toMap
   def phraseSuggestion(name: String): Map[String, PhraseSuggestionResult] =
-    suggestion(name).mapValues(_.toPhrase)
+    suggestion(name).mapValues(_.toPhrase).toMap
 
   def to[T: HitReader: ClassTag]: IndexedSeq[T] = hits.hits.map(_.to[T]).toIndexedSeq
   def safeTo[T: HitReader]: IndexedSeq[Try[T]] = hits.hits.map(_.safeTo[T]).toIndexedSeq

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/SearchResponse.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/SearchResponse.scala
@@ -2,21 +2,28 @@ package com.sksamuel.elastic4s.requests.searches
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.sksamuel.elastic4s.HitReader
+import com.sksamuel.elastic4s.json.{SourceAsContentBuilder, XContentBuilder}
 import com.sksamuel.elastic4s.requests.common.Shards
 import com.sksamuel.elastic4s.requests.searches.aggs.responses.Aggregations
-import com.sksamuel.elastic4s.requests.searches.suggestion.{CompletionSuggestionResult, PhraseSuggestionResult, SuggestionResult, TermSuggestionResult}
+import com.sksamuel.elastic4s.requests.searches.suggestion.{
+  CompletionSuggestionResult,
+  PhraseSuggestionResult,
+  SuggestionResult,
+  TermSuggestionResult
+}
 
 import scala.reflect.ClassTag
 import scala.util.Try
 
-case class SearchResponse(took: Long,
-                          @JsonProperty("timed_out") isTimedOut: Boolean,
-                          @JsonProperty("terminated_early") isTerminatedEarly: Boolean,
-                          private val suggest: Map[String, Seq[SuggestionResult]],
-                          @JsonProperty("_shards") private val _shards: Shards,
-                          @JsonProperty("_scroll_id") scrollId: Option[String],
-                          @JsonProperty("aggregations") private val _aggregationsAsMap: Map[String, Any],
-                          hits: SearchHits) {
+case class SearchResponse(
+    took: Long,
+    @JsonProperty("timed_out") isTimedOut: Boolean,
+    @JsonProperty("terminated_early") isTerminatedEarly: Boolean,
+    private val suggest: Map[String, Seq[SuggestionResult]],
+    @JsonProperty("_shards") private val _shards: Shards,
+    @JsonProperty("_scroll_id") scrollId: Option[String],
+    @JsonProperty("aggregations") private val _aggregationsAsMap: Map[String, Any],
+    hits: SearchHits) {
 
   def aggregationsAsMap: Map[String, Any] = Option(_aggregationsAsMap).getOrElse(Map.empty)
   def totalHits: Long = hits.total.value
@@ -29,8 +36,8 @@ case class SearchResponse(took: Long,
   def isEmpty: Boolean = hits.isEmpty
   def nonEmpty: Boolean = hits.nonEmpty
 
-//  lazy val aggsAsContentBuilder = SourceAsContentBuilder(aggregationsAsMap)
-//  lazy val aggregationsAsString: String = aggsAsContentBuilder.string()
+  lazy val aggsAsContentBuilder: XContentBuilder = SourceAsContentBuilder(aggregationsAsMap)
+  lazy val aggregationsAsString: String = aggsAsContentBuilder.string()
   def aggs: Aggregations = aggregations
   def aggregations: Aggregations = Aggregations(aggregationsAsMap)
 
@@ -44,10 +51,13 @@ case class SearchResponse(took: Long,
       }
       .toMap
 
-  def termSuggestion(name: String): Map[String, TermSuggestionResult] = suggestion(name).mapValues(_.toTerm).toMap
-  def completionSuggestion(name: String): Map[String, CompletionSuggestionResult] = suggestion(name).mapValues(_.toCompletion).toMap
-  def phraseSuggestion(name: String): Map[String, PhraseSuggestionResult] = suggestion(name).mapValues(_.toPhrase).toMap
+  def termSuggestion(name: String): Map[String, TermSuggestionResult] =
+    suggestion(name).mapValues(_.toTerm)
+  def completionSuggestion(name: String): Map[String, CompletionSuggestionResult] =
+    suggestion(name).mapValues(_.toCompletion)
+  def phraseSuggestion(name: String): Map[String, PhraseSuggestionResult] =
+    suggestion(name).mapValues(_.toPhrase)
 
-  def to[T: HitReader : ClassTag]: IndexedSeq[T] = hits.hits.map(_.to[T]).toIndexedSeq
+  def to[T: HitReader: ClassTag]: IndexedSeq[T] = hits.hits.map(_.to[T]).toIndexedSeq
   def safeTo[T: HitReader]: IndexedSeq[Try[T]] = hits.hits.map(_.safeTo[T]).toIndexedSeq
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/AggregationAsStringTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/searches/aggs/AggregationAsStringTest.scala
@@ -24,37 +24,52 @@ class AggregationAsStringTest extends AnyFunSuite with DockerTests with Matchers
     }
   }.await
 
-  client.execute(
-    bulk(
-      indexInto("aggstring") fields("name" -> "Willis Tower", "height" -> 1244),
-      indexInto("aggstring") fields("name" -> "Burj Kalifa", "height" -> 2456),
-      indexInto("aggstring") fields("name" -> "Tower of London", "height" -> 169)
-    ).refresh(RefreshPolicy.Immediate)
-  ).await
+  client
+    .execute(
+      bulk(
+        indexInto("aggstring") fields ("name" -> "Willis Tower", "height" -> 1244),
+        indexInto("aggstring") fields ("name" -> "Burj Kalifa", "height" -> 2456),
+        indexInto("aggstring") fields ("name" -> "Tower of London", "height" -> 169)
+      ).refresh(RefreshPolicy.Immediate)
+    )
+    .await
 
-  // todo
-//  test("agg as string should return aggregation json") {
-//    client.execute {
-//      search("aggstring").matchAllQuery().aggs(
-//        maxAgg("agg1", "height"),
-//        sumAgg("agg2", "height"),
-//        termsAgg("agg3", "name")
-//      )
-//    }.await.result.aggregationsAsString shouldBe
-//      """{"agg2":{"value":3869.0},"agg1":{"value":2456.0},"agg3":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"tower","doc_count":2},{"key":"burj","doc_count":1},{"key":"kalifa","doc_count":1},{"key":"london","doc_count":1},{"key":"of","doc_count":1},{"key":"willis","doc_count":1}]}}"""
-//  }
-//
-//  test("agg as string should return empty json when no aggregations are present") {
-//    client.execute {
-//      search("aggstring").matchAllQuery()
-//    }.await.result.aggregationsAsString shouldBe "{}"
-//  }
+  test("agg as string should return aggregation json") {
+    client
+      .execute {
+        search("aggstring")
+          .matchAllQuery()
+          .aggs(
+            maxAgg("agg1", "height"),
+            sumAgg("agg2", "height"),
+            termsAgg("agg3", "name")
+          )
+      }
+      .await
+      .result
+      .aggregationsAsString shouldBe
+      """{"agg2":{"value":3869.0},"agg1":{"value":2456.0},"agg3":{"doc_count_error_upper_bound":0,"sum_other_doc_count":0,"buckets":[{"key":"tower","doc_count":2},{"key":"burj","doc_count":1},{"key":"kalifa","doc_count":1},{"key":"london","doc_count":1},{"key":"of","doc_count":1},{"key":"willis","doc_count":1}]}}"""
+  }
 
+  test("agg as string should return empty json when no aggregations are present") {
+    client
+      .execute {
+        search("aggstring").matchAllQuery()
+      }
+      .await
+      .result
+      .aggregationsAsString shouldBe "{}"
+  }
 
   test("contains for not existent aggregation should return false") {
-    client.execute {
-      search("aggstring").matchAllQuery()
-    }.await.result.aggregations.contains("no_agg") shouldBe false
+    client
+      .execute {
+        search("aggstring").matchAllQuery()
+      }
+      .await
+      .result
+      .aggregations
+      .contains("no_agg") shouldBe false
   }
 
 }


### PR DESCRIPTION
The class `SearchResponse` was moved from 'elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches'
to the current location by commit 7f23247f927afa2e884b4ce6ead10bb5c10d86ce.
The only change to this class during this refactor was to comment out
two lines which made available returning the `Aggregations` as a
`String`.

This feature was added as part of sksamuel/elastic4s#909 and is still
useful.