### PR TITLE
Make clients AutoCloseable

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticClient.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticClient.scala
@@ -15,7 +15,7 @@ import scala.language.higherKinds
   *
   * @param client the HTTP client library to use
   **/
-case class ElasticClient(client: HttpClient) {
+case class ElasticClient(client: HttpClient) extends AutoCloseable {
 
   protected val logger: Logger = LoggerFactory.getLogger(getClass.getName)
 

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/HttpClient.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/HttpClient.scala
@@ -10,7 +10,7 @@ import org.slf4j.{Logger, LoggerFactory}
   * Akka HTTP client, STTP or whatever can be used with elasticsearch.
   * The wrapped client can then be passed into the ElasticClient.
   */
-trait HttpClient {
+trait HttpClient extends AutoCloseable {
 
   protected val logger: Logger = LoggerFactory.getLogger(getClass.getName)
 


### PR DESCRIPTION
This PR makes `ElasticClient` and `HttpClient` `AutoCloseable` so that they can be used in resource management.

Relates to: #2588

