### PR TITLE
Add Translog option to UpdateIndexLevelSettingsRequest

### DIFF
--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/indexes/UpdateIndexLevelSettingsBuilderTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/indexes/UpdateIndexLevelSettingsBuilderTest.scala
@@ -1,0 +1,38 @@
+package com.sksamuel.elastic4s.requests.indexes
+
+import com.sksamuel.elastic4s.handlers.index.UpdateIndexLevelSettingsBuilder
+import com.sksamuel.elastic4s.requests.admin.{TranslogRequest, UpdateIndexLevelSettingsRequest}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class UpdateIndexLevelSettingsBuilderTest extends AnyFunSuite with Matchers {
+
+  test("build UpdateIndexLevelSettingsRequest without translog") {
+    val definition = UpdateIndexLevelSettingsRequest(
+      indexes = Seq("test_index"),
+      numberOfReplicas = Some(0),
+      autoExpandReplicas = Some("0-all"),
+      refreshInterval = Some("30s"),
+      maxResultWindow = Some(100),
+      translog = None
+    )
+
+    UpdateIndexLevelSettingsBuilder(definition).string shouldBe """{"index":{"number_of_replicas":0,"auto_expand_replicas":"0-all","refresh_interval":"30s","max_result_window":100}}"""
+  }
+
+  test("build UpdateIndexLevelSettingsRequest with translong") {
+    val definition = UpdateIndexLevelSettingsRequest(
+      indexes = Seq("test_index"),
+      numberOfReplicas = Some(0),
+      autoExpandReplicas = Some("0-all"),
+      refreshInterval = Some("30s"),
+      maxResultWindow = Some(100),
+      translog = Some(TranslogRequest(
+        durability = "request",
+        syncInterval = Some("5s"),
+        flushThresholdSize = Some("512mb"),
+      ))
+    )
+    UpdateIndexLevelSettingsBuilder(definition).string shouldBe """{"index":{"number_of_replicas":0,"auto_expand_replicas":"0-all","refresh_interval":"30s","max_result_window":100,"translog":{"durability":"request","sync_interval":"5s","flush_threshold_size":"512mb"}}}"""
+  }
+}

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/admin/domain.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/admin/domain.scala
@@ -42,11 +42,16 @@ case class FlushIndexRequest(indexes: Seq[String],
 
 case class RefreshIndexRequest(indexes: Seq[String])
 
+case class TranslogRequest(durability: String,
+                           syncInterval: Option[String],
+                           flushThresholdSize: Option[String])
+
 case class UpdateIndexLevelSettingsRequest(indexes: Seq[String],
                                            numberOfReplicas: Option[Int] = None,
                                            autoExpandReplicas: Option[String] = None,
                                            refreshInterval: Option[String] = None,
-                                           maxResultWindow: Option[Int] = None) {
+                                           maxResultWindow: Option[Int] = None,
+                                           translog: Option[TranslogRequest] = None) {
 
   def numberOfReplicas(numberOfReplicas: Int): UpdateIndexLevelSettingsRequest =
     copy(numberOfReplicas = numberOfReplicas.some)
@@ -56,6 +61,8 @@ case class UpdateIndexLevelSettingsRequest(indexes: Seq[String],
     copy(refreshInterval = refreshInterval.some)
   def maxResultWindow(maxResultWindow: Int): UpdateIndexLevelSettingsRequest =
     copy(maxResultWindow = maxResultWindow.some)
+  def translog(translog: TranslogRequest): UpdateIndexLevelSettingsRequest =
+    copy(translog = translog.some)
 
 }
 

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/index/UpdateIndexLevelSettingsBuilder.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/index/UpdateIndexLevelSettingsBuilder.scala
@@ -13,6 +13,14 @@ object UpdateIndexLevelSettingsBuilder {
     d.refreshInterval.foreach(source.field("refresh_interval", _))
     d.maxResultWindow.foreach(source.field("max_result_window", _))
 
+    d.translog.foreach { t =>
+      val translog = source.startObject("translog")
+      translog.field("durability", t.durability)
+      t.syncInterval.foreach(si => translog.field("sync_interval", si))
+      t.flushThresholdSize.foreach(si => translog.field("flush_threshold_size", si))
+      translog.endObject()
+    }
+
     source.endObject().endObject()
     source
   }


### PR DESCRIPTION
Hi,
Just a small pull request to add translog option to `UpdateIndexLevelSettingsRequest`.
I have added only the non depredated translog arguments https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules-translog.html.

On my computer, 2 unit tests don't pass but I don't know why (not related to my PR).

```Shell
docker-compose up
sbt clean test
...
[info] *** 2 TESTS FAILED ***
[error] Failed tests:
[error]         com.sksamuel.elastic4s.search.queries.DateRangeQueryHttpTest
[error]         com.sksamuel.elastic4s.search.ScrollTest
```

