### PR TITLE
Add support for jvm and indices details on node stats

### DIFF
--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/nodes/domain.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/nodes/domain.scala
@@ -21,11 +21,22 @@ case class OsStats(@JsonProperty("cpu_percent") cpuPercent: Int,
                    mem: MemoryStats,
                    swap: SwapStats)
 
+case class Docs(count: Long)
+
+case class Indices(docs: Docs)
+
+case class Jvm(@JsonProperty("uptime_in_millis") uptimeInMillis: Long) {
+  val uptime: java.time.Duration = java.time.Duration.ofMillis(uptimeInMillis)
+}
+
 case class NodeStats(name: String,
                      @JsonProperty("transport_address") transportAddress: String,
                      host: String,
                      ip: Seq[String],
-                     os: Option[OsStats])
+                     os: Option[OsStats],
+                     roles: Seq[String],
+                     indices: Indices,
+                     jvm: Jvm)
 
 case class NodesStatsResponse(@JsonProperty("cluster_name") clusterName: String, nodes: Map[String, NodeStats])
 


### PR DESCRIPTION
https://www.elastic.co/guide/en/elasticsearch/reference/7.17/cluster-nodes-stats.html

We wanted to get jvm and indices details from the Node Stats API, so are adding support for that here. To get these details using a node stats request, construct one like this:

```
NodeStatsRequest(nodes = Seq.empty, stats = Seq("jvm","indices"))
```
