### PR TITLE
Add support for Stored Script APIs

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticApi.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.elastic4s
 
-import com.sksamuel.elastic4s.api.{AggregationApi, AliasesApi, AnalyzeApi, AnalyzerApi, BulkApi, CatsApi, ClearRolesCacheApi, ClusterApi, CollapseApi, CountApi, CreateIndexApi, CreateRoleApi, CreateUserApi, DeleteApi, DeleteIndexApi, DeleteRoleApi, DeleteUserApi, ExistsApi, ExplainApi, ForceMergeApi, GetApi, HighlightApi, IndexAdminApi, IndexApi, IndexRecoveryApi, IndexTemplateApi, IngestApi, LocksApi, MappingApi, NodesApi, NormalizerApi, PipelineAggregationApi, QueryApi, ReindexApi, RoleApi, ScoreApi, ScriptApi, ScrollApi, SearchApi, SearchTemplateApi, SettingsApi, SnapshotApi, SortApi, SuggestionApi, TaskApi, TermVectorApi, TokenFilterApi, TokenizerApi, TypesApi, UpdateApi, UserAdminApi, UserApi, ValidateApi}
+import com.sksamuel.elastic4s.api.{AggregationApi, AliasesApi, AnalyzeApi, AnalyzerApi, BulkApi, CatsApi, ClearRolesCacheApi, ClusterApi, CollapseApi, CountApi, CreateIndexApi, CreateRoleApi, CreateUserApi, DeleteApi, DeleteIndexApi, DeleteRoleApi, DeleteUserApi, ExistsApi, ExplainApi, ForceMergeApi, GetApi, HighlightApi, IndexAdminApi, IndexApi, IndexRecoveryApi, IndexTemplateApi, IngestApi, LocksApi, MappingApi, NodesApi, NormalizerApi, PipelineAggregationApi, QueryApi, ReindexApi, RoleApi, ScoreApi, ScriptApi, ScrollApi, SearchApi, SearchTemplateApi, SettingsApi, SnapshotApi, SortApi, StoredScriptApi, SuggestionApi, TaskApi, TermVectorApi, TokenFilterApi, TokenizerApi, TypesApi, UpdateApi, UserAdminApi, UserApi, ValidateApi}
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
@@ -50,6 +50,7 @@ trait ElasticApi
     with SettingsApi
     with SnapshotApi
     with SortApi
