### PR TITLE
Add support for getting Cluster settings

### DIFF
--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/cluster/settings.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/cluster/settings.scala
@@ -1,5 +1,7 @@
 package com.sksamuel.elastic4s.requests.cluster
 
+case class GetClusterSettingsRequest()
+
 case class ClusterSettingsRequest(persistentSettings: Map[String, String], transientSettings: Map[String, String]) {
 
   def persistentSettings(settings: Map[String, String]): ClusterSettingsRequest =

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/cluster/ClusterHandlers.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/cluster/ClusterHandlers.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.elastic4s.handlers.cluster
 
-import com.sksamuel.elastic4s.requests.cluster.{AddRemoteClusterResponse, AddRemoteClusterSettingsRequest, ClusterHealthRequest, ClusterHealthResponse, ClusterSettingsRequest, ClusterSettingsResponse, ClusterStateRequest, ClusterStateResponse, ClusterStatsRequest, ClusterStatsResponse, RemoteClusterInfo, RemoteClusterInfoRequest}
+import com.sksamuel.elastic4s.requests.cluster.{AddRemoteClusterResponse, AddRemoteClusterSettingsRequest, ClusterHealthRequest, ClusterHealthResponse, ClusterSettingsRequest, ClusterSettingsResponse, ClusterStateRequest, ClusterStateResponse, ClusterStatsRequest, ClusterStatsResponse, GetClusterSettingsRequest, RemoteClusterInfo, RemoteClusterInfoRequest}
 import com.sksamuel.elastic4s.{ElasticRequest, Handler, HttpEntity}
 
 trait ClusterHandlers {
@@ -23,6 +23,12 @@ trait ClusterHandlers {
         ""
       else
         "/" + indices.mkString(",")
+  }
+
+  implicit object GetClusterSettingsHandler extends Handler[GetClusterSettingsRequest, ClusterSettingsResponse] {
+    override def build(request: GetClusterSettingsRequest): ElasticRequest = {
+      ElasticRequest("GET", "/_cluster/settings", Map("flat_settings" -> true))
+    }
   }
 
   implicit object ClusterSettingsHandler extends Handler[ClusterSettingsRequest, ClusterSettingsResponse] {


### PR DESCRIPTION
There's already existing support for putting a cluster setting, this change adds support for _reading_ all cluster settings (delivered in the 'flat' key-value format, rather than a nested JSON structure).

https://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-get-settings.html#cluster-get-settings-api-query-params
