### PR TITLE
Add support for calendarInterval and fixedInterval to DateHistogramValueSource

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/CompositeAggregation.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/CompositeAggregation.scala
@@ -1,5 +1,4 @@
 package com.sksamuel.elastic4s.requests.searches.aggs
-
 import com.sksamuel.elastic4s.requests.script.Script
 import com.sksamuel.elastic4s.requests.searches.DateHistogramInterval
 import com.sksamuel.elastic4s.requests.searches.aggs.responses.{AggBucket, BucketAggregation, HasAggregations}
@@ -10,14 +9,12 @@ sealed abstract class ValueSource(val valueSourceType: String, val name: String,
                                   val script: Option[Script],
                                   val order: Option[String],
                                   val missingBucket: Boolean)
-
 case class TermsValueSource(override val name: String,
                             override val field: Option[String] = None,
                             override val script: Option[Script] = None,
                             override val order: Option[String] = None,
                             override val missingBucket: Boolean = false)
   extends ValueSource("terms", name, field, script, order, missingBucket)
-
 case class HistogramValueSource(override val name: String,
                                 interval: Int,
                                 override val field: Option[String] = None,
@@ -27,8 +24,8 @@ case class HistogramValueSource(override val name: String,
   extends ValueSource("histogram", name, field, script, order, missingBucket)
 
 case class DateHistogramValueSource(override val name: String,
-                                    calendarInterval: Option[DateHistogramInterval] = None,
-                                    fixedInterval: Option[DateHistogramInterval] = None,
+                                    calendarInterval: Option[String] = None,
+                                    fixedInterval: Option[String] = None,
                                     interval: Option[String] = None,
                                     override val field: Option[String] = None,
                                     override val script: Option[Script] = None,
@@ -37,22 +34,6 @@ case class DateHistogramValueSource(override val name: String,
                                     format: Option[String] = None,
                                     override val missingBucket: Boolean = false)
   extends ValueSource("date_histogram", name, field, script, order, missingBucket)
-
-object DateHistogramValueSource {
-  def apply(
-             name: String,
-             interval: String,
-             field: Option[String] = None,
-             script: Option[Script] = None,
-             order: Option[String] = None,
-             timeZone: Option[String] = None,
-             format: Option[String] = None,
-             missingBucket: Boolean = false
-           ): DateHistogramValueSource = {
-    DateHistogramValueSource(name, interval, field, script, order, timeZone, format, missingBucket)
-  }
-}
-
 case class CompositeAggregation(name: String,
                                 sources: Seq[ValueSource] = Nil,
                                 size: Option[Int] = None,
@@ -60,41 +41,33 @@ case class CompositeAggregation(name: String,
                                 metadata: Map[String, AnyRef] = Map.empty,
                                 after: Option[Map[String, Any]] = None)
   extends Aggregation {
-
   type T = CompositeAggregation
-
   def sources(sources: Seq[ValueSource]): CompositeAggregation = copy(sources = sources)
-
   def size(size: Int): CompositeAggregation = copy(size = size.some)
-
   def after(after: Map[String, Any]): CompositeAggregation = copy(after = after.some)
-
   override def subAggregations(aggs: Iterable[AbstractAggregation]): T = copy(subaggs = aggs.toSeq)
-
   override def metadata(map: Map[String, AnyRef]): T = copy(metadata = map)
 }
-
 /*
  * Responses
  */
 object CompositeAggregation {
 
   case class CompositeAggBucket(
-    key: Map[String,Any],
-    docCount: Long,
-    override val data: Map[String, Any]
-  ) extends AggBucket with HasAggregations
+                                 key: Map[String,Any],
+                                 docCount: Long,
+                                 override val data: Map[String, Any]
+                               ) extends AggBucket with HasAggregations
 
   case class CompositeAggregationResult(
-    name: String,
-    buckets: Seq[CompositeAggBucket],
-    afterKey: Option[Map[String, Any]],
-    private val data: Map[String, Any]
-  ) extends BucketAggregation
+                                         name: String,
+                                         buckets: Seq[CompositeAggBucket],
+                                         afterKey: Option[Map[String, Any]],
+                                         private val data: Map[String, Any]
+                                       ) extends BucketAggregation
 
   implicit class CompositeAggResult(aggs: HasAggregations){
     def compositeAgg(name: String) : CompositeAggregationResult = {
-
       val data = aggs.dataAsMap(name).asInstanceOf[Map[String,Any]]
       val buckets = data("buckets").asInstanceOf[Seq[Map[String, Any]]].map( v  =>
         CompositeAggBucket(
@@ -103,7 +76,6 @@ object CompositeAggregation {
           data = v
         )
       )
-
       CompositeAggregationResult(
         name = name,
         buckets = buckets,

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/CompositeAggregation.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/CompositeAggregation.scala
@@ -1,6 +1,7 @@
 package com.sksamuel.elastic4s.requests.searches.aggs
 
 import com.sksamuel.elastic4s.requests.script.Script
+import com.sksamuel.elastic4s.requests.searches.DateHistogramInterval
 import com.sksamuel.elastic4s.requests.searches.aggs.responses.{AggBucket, BucketAggregation, HasAggregations}
 import com.sksamuel.exts.OptionImplicits._
 
@@ -26,7 +27,9 @@ case class HistogramValueSource(override val name: String,
   extends ValueSource("histogram", name, field, script, order, missingBucket)
 
 case class DateHistogramValueSource(override val name: String,
-                                    interval: String,
+                                    calendarInterval: Option[DateHistogramInterval] = None,
+                                    fixedInterval: Option[DateHistogramInterval] = None,
+                                    interval: Option[String] = None,
                                     override val field: Option[String] = None,
                                     override val script: Option[Script] = None,
                                     override val order: Option[String] = None,
@@ -35,6 +38,20 @@ case class DateHistogramValueSource(override val name: String,
                                     override val missingBucket: Boolean = false)
   extends ValueSource("date_histogram", name, field, script, order, missingBucket)
 
+object DateHistogramValueSource {
+  def apply(
+             name: String,
+             interval: String,
+             field: Option[String] = None,
+             script: Option[Script] = None,
+             order: Option[String] = None,
+             timeZone: Option[String] = None,
+             format: Option[String] = None,
+             missingBucket: Boolean = false
+           ): DateHistogramValueSource = {
+    DateHistogramValueSource(name, interval, field, script, order, timeZone, format, missingBucket)
+  }
+}
 
 case class CompositeAggregation(name: String,
                                 sources: Seq[ValueSource] = Nil,

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/CompositeAggregationBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/CompositeAggregationBuilder.scala
@@ -22,8 +22,16 @@ object CompositeAggregationBuilder {
       if (s.missingBucket) builder.field("missing_bucket", true)
       s match {
         case HistogramValueSource(_, interval, _, _, _, _) => builder.field("interval", interval)
-        case DateHistogramValueSource(_, interval, _, _, _, timeZone, format, _) =>
-          builder.field("interval", interval)
+        case DateHistogramValueSource(_, None, None, interval, _, _, _, timeZone, format, _) =>
+          builder.field("interval", interval.get)
+          timeZone.foreach(builder.field("time_zone", _))
+          format.foreach(builder.field("format", _))
+        case DateHistogramValueSource(_, calendarInterval, None, None, _, _, _, timeZone, format, _) =>
+          builder.field("calendar_interval", calendarInterval.get.toString)
+          timeZone.foreach(builder.field("time_zone", _))
+          format.foreach(builder.field("format", _))
+        case DateHistogramValueSource(_, None, fixedInterval, None, _, _, _, timeZone, format, _) =>
+          builder.field("fixed_interval", fixedInterval.get.toString)
           timeZone.foreach(builder.field("time_zone", _))
           format.foreach(builder.field("format", _))
         case _ =>

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/CompositeAggregationBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/CompositeAggregationBuilder.scala
@@ -1,15 +1,12 @@
 package com.sksamuel.elastic4s.requests.searches.aggs.builders
 
 import com.sksamuel.elastic4s.handlers.script
-import com.sksamuel.elastic4s.handlers.script.ScriptBuilderFn
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 import com.sksamuel.elastic4s.requests.searches.aggs.{CompositeAggregation, DateHistogramValueSource, HistogramValueSource, SubAggsBuilderFn}
 
 object CompositeAggregationBuilder {
-
   def apply(agg: CompositeAggregation): XContentBuilder = {
     val builder = XContentFactory.jsonBuilder().startObject("composite")
-
     agg.size.foreach(builder.field("size", _))
     builder.startArray("sources")
     agg.sources.foreach(s => {
@@ -22,16 +19,16 @@ object CompositeAggregationBuilder {
       if (s.missingBucket) builder.field("missing_bucket", true)
       s match {
         case HistogramValueSource(_, interval, _, _, _, _) => builder.field("interval", interval)
-        case DateHistogramValueSource(_, None, None, interval, _, _, _, timeZone, format, _) =>
-          builder.field("interval", interval.get)
-          timeZone.foreach(builder.field("time_zone", _))
-          format.foreach(builder.field("format", _))
         case DateHistogramValueSource(_, calendarInterval, None, None, _, _, _, timeZone, format, _) =>
-          builder.field("calendar_interval", calendarInterval.get.toString)
+          builder.field("calendar_interval", calendarInterval.get)
           timeZone.foreach(builder.field("time_zone", _))
           format.foreach(builder.field("format", _))
         case DateHistogramValueSource(_, None, fixedInterval, None, _, _, _, timeZone, format, _) =>
-          builder.field("fixed_interval", fixedInterval.get.toString)
+          builder.field("fixed_interval", fixedInterval.get)
+          timeZone.foreach(builder.field("time_zone", _))
+          format.foreach(builder.field("format", _))
+        case DateHistogramValueSource(_, None, None, interval, _, _, _, timeZone, format, _) =>
+          builder.field("interval", interval.get)
           timeZone.foreach(builder.field("time_zone", _))
           format.foreach(builder.field("format", _))
         case _ =>
@@ -43,14 +40,11 @@ object CompositeAggregationBuilder {
     builder.endArray()
     agg.after.map(afterMap => {
       builder.startObject("after")
-      afterMap.map { case (k,v) => builder.autofield(k,v) }
+      afterMap.map { case (k, v) => builder.autofield(k, v) }
       builder.endObject()
     })
     builder.endObject()
-
     SubAggsBuilderFn(agg, builder)
-
     builder
   }
-
 }

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/CompositeAggregationBuilderTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/CompositeAggregationBuilderTest.scala
@@ -13,7 +13,6 @@ class CompositeAggregationBuilderTest extends AnyFunSuite with Matchers {
         TermsValueSource("s1", field = Some("f1")))
       )
     )
-
     SearchBodyBuilderFn(search).string() shouldBe
       """{"aggs":{"comp":{"composite":{"sources":[{"s1":{"terms":{"field":"f1"}}}]}}}}"""
   }
@@ -25,7 +24,6 @@ class CompositeAggregationBuilderTest extends AnyFunSuite with Matchers {
         TermsValueSource("s2", field = Some("f2"))
       ))
     )
-
     SearchBodyBuilderFn(search).string() shouldBe
       """{"aggs":{"comp":{"composite":{"sources":[{"s1":{"terms":{"field":"f1"}}},{"s2":{"terms":{"field":"f2"}}}]}}}}"""
   }
@@ -36,7 +34,6 @@ class CompositeAggregationBuilderTest extends AnyFunSuite with Matchers {
         TermsValueSource("s1", script = Some(Script("doc['product'].value"))))
       )
     )
-
     SearchBodyBuilderFn(search).string() shouldBe
       """{"aggs":{"comp":{"composite":{"sources":[{"s1":{"terms":{"script":{"source":"doc['product'].value"}}}}]}}}}"""
   }
@@ -46,13 +43,12 @@ class CompositeAggregationBuilderTest extends AnyFunSuite with Matchers {
       CompositeAggregation("comp", sources = Seq(
         TermsValueSource("s1", field = Some("f1"), order = Some("desc"), missingBucket = true),
         HistogramValueSource("s2", 5, field = Some("f2"), order = Some("desc"), missingBucket = true),
-        DateHistogramValueSource("s3", "5d", field = Some("f3"), order = Some("desc"), timeZone = Some("+01:00"), missingBucket = true)
+        DateHistogramValueSource("s3", interval = Some("5d"), field = Some("f3"), order = Some("desc"), timeZone = Some("+01:00"), missingBucket = true)
       ))
     )
 
     SearchBodyBuilderFn(search).string() shouldBe
       """{"aggs":{"comp":{"composite":{"sources":[{"s1":{"terms":{"field":"f1","order":"desc","missing_bucket":true}}},{"s2":{"histogram":{"field":"f2","order":"desc","missing_bucket":true,"interval":5}}},{"s3":{"date_histogram":{"field":"f3","order":"desc","missing_bucket":true,"interval":"5d","time_zone":"+01:00"}}}]}}}}"""
-
   }
 
   test("CompositeAggregationBuilder should build simple terms-valued composites with after parameters") {
@@ -62,7 +58,6 @@ class CompositeAggregationBuilderTest extends AnyFunSuite with Matchers {
         after = Some(Map("myafter1" -> 1, "myafter2" -> "2"))
       )
     )
-
     SearchBodyBuilderFn(search).string() shouldBe
       """{"aggs":{"comp":{"composite":{"sources":[{"s1":{"terms":{"field":"f1"}}}],"after":{"myafter1":1,"myafter2":"2"}}}}}"""
   }


### PR DESCRIPTION
Changes made due to deprecated warns in project logs from Elasticsearch - field interval is deprecated in Elasticsearch and should not be used.

Added support for `calendarInterval` and `fixedInterval` to `DateHistogramValueSource` case class. 
Added handling of these parameters to `CompositeAggregationBuilder`.

Due to change made in `DateHistogramValueSource` case class - interval is now an Option, just as `calendarInterval` and `fixedInterval` - there is no backward compatibility, `interval` is deprecated and will be removed from Elasticsearch in the future.