### PR TITLE
Feat: add support for analyzers in annotated_text fields

### DIFF
--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/AnnotatedTextField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/AnnotatedTextField.scala
@@ -3,6 +3,16 @@ package com.sksamuel.elastic4s.fields
 object AnnotatedTextField {
   val `type` = "annotated_text"
 }
-case class AnnotatedTextField(name: String, copyTo: Seq[String] = Nil) extends ElasticField {
+case class AnnotatedTextField(name: String,
+                              analyzer: Option[String] = None,
+                              searchAnalyzer: Option[String] = None,
+                              searchQuoteAnalyzer: Option[String] = None,
+                              copyTo: Seq[String] = Nil) extends ElasticField {
   override def `type`: String = AnnotatedTextField.`type`
+
+  def analyzer(name: String): AnnotatedTextField = copy(analyzer = Option(name))
+
+  def searchAnalyzer(name: String): AnnotatedTextField = copy(searchAnalyzer = Option(name))
+
+  def searchQuoteAnalyzer(name: String): AnnotatedTextField = copy(searchQuoteAnalyzer = Option(name))
 }

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/AnnotatedTextFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/AnnotatedTextFieldBuilderFn.scala
@@ -6,6 +6,9 @@ import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 object AnnotatedTextFieldBuilderFn {
   def toField(name: String, values: Map[String, Any]): AnnotatedTextField = AnnotatedTextField(
     name,
+    values.get("analyzer").map(_.asInstanceOf[String]),
+    values.get("search_analyzer").map(_.asInstanceOf[String]),
+    values.get("search_quote_analyzer").map(_.asInstanceOf[String]),
     values.get("copy_to").map(_.asInstanceOf[Seq[String]]).getOrElse(Seq.empty)
   )
 
@@ -13,6 +16,11 @@ object AnnotatedTextFieldBuilderFn {
 
     val builder = XContentFactory.jsonBuilder()
     builder.field("type", field.`type`)
+
+    field.analyzer.foreach(builder.field("analyzer", _))
+    field.searchAnalyzer.foreach(builder.field("search_analyzer", _))
+    field.searchQuoteAnalyzer.foreach(builder.field("search_quote_analyzer", _))
+
     if (field.copyTo.nonEmpty) builder.array("copy_to", field.copyTo.toArray)
     builder.endObject()
   }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/fields/ElasticFieldBuilderFnTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/fields/ElasticFieldBuilderFnTest.scala
@@ -102,13 +102,13 @@ class ElasticFieldBuilderFnTest extends AnyWordSpec with Matchers {
         analyzer = Some("standard"),
         searchAnalyzer = Some("standard"),
         searchQuoteAnalyzer = Some("standard"))
-      val jsonString = """{"type":"annotated_text","analyzer":"standard","search_analyzer":"standard","search_quote_analyzer":"standard"]}"""
+      val jsonString = """{"type":"annotated_text","analyzer":"standard","search_analyzer":"standard","search_quote_analyzer":"standard"}"""
 
-      ElasticFieldBuilderFn(field) shouldBe(jsonString)
+      ElasticFieldBuilderFn(field).string() shouldBe(jsonString)
       ElasticFieldBuilderFn.construct(field.name, JacksonSupport.mapper.readValue[Map[String, Any]](jsonString)) shouldBe(field)
 
       val fieldSet = AnnotatedTextField("annotatedText").analyzer("standard").searchAnalyzer("standard").searchQuoteAnalyzer("standard")
-      ElasticFieldBuilderFn(fieldSet) shouldBe(jsonString)
+      ElasticFieldBuilderFn(fieldSet).string() shouldBe(jsonString)
       ElasticFieldBuilderFn.construct(fieldSet.name, JacksonSupport.mapper.readValue[Map[String, Any]](jsonString)) shouldBe(fieldSet)
     }
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/fields/ElasticFieldBuilderFnTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/fields/ElasticFieldBuilderFnTest.scala
@@ -97,6 +97,21 @@ class ElasticFieldBuilderFnTest extends AnyWordSpec with Matchers {
 
     }
 
+    "support AnnotatedTextField analyzers" in {
+      val field = AnnotatedTextField("annotatedText",
+        analyzer = Some("standard"),
+        searchAnalyzer = Some("standard"),
+        searchQuoteAnalyzer = Some("standard"))
+      val jsonString = """{"type":"annotated_text","analyzer":"standard","search_analyzer":"standard","search_quote_analyzer":"standard"]}"""
+
+      ElasticFieldBuilderFn(field) shouldBe(jsonString)
+      ElasticFieldBuilderFn.construct(field.name, JacksonSupport.mapper.readValue[Map[String, Any]](jsonString)) shouldBe(field)
+
+      val fieldSet = AnnotatedTextField("annotatedText").analyzer("standard").searchAnalyzer("standard").searchQuoteAnalyzer("standard")
+      ElasticFieldBuilderFn(fieldSet) shouldBe(jsonString)
+      ElasticFieldBuilderFn.construct(fieldSet.name, JacksonSupport.mapper.readValue[Map[String, Any]](jsonString)) shouldBe(fieldSet)
+    }
+
   }
 
 }


### PR DESCRIPTION
Related issue: #2625 
Adds more parameters for `AnnotatedTextField`:
* analyzer
* searchAnalyzer
* searchQuoteAnalyzer