+    with StoredScriptApi
     with SuggestionApi
     with TaskApi
     with TermVectorApi

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticDsl.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticDsl.scala
@@ -14,6 +14,7 @@ import com.sksamuel.elastic4s.handlers.index.{IndexAdminHandlers, IndexHandlers,
 import com.sksamuel.elastic4s.handlers.locks.LocksHandlers
 import com.sksamuel.elastic4s.handlers.nodes.NodesHandlers
 import com.sksamuel.elastic4s.handlers.reindex.ReindexHandlers
+import com.sksamuel.elastic4s.handlers.script.StoredScriptHandlers
 import com.sksamuel.elastic4s.handlers.security.roles.{RoleAdminHandlers, RoleHandlers}
 import com.sksamuel.elastic4s.handlers.security.users.{UserAdminHandlers, UserHandlers}
 import com.sksamuel.elastic4s.handlers.settings.SettingsHandlers
@@ -54,6 +55,7 @@ trait ElasticDsl
     with SearchScrollHandlers
     with SettingsHandlers
     with SnapshotHandlers
+    with StoredScriptHandlers
     with UpdateHandlers
     with TaskHandlers
     with TermVectorHandlers

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/api/StoredScriptApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/api/StoredScriptApi.scala
@@ -1,0 +1,10 @@
+package com.sksamuel.elastic4s.api
+
+import com.sksamuel.elastic4s.requests.script.{DeleteStoredScriptRequest, GetStoredScriptRequest, PutStoredScriptRequest, StoredScriptSource}
+
+trait StoredScriptApi {
+
+  def getStoredScript(id: String): GetStoredScriptRequest = GetStoredScriptRequest(id)
+  def deleteStoredScript(id: String): DeleteStoredScriptRequest = DeleteStoredScriptRequest(id)
+  def putStoredScript(id: String, script: StoredScriptSource): PutStoredScriptRequest = PutStoredScriptRequest(id, script)
+}

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/script/DeleteStoredScriptRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/script/DeleteStoredScriptRequest.scala
@@ -1,0 +1,3 @@
+package com.sksamuel.elastic4s.requests.script
+
+case class DeleteStoredScriptRequest(id: String)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/script/DeleteStoredScriptResponse.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/script/DeleteStoredScriptResponse.scala
@@ -1,0 +1,3 @@
+package com.sksamuel.elastic4s.requests.script
+
+case class DeleteStoredScriptResponse(acknowledged: Boolean)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/script/GetStoredScriptRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/script/GetStoredScriptRequest.scala
@@ -1,0 +1,3 @@
+package com.sksamuel.elastic4s.requests.script
+
+case class GetStoredScriptRequest(id: String)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/script/GetStoredScriptResponse.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/script/GetStoredScriptResponse.scala
@@ -1,0 +1,7 @@
+package com.sksamuel.elastic4s.requests.script
+
+case class GetStoredScriptResponse(
+  _id: String,
+  found: Boolean,
+  script: StoredScriptSource
+)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/script/PutStoredScriptRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/script/PutStoredScriptRequest.scala
@@ -1,0 +1,3 @@
+package com.sksamuel.elastic4s.requests.script
+
+case class PutStoredScriptRequest(id: String, script: StoredScriptSource)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/script/PutStoredScriptResponse.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/script/PutStoredScriptResponse.scala
@@ -1,0 +1,3 @@
+package com.sksamuel.elastic4s.requests.script
+
+case class PutStoredScriptResponse(acknowledged: Boolean)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/script/StoredScriptSource.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/script/StoredScriptSource.scala
@@ -1,0 +1,3 @@
+package com.sksamuel.elastic4s.requests.script
+
+case class StoredScriptSource(lang: String, source: String)

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/script/StoredScriptHandlers.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/script/StoredScriptHandlers.scala
@@ -1,0 +1,45 @@
+package com.sksamuel.elastic4s.handlers.script
+
+import com.sksamuel.elastic4s.requests.script.{
+  DeleteStoredScriptRequest,
+  DeleteStoredScriptResponse,
+  GetStoredScriptRequest,
+  GetStoredScriptResponse,
+  PutStoredScriptRequest,
+  PutStoredScriptResponse
+}
+import com.sksamuel.elastic4s.json.XContentFactory
+import com.sksamuel.elastic4s._
+
+trait StoredScriptHandlers {
+
+  implicit object DeleteStoredScriptHandler extends Handler[DeleteStoredScriptRequest, DeleteStoredScriptResponse] {
+    override def build(request: DeleteStoredScriptRequest): ElasticRequest = {
+      val endpoint = "/_scripts/" + request.id
+      ElasticRequest("DELETE", endpoint)
+    }
+  }
+
+  implicit object GetStoredScriptHandler extends Handler[GetStoredScriptRequest, GetStoredScriptResponse] {
+    override def build(request: GetStoredScriptRequest): ElasticRequest = {
+      val endpoint = "/_scripts/" + request.id
+      ElasticRequest("GET", endpoint)
+    }
+  }
+
+  implicit object PutStoredScriptHandler extends Handler[PutStoredScriptRequest, PutStoredScriptResponse] {
+    override def build(request: PutStoredScriptRequest): ElasticRequest = {
+      val endpoint = "/_scripts/" + request.id
+
+      val builder = XContentFactory.jsonBuilder()
+      builder.startObject("script")
+      builder.field("lang", request.script.lang)
+      builder.field("source", request.script.source)
+      builder.endObject()
+
+      ElasticRequest("PUT", endpoint, HttpEntity(builder.string()))
+    }
+  }
+}
+
+object StoredScriptHandlers extends StoredScriptHandlers

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/script/PutStoredScriptHttpTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/script/PutStoredScriptHttpTest.scala
@@ -1,0 +1,29 @@
+package com.sksamuel.elastic4s.requests.script
+
+import com.sksamuel.elastic4s.testkit.DockerTests
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
+
+class PutStoredScriptHttpTest extends AnyFunSuite with Matchers with DockerTests {
+
+  test("put stored script should upload new script") {
+    val storedScriptId = "putscripttest"
+    val storedScript = StoredScriptSource("painless", "_score")
+
+    Try {
+      client.execute {
+        deleteStoredScript(storedScriptId)
+      }.await
+    }
+
+    client.execute {
+      putStoredScript(storedScriptId, storedScript)
+    }.await
+
+    client.execute {
+      getStoredScript(storedScriptId)
+    }.await.result shouldBe GetStoredScriptResponse(storedScriptId, found=true, storedScript)
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/sksamuel/elastic4s/issues/2537

Adds support for all 3 Stored Scripts APIs

 * Put stored script
 * Get stored script
 * Delete stored script

Stored Scripts APIs Documentation: 

https://www.elastic.co/guide/en/elasticsearch/reference/current/script-apis.html#stored-script-apis

