### PR TITLE
Use unified Scaladex badge on ReadMe to show which Scala versions are supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@ elastic4s - Elasticsearch Scala Client
 =========
 
 ![master](https://github.com/sksamuel/elastic4s/workflows/master/badge.svg)
-[<img src="https://img.shields.io/maven-central/v/com.sksamuel.elastic4s/elastic4s-core_2.12.svg?label=latest%20release%20for%202.12"/>](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22elastic4s-core_2.12%22)
-[<img src="https://img.shields.io/maven-central/v/com.sksamuel.elastic4s/elastic4s-core_2.13.svg?label=latest%20release%20for%202.13"/>](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22elastic4s-core_2.13%22)
+[![elastic4s-core Scala version support](https://index.scala-lang.org/sksamuel/elastic4s/elastic4s-core/latest-by-scala-version.svg)](https://index.scala-lang.org/sksamuel/elastic4s/elastic4s-core)
 [<img src="https://img.shields.io/nexus/s/https/oss.sonatype.org/com.sksamuel.elastic4s/elastic4s-core_2.13.svg?label=latest%20snapshot&style=plastic"/>](https://oss.sonatype.org/content/repositories/snapshots/com/sksamuel/elastic4s/)
 
 Elastic4s is a concise, idiomatic, reactive, type safe Scala client for Elasticsearch. The official Elasticsearch Java client can of course be used in Scala, but due to Java's syntax it is more verbose and it naturally doesn't support classes in the core Scala core library nor Scala idioms such as typeclass support.


### PR DESCRIPTION
This unified Scaladex badge summarises which versions of Scala are supported by `elastic4s`, and what the latest `elastic4s` version is for each of those Scala versions, so you don't need to add a new badge every time a new version of Scala is supported:

[![elastic4s-core Scala version support](https://index.scala-lang.org/sksamuel/elastic4s/elastic4s-core/latest-by-scala-version.svg)](https://index.scala-lang.org/sksamuel/elastic4s/elastic4s-core)

In-situ in the ReadMe file:

![image](https://user-images.githubusercontent.com/52038/145377688-6d78a95f-5ae8-4c0b-89f8-a24f7c550892.png)


More details on the badge format: https://github.com/scalacenter/scaladex/pull/660