### PR TITLE
IndexMappings to ElasticField

### DIFF
--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/AggregateMetricField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/AggregateMetricField.scala
@@ -1,5 +1,8 @@
 package com.sksamuel.elastic4s.fields
 
+object AggregateMetricField {
+  val `type` = "aggregate_metric_double"
+}
 case class AggregateMetricField(name: String, metrics: Seq[String], defaultMetric: String) extends ElasticField {
-  override def `type`: String = "aggregate_metric_double"
+  override def `type`: String = AggregateMetricField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/AliasField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/AliasField.scala
@@ -1,6 +1,9 @@
 package com.sksamuel.elastic4s.fields
 
+object AliasField {
+  val `type` = "alias"
+}
 case class AliasField(name: String,
                       path: String) extends ElasticField {
-  override def `type`: String = "alias"
+  override def `type`: String = AliasField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/AnnotatedTextField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/AnnotatedTextField.scala
@@ -1,5 +1,8 @@
 package com.sksamuel.elastic4s.fields
 
+object AnnotatedTextField {
+  val `type` = "annotated_text"
+}
 case class AnnotatedTextField(name: String) extends ElasticField {
-  override def `type`: String = "annotated_text"
+  override def `type`: String = AnnotatedTextField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/BinaryField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/BinaryField.scala
@@ -1,7 +1,10 @@
 package com.sksamuel.elastic4s.fields
 
+object BinaryField {
+  val `type`: String = "binary"
+}
 case class BinaryField(name: String,
                        docValues: Option[Boolean] = None,
                        store: Option[Boolean] = None) extends ElasticField {
-  override def `type`: String = "binary"
+  override def `type`: String = BinaryField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/BooleanField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/BooleanField.scala
@@ -1,12 +1,16 @@
 package com.sksamuel.elastic4s.fields
 
+object BooleanField {
+  val `type`: String = "boolean"
+}
+
 case class BooleanField(name: String,
-                        boost: Option[Double] = None,
-                        copyTo: Seq[String] = Nil, // https://www.elastic.co/guide/en/elasticsearch/reference/current/copy-to.html
-                        docValues: Option[Boolean] = None,
-                        index: Option[Boolean] = None,
-                        nullValue: Option[Boolean] = None,
-                        store: Option[Boolean] = None,
-                        meta: Map[String, Any] = Map.empty) extends ElasticField {
-  override def `type`: String = "boolean"
+  boost: Option[Double] = None,
+  copyTo: Seq[String] = Nil, // https://www.elastic.co/guide/en/elasticsearch/reference/current/copy-to.html
+  docValues: Option[Boolean] = None,
+  index: Option[Boolean] = None,
+  nullValue: Option[Boolean] = None,
+  store: Option[Boolean] = None,
+  meta: Map[String, Any] = Map.empty) extends ElasticField {
+  override def `type`: String = BooleanField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/ByteField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/ByteField.scala
@@ -1,5 +1,8 @@
 package com.sksamuel.elastic4s.fields
 
+object ByteField {
+  val `type`: String = "byte"
+}
 case class ByteField(name: String,
                      boost: Option[Double] = None,
                      coerce: Option[Boolean] = None,
@@ -10,5 +13,5 @@ case class ByteField(name: String,
                      nullValue: Option[Byte] = None,
                      store: Option[Boolean] = None,
                      meta: Map[String, Any] = Map.empty) extends NumberField[Byte] {
-  override def `type`: String = "byte"
+  override def `type`: String = ByteField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/CompletionField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/CompletionField.scala
@@ -2,6 +2,9 @@ package com.sksamuel.elastic4s.fields
 
 import com.sksamuel.exts.OptionImplicits.RichOptionImplicits
 
+object CompletionField {
+  val `type`: String = "completion"
+}
 case class CompletionField(name: String,
                            analyzer: Option[String] = None,
                            boost: Option[Double] = None,
@@ -21,7 +24,7 @@ case class CompletionField(name: String,
                            termVector: Option[String] = None,
                            contexts: Seq[ContextField] = Nil,
                            meta: Map[String, Any] = Map.empty) extends ElasticField {
-  override def `type`: String = "completion"
+  override def `type`: String = CompletionField.`type`
 
   def analyzer(name: String): CompletionField = copy(analyzer = name.some)
   def searchAnalyzer(name: String): CompletionField = copy(searchAnalyzer = name.some)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/ConstantKeywordField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/ConstantKeywordField.scala
@@ -1,5 +1,8 @@
 package com.sksamuel.elastic4s.fields
 
+object ConstantKeywordField {
+  val `type`: String = "constant_keyword"
+}
 case class ConstantKeywordField(override val name: String, value: String) extends ElasticField {
-  override def `type`: String = "constant_keyword"
+  override def `type`: String = ConstantKeywordField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DateField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DateField.scala
@@ -2,6 +2,9 @@ package com.sksamuel.elastic4s.fields
 
 import com.sksamuel.exts.OptionImplicits.RichOptionImplicits
 
+object DateField {
+  val `type`: String = "date"
+}
 // https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html
 case class DateField(name: String,
                      boost: Option[Double] = None,
@@ -14,13 +17,21 @@ case class DateField(name: String,
                      nullValue: Option[String] = None,
                      store: Option[Boolean] = None,
                      meta: Map[String, Any] = Map.empty) extends ElasticField {
-  override def `type`: String = "date"
+  override def `type`: String = DateField.`type`
+
   def format(format: String): DateField = copy(format = format.some)
+
   def boost(boost: Double): DateField = copy(boost = boost.some)
+
   def docValues(docValues: Boolean): DateField = copy(docValues = docValues.some)
+
   def locale(locale: String): DateField = copy(locale = locale.some)
+
   def ignoreMalformed(ignoreMalformed: Boolean): DateField = copy(ignoreMalformed = ignoreMalformed.some)
+
   def index(index: Boolean): DateField = copy(index = index.some)
+
   def nullValue(nullValue: String): DateField = copy(nullValue = nullValue.some)
+
   def store(store: Boolean): DateField = copy(store = store.some)
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DateNanosField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DateNanosField.scala
@@ -1,5 +1,8 @@
 package com.sksamuel.elastic4s.fields
 
+object DateNanosField {
+  val `type`: String = "date_nanos"
+}
 case class DateNanosField(name: String,
                           boost: Option[Double] = None,
                           copyTo: Seq[String] = Nil,
@@ -11,5 +14,5 @@ case class DateNanosField(name: String,
                           nullValue: Option[String] = None,
                           store: Option[Boolean] = None,
                           meta: Map[String, Any] = Map.empty) extends ElasticField {
-  override def `type`: String = "date_nanos"
+  override def `type`: String = DateNanosField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DateRangeField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DateRangeField.scala
@@ -1,10 +1,13 @@
 package com.sksamuel.elastic4s.fields
 
+object DateRangeField {
+  val `type`: String = "date_range"
+}
 case class DateRangeField(name: String,
                           boost: Option[Double] = None,
                           coerce: Option[Boolean] = None,
                           index: Option[Boolean] = None,
                           format: Option[String] = None,
                           store: Option[Boolean] = None) extends RangeField {
-  override def `type`: String = "date_range"
+  override def `type`: String = DateRangeField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DenseVectorField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DenseVectorField.scala
@@ -1,6 +1,9 @@
 package com.sksamuel.elastic4s.fields
 
+object DenseVectorField {
+  val `type`: String = "dense_vector"
+}
 case class DenseVectorField(name: String,
                             dims: Int) extends ElasticField {
-  override def `type`: String = "dense_vector"
+  override def `type`: String = DenseVectorField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DoubleField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DoubleField.scala
@@ -2,6 +2,9 @@ package com.sksamuel.elastic4s.fields
 
 import com.sksamuel.exts.OptionImplicits.RichOptionImplicits
 
+object DoubleField {
+  val `type`: String = "double"
+}
 case class DoubleField(name: String,
                        boost: Option[Double] = None,
                        coerce: Option[Boolean] = None,
@@ -12,9 +15,13 @@ case class DoubleField(name: String,
                        nullValue: Option[Double] = None,
                        store: Option[Boolean] = None,
                        meta: Map[String, Any] = Map.empty) extends NumberField[Double] {
-  override def `type`: String = "double"
+  override def `type`: String = DoubleField.`type`
+
   def coerce(coerce: Boolean): DoubleField = copy(coerce = coerce.some)
+
   def stored(store: Boolean): DoubleField = copy(store = store.some)
+
   def ignoreMalformed(ignoreMalformed: Boolean): DoubleField = copy(ignoreMalformed = ignoreMalformed.some)
+
   def boost(boost: Double): DoubleField = copy(boost = boost.some)
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DoubleRangeField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DoubleRangeField.scala
@@ -1,9 +1,12 @@
 package com.sksamuel.elastic4s.fields
 
+object DoubleRangeField {
+  val `type`: String = "double_range"
+}
 case class DoubleRangeField(name: String,
                             boost: Option[Double] = None,
                             coerce: Option[Boolean] = None,
                             index: Option[Boolean] = None,
                             store: Option[Boolean] = None) extends RangeField {
-  override def `type`: String = "double_range"
+  override def `type`: String = DoubleRangeField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/FlattenedField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/FlattenedField.scala
@@ -1,5 +1,8 @@
 package com.sksamuel.elastic4s.fields
 
+object FlattenedField {
+  val `type`: String = "flattened"
+}
 case class FlattenedField(name: String,
                           boost: Option[Double] = None,
                           docValues: Option[Boolean] = None,
@@ -12,5 +15,5 @@ case class FlattenedField(name: String,
                           similarity: Option[String] = None,
                           splitQueriesOnWhitespace: Option[Boolean] = None,
                           meta: Map[String, String] = Map.empty) extends ElasticField {
-  override def `type`: String = "flattened"
+  override def `type`: String = FlattenedField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/FloatField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/FloatField.scala
@@ -1,5 +1,8 @@
 package com.sksamuel.elastic4s.fields
 
+object FloatField {
+  val `type`: String = "float"
+}
 case class FloatField(name: String,
                       boost: Option[Double] = None,
                       coerce: Option[Boolean] = None,
@@ -10,5 +13,5 @@ case class FloatField(name: String,
                       nullValue: Option[Float] = None,
                       store: Option[Boolean] = None,
                       meta: Map[String, Any] = Map.empty) extends NumberField[Float] {
-  override def `type`: String = "float"
+  override def `type`: String = FloatField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/FloatRangeField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/FloatRangeField.scala
@@ -1,9 +1,12 @@
 package com.sksamuel.elastic4s.fields
 
+object FloatRangeField {
+  val `type`: String = "float_range"
+}
 case class FloatRangeField(name: String,
                            boost: Option[Double] = None,
                            coerce: Option[Boolean] = None,
                            index: Option[Boolean] = None,
                            store: Option[Boolean] = None) extends RangeField {
-  override def `type`: String = "float_range"
+  override def `type`: String = FloatRangeField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/GeoPointField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/GeoPointField.scala
@@ -2,6 +2,9 @@ package com.sksamuel.elastic4s.fields
 
 import com.sksamuel.exts.OptionImplicits.RichOptionImplicits
 
+object GeoPointField {
+  val `type`: String = "geo_point"
+}
 case class GeoPointField(name: String,
                          boost: Option[Double] = None,
                          copyTo: Seq[String] = Nil,
@@ -13,6 +16,7 @@ case class GeoPointField(name: String,
                          nullValue: Option[String] = None,
                          store: Option[Boolean] = None,
                          meta: Map[String, Any] = Map.empty) extends ElasticField {
-  override def `type`: String = "geo_point"
+  override def `type`: String = GeoPointField.`type`
+
   def docValues(docValues: Boolean): GeoPointField = copy(docValues = docValues.some)
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/GeoShapeField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/GeoShapeField.scala
@@ -2,6 +2,9 @@ package com.sksamuel.elastic4s.fields
 
 import com.sksamuel.exts.OptionImplicits.RichOptionImplicits
 
+object GeoShapeField {
+  val `type`: String = "geo_shape"
+}
 case class GeoShapeField(name: String,
                          boost: Option[Double] = None,
                          copyTo: Seq[String] = Nil,
@@ -20,7 +23,7 @@ case class GeoShapeField(name: String,
                          pointsOnly: Option[Boolean] = None,
                          treeLevels: Option[String] = None,
                          meta: Map[String, Any] = Map.empty) extends ElasticField {
-  override def `type`: String = "geo_shape"
+  override def `type`: String = GeoShapeField.`type`
 
   def tree(tree: String): GeoShapeField = copy(tree = tree.some)
   def precision(precision: String): GeoShapeField = copy(precision = precision.some)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/HalfFloatField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/HalfFloatField.scala
@@ -1,5 +1,8 @@
 package com.sksamuel.elastic4s.fields
 
+object HalfFloatField {
+  val `type`: String = "half_float"
+}
 case class HalfFloatField(name: String,
                           boost: Option[Double] = None,
                           coerce: Option[Boolean] = None,
@@ -10,5 +13,5 @@ case class HalfFloatField(name: String,
                           nullValue: Option[Float] = None,
                           store: Option[Boolean] = None,
                           meta: Map[String, Any] = Map.empty) extends NumberField[Float] {
-  override def `type`: String = "half_float"
+  override def `type`: String = HalfFloatField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/HistogramField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/HistogramField.scala
@@ -1,5 +1,8 @@
 package com.sksamuel.elastic4s.fields
 
+object HistogramField {
+  val `type`: String = "histogram"
+}
 case class HistogramField(name: String) extends ElasticField {
-  override def `type`: String = "histogram"
+  override def `type`: String = HistogramField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/IntegerField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/IntegerField.scala
@@ -2,6 +2,9 @@ package com.sksamuel.elastic4s.fields
 
 import com.sksamuel.exts.OptionImplicits.RichOptionImplicits
 
+object IntegerField {
+  val `type`: String = "integer"
+}
 case class IntegerField(name: String,
                         boost: Option[Double] = None,
                         coerce: Option[Boolean] = None,
@@ -12,8 +15,11 @@ case class IntegerField(name: String,
                         nullValue: Option[Int] = None,
                         store: Option[Boolean] = None,
                         meta: Map[String, Any] = Map.empty) extends NumberField[Int] {
-  override def `type`: String = "integer"
+  override def `type`: String = IntegerField.`type`
+
   def coerce(coerce: Boolean): IntegerField = copy(coerce = coerce.some)
+
   def stored(store: Boolean): IntegerField = copy(store = store.some)
+
   def nullValue(nullValue: Int): IntegerField = copy(nullValue = nullValue.some)
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/IntegerRangeField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/IntegerRangeField.scala
@@ -1,9 +1,12 @@
 package com.sksamuel.elastic4s.fields
 
+object IntegerRangeField {
+  val `type`: String = "integer_range"
+}
 case class IntegerRangeField(name: String,
                              boost: Option[Double] = None,
                              coerce: Option[Boolean] = None,
                              index: Option[Boolean] = None,
                              store: Option[Boolean] = None) extends RangeField {
-  override def `type`: String = "integer_range"
+  override def `type`: String = IntegerRangeField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/IpField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/IpField.scala
@@ -2,6 +2,9 @@ package com.sksamuel.elastic4s.fields
 
 import com.sksamuel.exts.OptionImplicits.RichOptionImplicits
 
+object IpField {
+  val `type`: String = "ip"
+}
 case class IpField(name: String,
                    boost: Option[Double] = None,
                    docValues: Option[Boolean] = None,
@@ -9,6 +12,7 @@ case class IpField(name: String,
                    index: Option[Boolean] = None,
                    nullValue: Option[String] = None,
                    store: Option[Boolean] = None) extends ElasticField {
-  override def `type`: String = "ip"
+  override def `type`: String = IpField.`type`
+
   def boost(boost: Double): IpField = copy(boost = boost.some)
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/IpRangeField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/IpRangeField.scala
@@ -1,5 +1,8 @@
 package com.sksamuel.elastic4s.fields
 
+object IpRangeField {
+  val `type`: String = "ip_range"
+}
 case class IpRangeField(name: String,
                         boost: Option[Double] = None,
                         coerce: Option[Boolean] = None,

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/JoinField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/JoinField.scala
@@ -1,9 +1,13 @@
 package com.sksamuel.elastic4s.fields
 
+object JoinField {
+  val `type`: String = "join"
+}
 case class JoinField(name: String,
                      eagerGlobalOrdinals: Option[Boolean] = None,
                      relations: Map[String, Any] = Map.empty,
                      meta: Map[String, Any] = Map.empty) extends ElasticField {
-  override def `type`: String = "join"
+  override def `type`: String = JoinField.`type`
+
   def relation(name: String, value: Any): JoinField = copy(relations = relations + (name -> value))
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/KeywordField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/KeywordField.scala
@@ -2,6 +2,9 @@ package com.sksamuel.elastic4s.fields
 
 import com.sksamuel.exts.OptionImplicits.RichOptionImplicits
 
+object KeywordField {
+  val `type`: String = "keyword"
+}
 // https://www.elastic.co/guide/en/elasticsearch/reference/current/keyword.html#keyword-field-type
 case class KeywordField(name: String,
                         boost: Option[Double] = None,
@@ -20,6 +23,7 @@ case class KeywordField(name: String,
                         store: Option[Boolean] = None,
                         termVector: Option[String] = None,
                         meta: Map[String, String] = Map.empty) extends ElasticField {
-  override def `type`: String = "keyword"
+  override def `type`: String = KeywordField.`type`
+
   def normalizer(normalizer: String): KeywordField = copy(normalizer = normalizer.some)
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/LongField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/LongField.scala
@@ -1,5 +1,8 @@
 package com.sksamuel.elastic4s.fields
 
+object LongField {
+  val `type`: String = "long"
+}
 case class LongField(name: String,
                      boost: Option[Double] = None,
                      coerce: Option[Boolean] = None,
@@ -10,5 +13,5 @@ case class LongField(name: String,
                      store: Option[Boolean] = None,
                      nullValue: Option[Long] = None,
                      meta: Map[String, Any] = Map.empty) extends NumberField[Long] {
-  override def `type`: String = "long"
+  override def `type`: String = LongField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/LongRangeField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/LongRangeField.scala
@@ -1,9 +1,12 @@
 package com.sksamuel.elastic4s.fields
 
+object LongRangeField {
+  val `type`: String = "long_range"
+}
 case class LongRangeField(name: String,
                           boost: Option[Double] = None,
                           coerce: Option[Boolean] = None,
                           index: Option[Boolean] = None,
                           store: Option[Boolean] = None) extends RangeField {
-  override def `type`: String = "long_range"
+  override def `type`: String = LongRangeField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/Murmur3Field.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/Murmur3Field.scala
@@ -1,5 +1,8 @@
 package com.sksamuel.elastic4s.fields
 
+object Murmur3Field {
+  val `type`: String = "murmur3"
+}
 case class Murmur3Field(name: String) extends ElasticField {
-  override def `type`: String = "murmur3"
+  override def `type`: String = Murmur3Field.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/NestedField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/NestedField.scala
@@ -2,19 +2,27 @@ package com.sksamuel.elastic4s.fields
 
 import com.sksamuel.exts.OptionImplicits.RichOptionImplicits
 
+object NestedField {
+  val `type`: String = "nested"
+}
 case class NestedField(name: String,
                        dynamic: Option[String] = None,
                        enabled: Option[Boolean] = None,
                        properties: Seq[ElasticField] = Nil,
                        includeInParent: Option[Boolean] = None,
                        includeInRoot: Option[Boolean] = None) extends ElasticField {
-  override def `type`: String = "nested"
+  override def `type`: String = NestedField.`type`
+
   def dynamic(d: Boolean): NestedField = dynamic(d.toString)
+
   def dynamic(d: String): NestedField = copy(dynamic = d.some)
+
   def includeInRoot(includeInRoot: Boolean): NestedField = copy(includeInRoot = includeInRoot.some)
+
   def includeInParent(includeInParent: Boolean): NestedField = copy(includeInParent = includeInParent.some)
 
   def fields(fields: ElasticField*): NestedField = copy(properties = fields.toList)
+
   def fields(fields: Iterable[ElasticField]): NestedField = copy(properties = fields.toList)
 
   def properties(properties: ElasticField*): NestedField = copy(properties = properties.toList)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/ObjectField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/ObjectField.scala
@@ -1,8 +1,11 @@
 package com.sksamuel.elastic4s.fields
 
+object ObjectField {
+  val `type`: String = "object"
+}
 case class ObjectField(name: String,
                        dynamic: Option[String] = None,
                        enabled: Option[Boolean] = None,
                        properties: Seq[ElasticField] = Nil) extends ElasticField {
-  override def `type`: String = "object"
+  override def `type`: String = ObjectField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/PercolatorField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/PercolatorField.scala
@@ -1,5 +1,8 @@
 package com.sksamuel.elastic4s.fields
 
+object PercolatorField {
+  val `type`: String = "percolator"
+}
 case class PercolatorField(name: String) extends ElasticField {
-  override def `type`: String = "percolator"
+  override def `type`: String = PercolatorField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/RankFeatureField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/RankFeatureField.scala
@@ -1,6 +1,9 @@
 package com.sksamuel.elastic4s.fields
 
+object RankFeatureField {
+  val `type`: String = "rank_feature"
+}
 case class RankFeatureField(name: String,
                             positiveScoreImpact: Option[Boolean] = None) extends ElasticField {
-  override def `type`: String = "rank_feature"
+  override def `type`: String = RankFeatureField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/RankFeaturesField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/RankFeaturesField.scala
@@ -1,5 +1,8 @@
 package com.sksamuel.elastic4s.fields
 
+object RankFeaturesField {
+  val `type`: String = "rank_features"
+}
 case class RankFeaturesField(name: String) extends ElasticField {
-  override def `type`: String = "rank_features"
+  override def `type`: String = RankFeaturesField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/ScaledFloatField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/ScaledFloatField.scala
@@ -1,5 +1,8 @@
 package com.sksamuel.elastic4s.fields
 
+object ScaledFloatField {
+  val `type`: String = "scaled_float"
+}
 case class ScaledFloatField(name: String,
                             boost: Option[Double] = None,
                             coerce: Option[Boolean] = None,

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/SearchAsYouTypeField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/SearchAsYouTypeField.scala
@@ -2,6 +2,9 @@ package com.sksamuel.elastic4s.fields
 
 import com.sksamuel.exts.OptionImplicits.RichOptionImplicits
 
+object SearchAsYouTypeField {
+  val `type`: String = "search_as_you_type"
+}
 case class SearchAsYouTypeField(name: String,
                                 analyzer: Option[String] = None,
                                 searchAnalyzer: Option[String] = None,
@@ -19,7 +22,7 @@ case class SearchAsYouTypeField(name: String,
                                 termVector: Option[String] = None,
                                 meta: Map[String, String] = Map.empty) extends ElasticField {
 
-  override def `type`: String = "search_as_you_type"
+  override def `type`: String = SearchAsYouTypeField.`type`
 
   def analyzer(name: String): SearchAsYouTypeField = copy(analyzer = Option(name))
   def searchAnalyzer(name: String): SearchAsYouTypeField = copy(searchAnalyzer = Option(name))

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/ShapeField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/ShapeField.scala
@@ -1,5 +1,8 @@
 package com.sksamuel.elastic4s.fields
 
+object ShapeField {
+  val `type`: String = "shape"
+}
 case class ShapeField(name: String,
                       boost: Option[Double] = None,
                       coerce: Option[Boolean] = None,
@@ -12,5 +15,5 @@ case class ShapeField(name: String,
                       store: Option[Boolean] = None,
                       orientation: Option[String] = None,
                       meta: Map[String, Any] = Map.empty) extends ElasticField {
-  override def `type`: String = "shape"
+  override def `type`: String = ShapeField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/ShortField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/ShortField.scala
@@ -1,5 +1,8 @@
 package com.sksamuel.elastic4s.fields
 
+object ShortField {
+  val `type`: String = "short"
+}
 case class ShortField(name: String,
                       boost: Option[Double] = None,
                       coerce: Option[Boolean] = None,
@@ -11,5 +14,5 @@ case class ShortField(name: String,
                       nullValue: Option[Short] = None,
                       store: Option[Boolean] = None,
                       meta: Map[String, Any] = Map.empty) extends NumberField[Short] {
-  override def `type`: String = "short"
+  override def `type`: String = ShortField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/TextField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/TextField.scala
@@ -3,6 +3,9 @@ package com.sksamuel.elastic4s.fields
 import com.sksamuel.elastic4s.requests.mappings.FielddataFrequencyFilter
 import com.sksamuel.exts.OptionImplicits.RichOptionImplicits
 
+object TextField {
+  val `type`: String = "text"
+}
 case class TextField(override val name: String,
                      analyzer: Option[String] = None,
                      boost: Option[Double] = None,
@@ -23,15 +26,24 @@ case class TextField(override val name: String,
                      store: Option[Boolean] = None,
                      termVector: Option[String] = None,
                      meta: Map[String, String] = Map.empty) extends ElasticField {
-  override def `type`: String = "text"
+  override def `type`: String = TextField.`type`
+
   def analyzer(name: String): TextField = copy(analyzer = Option(name))
+
   def searchAnalyzer(name: String): TextField = copy(searchAnalyzer = Option(name))
+
   def searchQuoteAnalyzer(name: String): TextField = copy(searchQuoteAnalyzer = Option(name))
+
   def copyTo(copyTo: String*): TextField = copy(copyTo = copyTo.toList)
+
   def copyTo(copyTo: Iterable[String]): TextField = copy(copyTo = copyTo.toList)
+
   def fielddata(fielddata: Boolean): TextField = copy(fielddata = fielddata.some)
+
   def fields(fields: ElasticField*): TextField = copy(fields = fields.toList)
+
   def fields(fields: Iterable[ElasticField]): TextField = copy(fields = fields.toList)
+
   def stored(store: Boolean): TextField = copy(store = store.some)
   def index(index: Boolean): TextField = copy(index = index.some)
   def indexOptions(indexOptions: String): TextField = copy(indexOptions = indexOptions.some)
@@ -44,6 +56,9 @@ case class TextField(override val name: String,
 
 case class IndexPrefixes(minChars: Int, maxChars: Int)
 
+object MatchOnlyTextField {
+  val `type`: String = "match_only_text"
+}
 case class MatchOnlyTextField(name: String, fields: List[ElasticField] = Nil) extends ElasticField {
-  override def `type`: String = "match_only_text"
+  override def `type`: String = MatchOnlyTextField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/TokenCountField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/TokenCountField.scala
@@ -1,5 +1,8 @@
 package com.sksamuel.elastic4s.fields
 
+object TokenCountField {
+  val `type`: String = "token_count"
+}
 case class TokenCountField(name: String,
                            analyzer: Option[String] = None,
                            boost: Option[Double] = None,
@@ -10,5 +13,5 @@ case class TokenCountField(name: String,
                            nullValue: Option[String] = None,
                            store: Option[Boolean] = None,
                            meta: Map[String, Any] = Map.empty) extends ElasticField {
-  override def `type`: String = "token_count"
+  override def `type`: String = TokenCountField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/UnsignedLongField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/UnsignedLongField.scala
@@ -1,5 +1,8 @@
 package com.sksamuel.elastic4s.fields
 
+object UnsignedLongField {
+  val `type`: String = "unsigned_long"
+}
 case class UnsignedLongField(name: String,
                              boost: Option[Double] = None,
                              coerce: Option[Boolean] = None,
@@ -10,5 +13,5 @@ case class UnsignedLongField(name: String,
                              store: Option[Boolean] = None,
                              nullValue: Option[Long] = None,
                              meta: Map[String, Any] = Map.empty) extends NumberField[Long] {
-  override def `type`: String = "unsigned_long"
+  override def `type`: String = UnsignedLongField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/UnsignedLongStringField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/UnsignedLongStringField.scala
@@ -1,5 +1,8 @@
 package com.sksamuel.elastic4s.fields
 
+object UnsignedLongStringField {
+  val `type`: String = "unsigned_long"
+}
 case class UnsignedLongStringField(name: String,
                                     boost: Option[Double] = None,
                                     coerce: Option[Boolean] = None,
@@ -10,5 +13,5 @@ case class UnsignedLongStringField(name: String,
                                     store: Option[Boolean] = None,
                                     nullValue: Option[String] = None,
                                     meta: Map[String, Any] = Map.empty) extends NumberField[String] {
-  override def `type`: String = "unsigned_long"
+  override def `type`: String = UnsignedLongStringField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/VersionField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/VersionField.scala
@@ -1,5 +1,8 @@
 package com.sksamuel.elastic4s.fields
 
+object VersionField {
+  val `type`: String = "version"
+}
 case class VersionField(name: String) extends ElasticField {
-  override def `type`: String = "version"
+  override def `type`: String = VersionField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/WildcardField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/WildcardField.scala
@@ -2,13 +2,18 @@ package com.sksamuel.elastic4s.fields
 
 import com.sksamuel.exts.OptionImplicits.RichOptionImplicits
 
+object WildcardField {
+  val `type`: String = "wildcard"
+}
 // As of version 7.9, Elasticsearch only supports the ignore_above and null_value
 // parameters on wildcard fields.
 // See https://www.elastic.co/guide/en/elasticsearch/reference/7.9/keyword.html#wildcard-field-type
 case class WildcardField(override val name: String,
                          ignoreAbove: Option[Int] = None,
                          nullValue: Option[String] = None) extends ElasticField {
-  override def `type`: String = "wildcard"
+  override def `type`: String = WildcardField.`type`
+
   def ignoreAbove(ignoreAbove: Int): WildcardField = copy(ignoreAbove = ignoreAbove.some)
+
   def nullValue(nullValue: String): WildcardField = copy(nullValue = nullValue.some)
 }

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/AggregateMetricFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/AggregateMetricFieldBuilderFn.scala
@@ -4,6 +4,10 @@ import com.sksamuel.elastic4s.fields.AggregateMetricField
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
 object AggregateMetricFieldBuilderFn {
+  def toField(name: String, values: Map[String, Any]): AggregateMetricField = {
+    AggregateMetricField(name, values.get("metrics").map(_.asInstanceOf[Seq[String]]).getOrElse(Seq.empty), values.get("default_metric").map(_.asInstanceOf[String]).get)
+  }
+
   def build(field: AggregateMetricField): XContentBuilder = {
     val builder = XContentFactory.jsonBuilder()
     builder.field("type", field.`type`)

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/AliasFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/AliasFieldBuilderFn.scala
@@ -4,6 +4,10 @@ import com.sksamuel.elastic4s.fields.AliasField
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
 object AliasFieldBuilderFn {
+  def toField(name: String, values: Map[String, Any]): AliasField = {
+    AliasField(name, values.get("path").map(_.asInstanceOf[String]).get)
+  }
+
   def build(field: AliasField): XContentBuilder = {
     val builder = XContentFactory.jsonBuilder()
     builder.field("type", field.`type`)

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/AnnotatedTextFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/AnnotatedTextFieldBuilderFn.scala
@@ -4,6 +4,8 @@ import com.sksamuel.elastic4s.fields.AnnotatedTextField
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
 object AnnotatedTextFieldBuilderFn {
+  def toField(name: String, values: Map[String, Any]): AnnotatedTextField = AnnotatedTextField(name)
+
   def build(field: AnnotatedTextField): XContentBuilder = {
 
     val builder = XContentFactory.jsonBuilder()

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/BinaryFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/BinaryFieldBuilderFn.scala
@@ -4,6 +4,13 @@ import com.sksamuel.elastic4s.fields.BinaryField
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
 object BinaryFieldBuilderFn {
+  def toField(name: String, values: Map[String, Any]): BinaryField =
+    BinaryField(
+      name,
+      values.get("doc_values").map(_.asInstanceOf[Boolean]),
+      values.get("store").map(_.asInstanceOf[Boolean])
+    )
+
   def build(field: BinaryField): XContentBuilder = {
     val builder = XContentFactory.jsonBuilder()
     builder.field("type", field.`type`)

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/BooleanFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/BooleanFieldBuilderFn.scala
@@ -4,6 +4,17 @@ import com.sksamuel.elastic4s.fields.BooleanField
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
 object BooleanFieldBuilderFn {
+  def toField(name: String, values: Map[String, Any]): BooleanField =
+    BooleanField(
+      name,
+      values.get("boost").map(_.asInstanceOf[Double]),
+      values.get("copy_to").map(_.asInstanceOf[Seq[String]]).getOrElse(Seq.empty),
+      values.get("doc_values").map(_.asInstanceOf[Boolean]),
+      values.get("index").map(_.asInstanceOf[Boolean]),
+      values.get("null_value").map(_.asInstanceOf[Boolean]),
+      values.get("store").map(_.asInstanceOf[Boolean])
+    )
+
 
   def build(field: BooleanField): XContentBuilder = {
 

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/CompletionFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/CompletionFieldBuilderFn.scala
@@ -1,9 +1,37 @@
 package com.sksamuel.elastic4s.handlers.fields
 
-import com.sksamuel.elastic4s.fields.CompletionField
+import com.sksamuel.elastic4s.fields.{CompletionField, ContextField}
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
 object CompletionFieldBuilderFn {
+  private def toContextField(values: Map[String, Any]) = ContextField(
+    values.get("name").map(_.asInstanceOf[String]).get,
+    values.get("type").map(_.asInstanceOf[String]).get,
+    values.get("path").map(_.asInstanceOf[String]),
+    values.get("precision").map(_.asInstanceOf[Int])
+  )
+
+  def toField(name: String, values: Map[String, Any]): CompletionField = CompletionField(
+    name,
+    values.get("analyzer").map(_.asInstanceOf[String]),
+    values.get("boost").map(_.asInstanceOf[Double]),
+    values.get("copy_to").map(_.asInstanceOf[Seq[String]]).getOrElse(Seq.empty),
+    values.get("index").map(_.asInstanceOf[Boolean]),
+    values.get("index_options").map(_.asInstanceOf[String]),
+    values.get("ignore_above").map(_.asInstanceOf[Int]),
+    values.get("ignore_malformed").map(_.asInstanceOf[Boolean]),
+    values.get("max_input_length").map(_.asInstanceOf[Int]),
+    values.get("norms").map(_.asInstanceOf[Boolean]),
+    values.get("null_value").map(_.asInstanceOf[String]),
+    values.get("preserve_separators").map(_.asInstanceOf[Boolean]),
+    values.get("preserve_position_increments").map(_.asInstanceOf[Boolean]),
+    values.get("similarity").map(_.asInstanceOf[String]),
+    values.get("search_analyzer").map(_.asInstanceOf[String]),
+    values.get("store").map(_.asInstanceOf[Boolean]),
+    values.get("term_vector").map(_.asInstanceOf[String]),
+    values.get("contexts").map(_.asInstanceOf[Seq[Map[String, Any]]]).map(_.map(toContextField)).getOrElse(Seq.empty)
+  )
+
 
   def build(field: CompletionField): XContentBuilder = {
 

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/ConstantKeywordFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/ConstantKeywordFieldBuilderFn.scala
@@ -4,6 +4,11 @@ import com.sksamuel.elastic4s.fields.ConstantKeywordField
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
 object ConstantKeywordFieldBuilderFn {
+  def toField(name: String, values: Map[String, Any]): ConstantKeywordField = ConstantKeywordField(
+    name,
+    values.get("value").map(_.asInstanceOf[String]).get
+  )
+
 
   def build(field: ConstantKeywordField): XContentBuilder = {
     val builder = XContentFactory.jsonBuilder()

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/DateFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/DateFieldBuilderFn.scala
@@ -4,6 +4,19 @@ import com.sksamuel.elastic4s.fields.DateField
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
 object DateFieldBuilderFn {
+  def toField(name: String, values: Map[String, Any]): DateField = DateField(
+    name,
+    values.get("boost").map(_.asInstanceOf[Double]),
+    values.get("copy_to").map(_.asInstanceOf[Seq[String]]).getOrElse(Seq.empty),
+    values.get("doc_values").map(_.asInstanceOf[Boolean]),
+    values.get("format").map(_.asInstanceOf[String]),
+    values.get("locale").map(_.asInstanceOf[String]),
+    values.get("ignore_malformed").map(_.asInstanceOf[Boolean]),
+    values.get("index").map(_.asInstanceOf[Boolean]),
+    values.get("null_value").map(_.asInstanceOf[String]),
+    values.get("store").map(_.asInstanceOf[Boolean])
+  )
+
 
   def build(field: DateField): XContentBuilder = {
 

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/DateNanosFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/DateNanosFieldBuilderFn.scala
@@ -4,6 +4,19 @@ import com.sksamuel.elastic4s.fields.DateNanosField
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
 object DateNanosFieldBuilderFn {
+  def toField(name: String, values: Map[String, Any]): DateNanosField = DateNanosField(
+    name,
+    values.get("boost").map(_.asInstanceOf[Double]),
+    values.get("copy_to").map(_.asInstanceOf[Seq[String]]).getOrElse(Seq.empty),
+    values.get("doc_values").map(_.asInstanceOf[Boolean]),
+    values.get("format").map(_.asInstanceOf[String]),
+    values.get("locale").map(_.asInstanceOf[String]),
+    values.get("ignore_malformed").map(_.asInstanceOf[Boolean]),
+    values.get("index").map(_.asInstanceOf[Boolean]),
+    values.get("null_value").map(_.asInstanceOf[String]),
+    values.get("store").map(_.asInstanceOf[Boolean])
+  )
+
 
   def build(field: DateNanosField): XContentBuilder = {
 

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/DenseVectorFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/DenseVectorFieldBuilderFn.scala
@@ -4,6 +4,11 @@ import com.sksamuel.elastic4s.fields.DenseVectorField
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
 object DenseVectorFieldBuilderFn {
+  def toField(name: String, values: Map[String, Any]): DenseVectorField = DenseVectorField(
+    name,
+    values.get("dims").map(_.asInstanceOf[Int]).get
+  )
+
 
   def build(field: DenseVectorField): XContentBuilder = {
 

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/ElasticFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/ElasticFieldBuilderFn.scala
@@ -42,4 +42,41 @@ object ElasticFieldBuilderFn {
       case f: WildcardField => WildcardFieldBuilderFn.build(f)
     }
   }
+
+  def construct(name: String, values: Map[String, Any]): ElasticField = {
+    values.get("type").collect {
+      case AggregateMetricField.`type` => AggregateMetricFieldBuilderFn.toField(name, values)
+      case AliasField.`type` => AliasFieldBuilderFn.toField(name, values)
+      case AnnotatedTextField.`type` => AnnotatedTextFieldBuilderFn.toField(name, values)
+      case BinaryField.`type` => BinaryFieldBuilderFn.toField(name, values)
+      case BooleanField.`type` => BooleanFieldBuilderFn.toField(name, values)
+      case ConstantKeywordField.`type` => ConstantKeywordFieldBuilderFn.toField(name, values)
+      case CompletionField.`type` => CompletionFieldBuilderFn.toField(name, values)
+      case DateField.`type` => DateFieldBuilderFn.toField(name, values)
+      case DateNanosField.`type` => DateNanosFieldBuilderFn.toField(name, values)
+      case DenseVectorField.`type` => DenseVectorFieldBuilderFn.toField(name, values)
+      case FlattenedField.`type` => FlattenedFieldBuilderFn.toField(name, values)
+      case GeoPointField.`type` => GeoPointFieldBuilderFn.toField(name, values)
+      case GeoShapeField.`type` => GeoShapeFieldBuilderFn.toField(name, values)
+      case HistogramField.`type` => HistogramFieldBuilderFn.toField(name, values)
+      case IpField.`type` => IpFieldBuilderFn.toField(name, values)
+      case IpRangeField.`type` => IpRangeFieldBuilderFn.toField(name, values)
+      case JoinField.`type` => JoinFieldBuilderFn.toField(name, values)
+      case KeywordField.`type` => KeywordFieldBuilderFn.toField(name, values)
+      case MatchOnlyTextField.`type` => MatchOnlyTextFieldBuilderFn.toField(name, values)
+      case Murmur3Field.`type` => Murmur3FieldBuilderFn.toField(name, values)
+      case NestedField.`type` => NestedFieldBuilderFn.toField(name, values)
+      case ObjectField.`type` => ObjectFieldBuilderFn.toField(name, values)
+      case PercolatorField.`type` => PercolatorFieldBuilderFn.toField(name, values)
+      case RankFeatureField.`type` => RankFeatureFieldBuilderFn.toField(name, values)
+      case RankFeaturesField.`type` => RankFeaturesFieldBuilderFn.toField(name, values)
+      case SearchAsYouTypeField.`type` => SearchAsYouTypeFieldBuilderFn.toField(name, values)
+      case TextField.`type` => TextFieldBuilderFn.toField(name, values)
+      case TokenCountField.`type` => TokenCountFieldBuilderFn.toField(name, values)
+      case VersionField.`type` => VersionFieldBuilderFn.toField(name, values)
+      case WildcardField.`type` => WildcardFieldBuilderFn.toField(name, values)
+      case rangeType: String if RangeFieldBuilderFn.supportedTypes.contains(rangeType) => RangeFieldBuilderFn.toField(rangeType, name, values)
+      case numberType: String if NumberFieldBuilderFn.supportedTypes.contains(numberType) => NumberFieldBuilderFn.toField(numberType, name, values)
+    }.orElse(values.get("properties").map(_ => ObjectFieldBuilderFn.toField(name, values))).getOrElse(throw new RuntimeException(s"Could not convert mapping for '$name' to an ElasticField"))
+  }
 }

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/FlattenedFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/FlattenedFieldBuilderFn.scala
@@ -4,6 +4,20 @@ import com.sksamuel.elastic4s.fields.FlattenedField
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
 object FlattenedFieldBuilderFn {
+  def toField(name: String, values: Map[String, Any]): FlattenedField = FlattenedField(
+    name,
+    values.get("boost").map(_.asInstanceOf[Double]),
+    values.get("doc_values").map(_.asInstanceOf[Boolean]),
+    values.get("depth_limit").map(_.asInstanceOf[Int]),
+    values.get("eager_global_ordinals").map(_.asInstanceOf[Boolean]),
+    values.get("ignore_above").map(_.asInstanceOf[Int]),
+    values.get("index").map(_.asInstanceOf[Boolean]),
+    values.get("index_options").map(_.asInstanceOf[String]),
+    values.get("null_value").map(_.asInstanceOf[String]),
+    values.get("similarity").map(_.asInstanceOf[String]),
+    values.get("split_queries_on_whitespace").map(_.asInstanceOf[Boolean])
+  )
+
   def build(field: FlattenedField): XContentBuilder = {
     val builder = XContentFactory.jsonBuilder()
     builder.field("type", field.`type`)

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/GeoPointFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/GeoPointFieldBuilderFn.scala
@@ -4,6 +4,19 @@ import com.sksamuel.elastic4s.fields.GeoPointField
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
 object GeoPointFieldBuilderFn {
+  def toField(name: String, values: Map[String, Any]): GeoPointField = GeoPointField(
+    name,
+    values.get("boost").map(_.asInstanceOf[Double]),
+    values.get("copy_to").map(_.asInstanceOf[Seq[String]]).getOrElse(Seq.empty),
+    values.get("doc_values").map(_.asInstanceOf[Boolean]),
+    values.get("ignore_malformed").map(_.asInstanceOf[Boolean]),
+    values.get("ignore_z_value").map(_.asInstanceOf[Boolean]),
+    values.get("index").map(_.asInstanceOf[Boolean]),
+    values.get("norms").map(_.asInstanceOf[Boolean]),
+    values.get("null_value").map(_.asInstanceOf[String]),
+    values.get("store").map(_.asInstanceOf[Boolean])
+  )
+
   def build(field: GeoPointField): XContentBuilder = {
     val builder = XContentFactory.jsonBuilder()
     builder.field("type", field.`type`)

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/GeoShapeFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/GeoShapeFieldBuilderFn.scala
@@ -4,6 +4,26 @@ import com.sksamuel.elastic4s.fields.GeoShapeField
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
 object GeoShapeFieldBuilderFn {
+  def toField(name: String, values: Map[String, Any]): GeoShapeField = GeoShapeField(
+    name,
+    values.get("boost").map(_.asInstanceOf[Double]),
+    values.get("copy_to").map(_.asInstanceOf[Seq[String]]).getOrElse(Seq.empty),
+    values.get("doc_values").map(_.asInstanceOf[Boolean]),
+    values.get("ignore_malformed").map(_.asInstanceOf[Boolean]),
+    values.get("ignore_z_value").map(_.asInstanceOf[Boolean]),
+    values.get("index").map(_.asInstanceOf[Boolean]),
+    values.get("norms").map(_.asInstanceOf[Boolean]),
+    values.get("null_value").map(_.asInstanceOf[String]),
+    values.get("store").map(_.asInstanceOf[Boolean]),
+    values.get("tree").map(_.asInstanceOf[String]),
+    values.get("precision").map(_.asInstanceOf[String]),
+    values.get("strategy").map(_.asInstanceOf[String]),
+    values.get("distance_error_pct").map(_.asInstanceOf[Double]),
+    values.get("orientation").map(_.asInstanceOf[String]),
+    values.get("points_only").map(_.asInstanceOf[Boolean]),
+    values.get("tree_levels").map(_.asInstanceOf[String])
+  )
+
   def build(field: GeoShapeField): XContentBuilder = {
     val builder = XContentFactory.jsonBuilder()
     builder.field("type", field.`type`)

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/HistogramFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/HistogramFieldBuilderFn.scala
@@ -4,6 +4,8 @@ import com.sksamuel.elastic4s.fields.HistogramField
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
 object HistogramFieldBuilderFn {
+  def toField(name: String, values: Map[String, Any]): HistogramField = HistogramField(name)
+
   def build(field: HistogramField): XContentBuilder = {
 
     val builder = XContentFactory.jsonBuilder()

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/IpFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/IpFieldBuilderFn.scala
@@ -4,6 +4,16 @@ import com.sksamuel.elastic4s.fields.{IpField, IpRangeField}
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
 object IpFieldBuilderFn {
+  def toField(name: String, values: Map[String, Any]): IpField = IpField(
+    name,
+    values.get("boost").map(_.asInstanceOf[Double]),
+    values.get("doc_values").map(_.asInstanceOf[Boolean]),
+    values.get("ignore_malformed").map(_.asInstanceOf[Boolean]),
+    values.get("index").map(_.asInstanceOf[Boolean]),
+    values.get("null_value").map(_.asInstanceOf[String]),
+    values.get("store").map(_.asInstanceOf[Boolean]),
+  )
+
 
   def build(field: IpField): XContentBuilder = {
 
@@ -20,6 +30,15 @@ object IpFieldBuilderFn {
 }
 
 object IpRangeFieldBuilderFn {
+  def toField(name: String, values: Map[String, Any]): IpRangeField = IpRangeField(
+    name,
+    values.get("boost").map(_.asInstanceOf[Double]),
+    values.get("coerce").map(_.asInstanceOf[Boolean]),
+    values.get("index").map(_.asInstanceOf[Boolean]),
+    values.get("format").map(_.asInstanceOf[String]),
+    values.get("store").map(_.asInstanceOf[Boolean])
+  )
+
 
   def build(field: IpRangeField): XContentBuilder = {
 

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/JoinFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/JoinFieldBuilderFn.scala
@@ -4,6 +4,12 @@ import com.sksamuel.elastic4s.fields.JoinField
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
 object JoinFieldBuilderFn {
+  def toField(name: String, values: Map[String, Any]): JoinField = JoinField(
+    name,
+    values.get("eager_global_ordinals").map(_.asInstanceOf[Boolean]),
+    values.get("relations").map(_.asInstanceOf[Map[String, Any]]).getOrElse(Map.empty)
+  )
+
 
   def build(field: JoinField): XContentBuilder = {
 

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/KeywordFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/KeywordFieldBuilderFn.scala
@@ -4,6 +4,27 @@ import com.sksamuel.elastic4s.fields.KeywordField
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
 object KeywordFieldBuilderFn {
+  def toField(name: String, values: Map[String, Any]): KeywordField = KeywordField(
+    name,
+    values.get("boost").map(_.asInstanceOf[Double]),
+    values.get("copy_to").map(_.asInstanceOf[Seq[String]]).getOrElse(Seq.empty),
+    values.get("doc_values").map(_.asInstanceOf[Boolean]),
+    values.get("eager_global_ordinals").map(_.asInstanceOf[Boolean]),
+    values
+      .get("fields")
+      .map(_.asInstanceOf[Map[String, Map[String, Any]]].map { case (key, value) => ElasticFieldBuilderFn.construct(key, value) }.toList).getOrElse(List.empty),
+    values.get("ignore_above").map(_.asInstanceOf[Int]),
+    values.get("index").map(_.asInstanceOf[Boolean]),
+    values.get("index_options").map(_.asInstanceOf[String]),
+    values.get("norms").map(_.asInstanceOf[Boolean]),
+    values.get("normalizer").map(_.asInstanceOf[String]),
+    values.get("null_value").map(_.asInstanceOf[String]),
+    values.get("similarity").map(_.asInstanceOf[String]),
+    values.get("split_queries_on_whitespace").map(_.asInstanceOf[Boolean]),
+    values.get("store").map(_.asInstanceOf[Boolean]),
+    values.get("term_vector").map(_.asInstanceOf[String])
+  )
+
 
   def build(field: KeywordField): XContentBuilder = {
 

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/MatchOnlyTextFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/MatchOnlyTextFieldBuilderFn.scala
@@ -4,6 +4,11 @@ import com.sksamuel.elastic4s.fields.MatchOnlyTextField
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
 object MatchOnlyTextFieldBuilderFn {
+  def toField(name: String, values: Map[String, Any]): MatchOnlyTextField = MatchOnlyTextField(
+    name,
+    values.get("fields").map(_.asInstanceOf[Map[String, Map[String, Any]]].map { case (key, value) => ElasticFieldBuilderFn.construct(key, value) }.toList).getOrElse(List.empty),
+  )
+
   def build(field: MatchOnlyTextField): XContentBuilder = {
     val builder = XContentFactory.jsonBuilder()
     builder.field("type", field.`type`)

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/Murmur3FieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/Murmur3FieldBuilderFn.scala
@@ -4,6 +4,8 @@ import com.sksamuel.elastic4s.fields.Murmur3Field
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
 object Murmur3FieldBuilderFn {
+  def toField(name: String, values: Map[String, Any]): Murmur3Field = Murmur3Field(name)
+
   def build(field: Murmur3Field): XContentBuilder = {
 
     val builder = XContentFactory.jsonBuilder()

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/NestedFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/NestedFieldBuilderFn.scala
@@ -4,6 +4,18 @@ import com.sksamuel.elastic4s.fields.NestedField
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
 object NestedFieldBuilderFn {
+  def toField(name: String, values: Map[String, Any]): NestedField = NestedField(
+    name,
+    values.get("dynamic").map(_.asInstanceOf[String]),
+    values.get("enabled").map(_.asInstanceOf[Boolean]),
+    values
+      .get("properties")
+      .map(_.asInstanceOf[Map[String, Map[String, Any]]].map { case (key, value) => ElasticFieldBuilderFn.construct(key, value) }.toSeq)
+      .getOrElse(Seq.empty),
+    values.get("include_in_parent").map(_.asInstanceOf[Boolean]),
+    values.get("include_in_root").map(_.asInstanceOf[Boolean])
+  )
+
 
   def build(field: NestedField): XContentBuilder = {
 

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/NumberFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/NumberFieldBuilderFn.scala
@@ -1,9 +1,115 @@
 package com.sksamuel.elastic4s.handlers.fields
 
-import com.sksamuel.elastic4s.fields.{NumberField, ScaledFloatField}
+import com.sksamuel.elastic4s.fields._
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
 object NumberFieldBuilderFn {
+  val supportedTypes = Set(ByteField.`type`, DoubleField.`type`, FloatField.`type`, HalfFloatField.`type`, ScaledFloatField.`type`, IntegerField.`type`, LongField.`type`, ShortField.`type`, UnsignedLongField.`type`)
+
+  def toField(numberType: String, name: String, values: Map[String, Any]): NumberField[_] = numberType match {
+    case ByteField.`type` => ByteField(
+      name,
+      values.get("boost").map(_.asInstanceOf[Double]),
+      values.get("coerce").map(_.asInstanceOf[Boolean]),
+      values.get("copy_to").map(_.asInstanceOf[Seq[String]]).getOrElse(Seq.empty),
+      values.get("doc_values").map(_.asInstanceOf[Boolean]),
+      values.get("ignore_malformed").map(_.asInstanceOf[Boolean]),
+      values.get("index").map(_.asInstanceOf[Boolean]),
+      values.get("null_value").map(_.asInstanceOf[Number]).map(_.byteValue()),
+      values.get("store").map(_.asInstanceOf[Boolean])
+    )
+    case DoubleField.`type` => DoubleField(
+      name,
+      values.get("boost").map(_.asInstanceOf[Double]),
+      values.get("coerce").map(_.asInstanceOf[Boolean]),
+      values.get("copy_to").map(_.asInstanceOf[Seq[String]]).getOrElse(Seq.empty),
+      values.get("doc_values").map(_.asInstanceOf[Boolean]),
+      values.get("ignore_malformed").map(_.asInstanceOf[Boolean]),
+      values.get("index").map(_.asInstanceOf[Boolean]),
+      values.get("null_value").map(_.asInstanceOf[Number]).map(_.doubleValue()),
+      values.get("store").map(_.asInstanceOf[Boolean])
+    )
+    case FloatField.`type` => FloatField(
+      name,
+      values.get("boost").map(_.asInstanceOf[Double]),
+      values.get("coerce").map(_.asInstanceOf[Boolean]),
+      values.get("copy_to").map(_.asInstanceOf[Seq[String]]).getOrElse(Seq.empty),
+      values.get("doc_values").map(_.asInstanceOf[Boolean]),
+      values.get("ignore_malformed").map(_.asInstanceOf[Boolean]),
+      values.get("index").map(_.asInstanceOf[Boolean]),
+      values.get("null_value").map(_.asInstanceOf[Number]).map(_.floatValue()),
+      values.get("store").map(_.asInstanceOf[Boolean])
+    )
+    case HalfFloatField.`type` => HalfFloatField(
+      name,
+      values.get("boost").map(_.asInstanceOf[Double]),
+      values.get("coerce").map(_.asInstanceOf[Boolean]),
+      values.get("copy_to").map(_.asInstanceOf[Seq[String]]).getOrElse(Seq.empty),
+      values.get("doc_values").map(_.asInstanceOf[Boolean]),
+      values.get("ignore_malformed").map(_.asInstanceOf[Boolean]),
+      values.get("index").map(_.asInstanceOf[Boolean]),
+      values.get("null_value").map(_.asInstanceOf[Number]).map(_.floatValue()),
+      values.get("store").map(_.asInstanceOf[Boolean])
+    )
+    case ScaledFloatField.`type` => ScaledFloatField(
+      name,
+      values.get("boost").map(_.asInstanceOf[Double]),
+      values.get("coerce").map(_.asInstanceOf[Boolean]),
+      values.get("copy_to").map(_.asInstanceOf[Seq[String]]).getOrElse(Seq.empty),
+      values.get("doc_values").map(_.asInstanceOf[Boolean]),
+      values.get("ignore_malformed").map(_.asInstanceOf[Boolean]),
+      values.get("scaling_factor").map(_.asInstanceOf[Int]),
+      values.get("index").map(_.asInstanceOf[Boolean]),
+      values.get("null_value").map(_.asInstanceOf[Number]).map(_.floatValue()),
+      values.get("store").map(_.asInstanceOf[Boolean])
+    )
+    case IntegerField.`type` => IntegerField(
+      name,
+      values.get("boost").map(_.asInstanceOf[Double]),
+      values.get("coerce").map(_.asInstanceOf[Boolean]),
+      values.get("copy_to").map(_.asInstanceOf[Seq[String]]).getOrElse(Seq.empty),
+      values.get("doc_values").map(_.asInstanceOf[Boolean]),
+      values.get("ignore_malformed").map(_.asInstanceOf[Boolean]),
+      values.get("index").map(_.asInstanceOf[Boolean]),
+      values.get("null_value").map(_.asInstanceOf[Number]).map(_.intValue()),
+      values.get("store").map(_.asInstanceOf[Boolean])
+    )
+    case LongField.`type` => LongField(
+      name,
+      values.get("boost").map(_.asInstanceOf[Double]),
+      values.get("coerce").map(_.asInstanceOf[Boolean]),
+      values.get("copy_to").map(_.asInstanceOf[Seq[String]]).getOrElse(Seq.empty),
+      values.get("doc_values").map(_.asInstanceOf[Boolean]),
+      values.get("ignore_malformed").map(_.asInstanceOf[Boolean]),
+      values.get("index").map(_.asInstanceOf[Boolean]),
+      values.get("store").map(_.asInstanceOf[Boolean]),
+      values.get("null_value").map(_.asInstanceOf[Number]).map(_.longValue())
+    )
+    case ShortField.`type` => ShortField(
+      name,
+      values.get("boost").map(_.asInstanceOf[Double]),
+      values.get("coerce").map(_.asInstanceOf[Boolean]),
+      values.get("copy_to").map(_.asInstanceOf[Seq[String]]).getOrElse(Seq.empty),
+      values.get("doc_values").map(_.asInstanceOf[Boolean]),
+      values.get("enabled").map(_.asInstanceOf[Boolean]),
+      values.get("ignore_malformed").map(_.asInstanceOf[Boolean]),
+      values.get("index").map(_.asInstanceOf[Boolean]),
+      values.get("null_value").map(_.asInstanceOf[Number]).map(_.shortValue()),
+      values.get("store").map(_.asInstanceOf[Boolean])
+    )
+    case UnsignedLongField.`type` => UnsignedLongField(
+      name,
+      values.get("boost").map(_.asInstanceOf[Double]),
+      values.get("coerce").map(_.asInstanceOf[Boolean]),
+      values.get("copy_to").map(_.asInstanceOf[Seq[String]]).getOrElse(Seq.empty),
+      values.get("doc_values").map(_.asInstanceOf[Boolean]),
+      values.get("ignore_malformed").map(_.asInstanceOf[Boolean]),
+      values.get("index").map(_.asInstanceOf[Boolean]),
+      values.get("store").map(_.asInstanceOf[Boolean]),
+      values.get("null_value").map(_.asInstanceOf[Number]).map(_.longValue())
+    )
+  }
+
 
   def build(field: NumberField[_]): XContentBuilder = {
 

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/ObjectFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/ObjectFieldBuilderFn.scala
@@ -4,6 +4,16 @@ import com.sksamuel.elastic4s.fields.ObjectField
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
 object ObjectFieldBuilderFn {
+  def toField(name: String, values: Map[String, Any]): ObjectField = ObjectField(
+    name,
+    values.get("dynamic").map(_.asInstanceOf[String]),
+    values.get("enabled").map(_.asInstanceOf[Boolean]),
+    values
+      .get("properties")
+      .map(_.asInstanceOf[Map[String, Map[String, Any]]].map { case (key, value) => ElasticFieldBuilderFn.construct(key, value) }.toSeq)
+      .getOrElse(Seq.empty)
+  )
+
 
   def build(field: ObjectField): XContentBuilder = {
 

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/PercolatorFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/PercolatorFieldBuilderFn.scala
@@ -4,6 +4,8 @@ import com.sksamuel.elastic4s.fields.PercolatorField
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
 object PercolatorFieldBuilderFn {
+  def toField(name: String, values: Map[String, Any]): PercolatorField = PercolatorField(name)
+
   def build(field: PercolatorField): XContentBuilder = {
 
     val builder = XContentFactory.jsonBuilder()

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/RangeFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/RangeFieldBuilderFn.scala
@@ -1,9 +1,56 @@
 package com.sksamuel.elastic4s.handlers.fields
 
-import com.sksamuel.elastic4s.fields.{DateRangeField, RangeField}
+import com.sksamuel.elastic4s.fields.{DateRangeField, DoubleRangeField, FloatRangeField, IntegerRangeField, IpRangeField, LongRangeField, RangeField}
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
 object RangeFieldBuilderFn {
+  val supportedTypes = Set(
+    DateRangeField.`type`,
+    DoubleRangeField.`type`,
+    FloatRangeField.`type`,
+    IntegerRangeField.`type`,
+    LongRangeField.`type`
+  )
+
+  def toField(`type`: String, name: String, values: Map[String, Any]): RangeField = `type` match {
+    case DateRangeField.`type` => DateRangeField(
+      name,
+      values.get("boost").map(_.asInstanceOf[Double]),
+      values.get("coerce").map(_.asInstanceOf[Boolean]),
+      values.get("index").map(_.asInstanceOf[Boolean]),
+      values.get("format").map(_.asInstanceOf[String]),
+      values.get("store").map(_.asInstanceOf[Boolean]),
+    )
+    case DoubleRangeField.`type` => DoubleRangeField(
+      name,
+      values.get("boost").map(_.asInstanceOf[Double]),
+      values.get("coerce").map(_.asInstanceOf[Boolean]),
+      values.get("index").map(_.asInstanceOf[Boolean]),
+      values.get("store").map(_.asInstanceOf[Boolean]),
+    )
+    case FloatRangeField.`type` => FloatRangeField(
+      name,
+      values.get("boost").map(_.asInstanceOf[Double]),
+      values.get("coerce").map(_.asInstanceOf[Boolean]),
+      values.get("index").map(_.asInstanceOf[Boolean]),
+      values.get("store").map(_.asInstanceOf[Boolean]),
+    )
+    case IntegerRangeField.`type` => IntegerRangeField(
+      name,
+      values.get("boost").map(_.asInstanceOf[Double]),
+      values.get("coerce").map(_.asInstanceOf[Boolean]),
+      values.get("index").map(_.asInstanceOf[Boolean]),
+      values.get("store").map(_.asInstanceOf[Boolean]),
+    )
+    case LongRangeField.`type` => LongRangeField(
+      name,
+      values.get("boost").map(_.asInstanceOf[Double]),
+      values.get("coerce").map(_.asInstanceOf[Boolean]),
+      values.get("index").map(_.asInstanceOf[Boolean]),
+      values.get("store").map(_.asInstanceOf[Boolean]),
+    )
+  }
+
 
   def build(field: RangeField): XContentBuilder = {
 

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/RankFeatureFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/RankFeatureFieldBuilderFn.scala
@@ -4,6 +4,11 @@ import com.sksamuel.elastic4s.fields.RankFeatureField
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
 object RankFeatureFieldBuilderFn {
+  def toField(name: String, values: Map[String, Any]): RankFeatureField = RankFeatureField(
+    name,
+    values.get("positive_score_impact").map(_.asInstanceOf[Boolean])
+  )
+
   def build(field: RankFeatureField): XContentBuilder = {
 
     val builder = XContentFactory.jsonBuilder()

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/RankFeaturesFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/RankFeaturesFieldBuilderFn.scala
@@ -4,6 +4,8 @@ import com.sksamuel.elastic4s.fields.RankFeaturesField
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
 object RankFeaturesFieldBuilderFn {
+  def toField(name: String, values: Map[String, Any]): RankFeaturesField = RankFeaturesField(name)
+
   def build(field: RankFeaturesField): XContentBuilder = {
 
     val builder = XContentFactory.jsonBuilder()

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/SearchAsYouTypeFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/SearchAsYouTypeFieldBuilderFn.scala
@@ -4,6 +4,24 @@ import com.sksamuel.elastic4s.fields.SearchAsYouTypeField
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
 object SearchAsYouTypeFieldBuilderFn {
+  def toField(name: String, values: Map[String, Any]): SearchAsYouTypeField = SearchAsYouTypeField(
+    name,
+    values.get("analyzer").map(_.asInstanceOf[String]),
+    values.get("search_analyzer").map(_.asInstanceOf[String]),
+    values.get("boost").map(_.asInstanceOf[Double]),
+    values.get("copy_to").map(_.asInstanceOf[Seq[String]]).getOrElse(Seq.empty),
+    values.get("doc_values").map(_.asInstanceOf[Boolean]),
+    values.get("fielddata").map(_.asInstanceOf[Boolean]),
+    values.get("ignore_above").map(_.asInstanceOf[Int]),
+    values.get("index").map(_.asInstanceOf[Boolean]),
+    values.get("index_options").map(_.asInstanceOf[String]),
+    values.get("max_shingle_size").map(_.asInstanceOf[Int]),
+    values.get("norms").map(_.asInstanceOf[Boolean]),
+    values.get("similarity").map(_.asInstanceOf[String]),
+    values.get("store").map(_.asInstanceOf[Boolean]),
+    values.get("term_vector").map(_.asInstanceOf[String])
+  )
+
 
   def build(field: SearchAsYouTypeField): XContentBuilder = {
 

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/TextFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/TextFieldBuilderFn.scala
@@ -1,9 +1,45 @@
 package com.sksamuel.elastic4s.handlers.fields
 
-import com.sksamuel.elastic4s.fields.TextField
+import com.sksamuel.elastic4s.fields.{IndexPrefixes, TextField}
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
+import com.sksamuel.elastic4s.requests.mappings.FielddataFrequencyFilter
 
 object TextFieldBuilderFn {
+  private def getFieldDataFrequencyFilter(values: Map[String, Any]) = FielddataFrequencyFilter(
+    values("min").asInstanceOf,
+    values("max").asInstanceOf,
+    values("min_segment_size").asInstanceOf
+  )
+
+  private def getIndexPrefixes(values: Map[String, Any]) = IndexPrefixes(values("min_chars").asInstanceOf, values("max_chars").asInstanceOf)
+
+  def toField(name: String, values: Map[String, Any]): TextField = TextField(
+    name,
+    values.get("analyzer").map(_.asInstanceOf[String]),
+    values.get("boost").map(_.asInstanceOf[Double]),
+    values.get("copy_to").map(_.asInstanceOf[Seq[String]]).getOrElse(Seq.empty),
+    values.get("eager_global_ordinals").map(_.asInstanceOf[Boolean]),
+    values
+      .get("fields")
+      .map(_.asInstanceOf[Map[String, Map[String, Any]]].map { case (key, value) =>
+        ElasticFieldBuilderFn.construct(key, value)
+      }.toList)
+      .getOrElse(List.empty),
+    values.get("fielddata").map(_.asInstanceOf[Boolean]),
+    values.get("fielddata_frequency_filter").map(_.asInstanceOf[Map[String, Any]]).map(getFieldDataFrequencyFilter),
+    values.get("index").map(_.asInstanceOf[Boolean]),
+    values.get("index_prefixes").map(_.asInstanceOf[Map[String, Any]]).map(getIndexPrefixes),
+    values.get("index_phrases").map(_.asInstanceOf[Boolean]),
+    values.get("index_options").map(_.asInstanceOf[String]),
+    values.get("norms").map(_.asInstanceOf[Boolean]),
+    values.get("position_increment_gap").map(_.asInstanceOf[Int]),
+    values.get("search_analyzer").map(_.asInstanceOf[String]),
+    values.get("search_quote_analyzer").map(_.asInstanceOf[String]),
+    values.get("similarity").map(_.asInstanceOf[String]),
+    values.get("store").map(_.asInstanceOf[Boolean]),
+    values.get("term_vector").map(_.asInstanceOf[String])
+  )
+
 
   def build(field: TextField): XContentBuilder = {
 

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/TokenCountFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/TokenCountFieldBuilderFn.scala
@@ -4,6 +4,18 @@ import com.sksamuel.elastic4s.fields.TokenCountField
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
 object TokenCountFieldBuilderFn {
+  def toField(name: String, values: Map[String, Any]): TokenCountField = TokenCountField(
+    name,
+    values.get("analyzer").map(_.asInstanceOf[String]),
+    values.get("boost").map(_.asInstanceOf[Double]),
+    values.get("copy_to").map(_.asInstanceOf[Seq[String]]).getOrElse(Seq.empty),
+    values.get("doc_values").map(_.asInstanceOf[Boolean]),
+    values.get("enable_position_increments").map(_.asInstanceOf[Boolean]),
+    values.get("index").map(_.asInstanceOf[Boolean]),
+    values.get("null_value").map(_.asInstanceOf[String]),
+    values.get("store").map(_.asInstanceOf[Boolean])
+  )
+
 
   def build(field: TokenCountField): XContentBuilder = {
 

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/VersionFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/VersionFieldBuilderFn.scala
@@ -4,6 +4,8 @@ import com.sksamuel.elastic4s.fields.VersionField
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
 object VersionFieldBuilderFn {
+  def toField(name: String, values: Map[String, Any]): VersionField = VersionField(name)
+
   def build(field: VersionField): XContentBuilder = {
     val builder = XContentFactory.jsonBuilder()
     builder.field("type", field.`type`)

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/WildcardFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/WildcardFieldBuilderFn.scala
@@ -4,6 +4,12 @@ import com.sksamuel.elastic4s.fields.WildcardField
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
 object WildcardFieldBuilderFn {
+  def toField(name: String, values: Map[String, Any]): WildcardField = WildcardField(
+    name,
+    values.get("ignore_above").map(_.asInstanceOf[Int]),
+    values.get("null_value").map(_.asInstanceOf[String])
+  )
+
 
   def build(field: WildcardField): XContentBuilder = {
     val builder = XContentFactory.jsonBuilder()

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/index/mapping/IndexMappersToFields.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/index/mapping/IndexMappersToFields.scala
@@ -1,0 +1,13 @@
+package com.sksamuel.elastic4s.handlers.index.mapping
+
+import com.sksamuel.elastic4s.fields.ElasticField
+import com.sksamuel.elastic4s.handlers.fields.ElasticFieldBuilderFn
+import com.sksamuel.elastic4s.requests.indexes.IndexMappings
+
+object IndexMappersToFields {
+
+  def mappingToFields(indexMapping: IndexMappings): Seq[ElasticField] =
+    indexMapping.mappings.map {
+      case (name, value: Map[String, Any]) => ElasticFieldBuilderFn.construct(name, value)
+    }.toSeq
+}

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/fields/ElasticFieldBuilderFnTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/fields/ElasticFieldBuilderFnTest.scala
@@ -1,0 +1,94 @@
+package com.sksamuel.elastic4s.fields
+
+import com.sksamuel.elastic4s.handlers.fields.ElasticFieldBuilderFn
+import com.sksamuel.elastic4s.jackson.JacksonSupport
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class ElasticFieldBuilderFnTest extends AnyWordSpec with Matchers {
+
+  "ElasticFieldBuilderFn" should {
+
+    "support CompletionField without contexts" in {
+      val field = CompletionField("theField", copyTo = Seq("a", "bc"), maxInputLength = Some(13), preservePositionIncrements = Some(true))
+
+      val jsonString = """{"type":"completion","copy_to":["a","bc"],"preserve_position_increments":true,"max_input_length":13}"""
+      ElasticFieldBuilderFn(field).string() shouldBe jsonString
+      ElasticFieldBuilderFn.construct(field.name, JacksonSupport.mapper.readValue[Map[String, Any]](jsonString)) shouldBe field
+    }
+
+    "support CompletionField with contexts" in {
+      val field = CompletionField("theField", copyTo = Seq("a", "bc"), maxInputLength = Some(13), preservePositionIncrements = Some(true), contexts = Seq(ContextField("location", "geo", precision = Some(4), path = Some("loc"))))
+
+      val jsonString = """{"type":"completion","copy_to":["a","bc"],"preserve_position_increments":true,"max_input_length":13,"contexts":[{"name":"location","type":"geo","path":"loc","precision":4}]}"""
+      ElasticFieldBuilderFn(field).string() shouldBe jsonString
+      ElasticFieldBuilderFn.construct(field.name, JacksonSupport.mapper.readValue[Map[String, Any]](jsonString)) shouldBe field
+    }
+
+    "support KeywordField without subfields" in {
+      val field = KeywordField("keyField", splitQueriesOnWhitespace = Some(true), ignoreAbove = Some(13), norms = Some(true), normalizer = Some("uppercase"))
+      val jsonString = """{"type":"keyword","ignore_above":13,"norms":true,"normalizer":"uppercase","split_queries_on_whitespace":true}"""
+      ElasticFieldBuilderFn(field).string() shouldBe jsonString
+      ElasticFieldBuilderFn.construct(field.name, JacksonSupport.mapper.readValue[Map[String, Any]](jsonString)) shouldBe field
+    }
+    "support KeywordField with subfields" in {
+      val field = KeywordField("keyField", fields = List(TextField("fullText", eagerGlobalOrdinals = Some(true)), KeywordField("lower_keys", normalizer = Some("lowercase"))))
+      val jsonString = """{"type":"keyword","fields":{"fullText":{"type":"text","eager_global_ordinals":true},"lower_keys":{"type":"keyword","normalizer":"lowercase"}}}"""
+      ElasticFieldBuilderFn(field).string() shouldBe jsonString
+      ElasticFieldBuilderFn.construct(field.name, JacksonSupport.mapper.readValue[Map[String, Any]](jsonString)) shouldBe field
+    }
+
+    "support ObjectField with subfields" in {
+      val field = ObjectField("obj", properties = Seq(TextField("fullName", eagerGlobalOrdinals = Some(true)), KeywordField("lastName", normalizer = Some("lowercase"))))
+      val jsonString = """{"type":"object","properties":{"fullName":{"type":"text","eager_global_ordinals":true},"lastName":{"type":"keyword","normalizer":"lowercase"}}}"""
+      ElasticFieldBuilderFn(field).string() shouldBe jsonString
+      ElasticFieldBuilderFn.construct(field.name, JacksonSupport.mapper.readValue[Map[String, Any]](jsonString)) shouldBe field
+    }
+
+    "support FloatRangeField" in {
+      val field = FloatRangeField("floatRange", index = Some(true))
+      val jsonString = """{"type":"float_range","index":true}"""
+      ElasticFieldBuilderFn(field).string() shouldBe jsonString
+      ElasticFieldBuilderFn.construct(field.name, JacksonSupport.mapper.readValue[Map[String, Any]](jsonString)) shouldBe field
+    }
+
+    "support DateRangeField" in {
+      val field = DateRangeField("time_range", format = Some("yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"))
+      val jsonString = """{"type":"date_range","format":"yyyy-MM-dd HH:mm:ss||yyyy-MM-dd||epoch_millis"}"""
+      ElasticFieldBuilderFn(field).string() shouldBe jsonString
+      ElasticFieldBuilderFn.construct(field.name, JacksonSupport.mapper.readValue[Map[String, Any]](jsonString)) shouldBe field
+    }
+    "Support ScaledFloat" in {
+      val field = ScaledFloatField("scaled_floating_field", scalingFactor = Some(100), nullValue = Some(13.6f))
+      val jsonString = """{"type":"scaled_float","null_value":13.600000381469727,"scaling_factor":100}"""
+      ElasticFieldBuilderFn(field).string() shouldBe jsonString
+      ElasticFieldBuilderFn.construct(field.name, JacksonSupport.mapper.readValue[Map[String, Any]](jsonString)) shouldBe field
+    }
+
+    "Support UnsignedLong" in {
+      val field = UnsignedLongField("unsigned_long_field", nullValue = Some(1647995L))
+      val jsonString = """{"type":"unsigned_long","null_value":1647995}"""
+      ElasticFieldBuilderFn(field).string() shouldBe jsonString
+      ElasticFieldBuilderFn.construct(field.name, JacksonSupport.mapper.readValue[Map[String, Any]](jsonString)) shouldBe field
+    }
+
+    "construct a field without type but with properties" in {
+      val jsonString = """{"properties":{"fullName":{"type":"text","eager_global_ordinals":true},"lastName":{"type":"keyword","normalizer":"lowercase"}}}"""
+      ElasticFieldBuilderFn.construct("test", JacksonSupport.mapper.readValue[Map[String, Any]](jsonString)) shouldBe ObjectField(
+        "test",
+        properties = Seq(TextField("fullName", eagerGlobalOrdinals = Some(true)), KeywordField("lastName", normalizer = Some("lowercase")))
+      )
+    }
+
+    "throw a RuntimeException if a field cannot be constructed" in {
+      val jsonString = """{"properties":{"fullName":{"type":"text","eager_global_ordinals":true},"lastName":{"type":"dynamic","normalizer":"lowercase"}}}"""
+      val ex = intercept[RuntimeException] {
+        ElasticFieldBuilderFn.construct("test", JacksonSupport.mapper.readValue[Map[String, Any]](jsonString))
+      }
+      ex.getMessage shouldBe "Could not convert mapping for 'lastName' to an ElasticField"
+
+    }
+
+  }
+
+}

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/fields/LongFieldTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/fields/LongFieldTest.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.elastic4s.fields
 
-import com.sksamuel.elastic4s.handlers.fields
 import com.sksamuel.elastic4s.handlers.fields.ElasticFieldBuilderFn
+import com.sksamuel.elastic4s.jackson.JacksonSupport
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
@@ -19,6 +19,8 @@ class LongFieldTest extends AnyFunSuite with Matchers {
       copyTo = List("q", "er")
     )
 
-    fields.ElasticFieldBuilderFn(field).string() shouldBe """{"type":"long","copy_to":["q","er"],"boost":1.2,"index":true,"null_value":142,"store":true,"coerce":true,"ignore_malformed":true}"""
+    val jsonStringValue = """{"type":"long","copy_to":["q","er"],"boost":1.2,"index":true,"null_value":142,"store":true,"coerce":true,"ignore_malformed":true}"""
+    ElasticFieldBuilderFn(field).string() shouldBe jsonStringValue
+    ElasticFieldBuilderFn.construct(field.name, JacksonSupport.mapper.readValue[Map[String, Any]](jsonStringValue)) shouldBe (field)
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/fields/SearchAsYouTypeFieldTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/fields/SearchAsYouTypeFieldTest.scala
@@ -1,7 +1,8 @@
-package com.sksamuel.elastic4s.requests.mappings
+package com.sksamuel.elastic4s.fields
 
 import com.sksamuel.elastic4s.ElasticApi
 import com.sksamuel.elastic4s.handlers.fields.SearchAsYouTypeFieldBuilderFn
+import com.sksamuel.elastic4s.jackson.JacksonSupport
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -21,7 +22,11 @@ class SearchAsYouTypeFieldTest extends AnyFlatSpec with Matchers with ElasticApi
       .ignoreAbove(30)
       .similarity("classic")
       .maxShingleSize(4)
-    SearchAsYouTypeFieldBuilderFn.build(field).string() shouldBe
-      """{"type":"search_as_you_type","analyzer":"foo","search_analyzer":"bar","boost":1.2,"copy_to":["copy1","copy2"],"index":true,"norms":true,"store":true,"fielddata":true,"ignore_above":30,"index_options":"freqs","similarity":"classic","max_shingle_size":4}"""
+
+    val expectedJson = """{"type":"search_as_you_type","analyzer":"foo","search_analyzer":"bar","boost":1.2,"copy_to":["copy1","copy2"],"index":true,"norms":true,"store":true,"fielddata":true,"ignore_above":30,"index_options":"freqs","similarity":"classic","max_shingle_size":4}"""
+    SearchAsYouTypeFieldBuilderFn.build(field).string() shouldBe expectedJson
+    SearchAsYouTypeFieldBuilderFn.toField(field.name, JacksonSupport.mapper.readValue[Map[String, Any]](expectedJson)) shouldBe (field)
+
+
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/fields/TextFieldTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/fields/TextFieldTest.scala
@@ -1,8 +1,7 @@
 package com.sksamuel.elastic4s.fields
 
-import com.sksamuel.elastic4s.ElasticApi
+import com.sksamuel.elastic4s.{ElasticApi, JacksonSupport}
 import com.sksamuel.elastic4s.analysis.LanguageAnalyzers
-import com.sksamuel.elastic4s.handlers.fields
 import com.sksamuel.elastic4s.handlers.fields.ElasticFieldBuilderFn
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -26,6 +25,8 @@ class TextFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
       norms = Some(true)
     )
 
-    fields.ElasticFieldBuilderFn(field).string() shouldBe """{"type":"text","analyzer":"bengali","boost":1.2,"copy_to":["q","er"],"index":true,"norms":true,"store":true,"fielddata":true,"position_increment_gap":3,"index_options":"freqs","search_analyzer":"norwegian","search_quote_analyzer":"english","similarity":"Classic1"}"""
+    val jsonStringValue = """{"type":"text","analyzer":"bengali","boost":1.2,"copy_to":["q","er"],"index":true,"norms":true,"store":true,"fielddata":true,"position_increment_gap":3,"index_options":"freqs","search_analyzer":"norwegian","search_quote_analyzer":"english","similarity":"Classic1"}"""
+    ElasticFieldBuilderFn(field).string() shouldBe jsonStringValue
+    ElasticFieldBuilderFn.construct(field.name, JacksonSupport.mapper.readValue[Map[String, Any]](jsonStringValue)) shouldBe (field)
   }
 }


### PR DESCRIPTION
proposal to fix #2548 

For compatibility I did not change the `IndexMappings` (i.e. the response objects of the GetMappingRequest).
I've added a "utility" `com.sksamuel.elastic4s.handlers.index.mapping.IndexMappersToFields` that transforms the mappings from an IndexMapping to a `Seq[ElasticField]`.
Since that is the "inverse" function of mapping the ElasticField to json (from the PutMapping req), I added a `construct` method to the ElasticFieldBuilderFn (and all "specialized" FieldBuilderFn) in the hope that if ElasticFields are added, the inverse function is also implemented.
I added also a few unit tests, but I wonder iff and how an exhaustive test suite could be "generated" ?

