### PR TITLE
Fix the charset of the argument byte array passed to the ByteArrayEntity

### DIFF
--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/index/IndexHandlers.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/index/IndexHandlers.scala
@@ -49,7 +49,7 @@ trait IndexHandlers {
       request.versionType.map(VersionTypeHttpString.apply).foreach(params.put("version_type", _))
 
       val body   = IndexContentBuilder(request)
-      val entity = ByteArrayEntity(body.getBytes, Some("application/json"))
+      val entity = ByteArrayEntity(body.getBytes(StandardCharsets.UTF_8), Some("application/json"))
 
       logger.debug(s"Endpoint=$endpoint")
       ElasticRequest(method, endpoint, params.toMap, entity)
@@ -84,7 +84,7 @@ trait IndexHandlers {
       }
 
       val body = AnalyseRequestContentBuilder(analyzeRequest)
-      val entity = ByteArrayEntity(body.getBytes, Some("application/json"))
+      val entity = ByteArrayEntity(body.getBytes(StandardCharsets.UTF_8), Some("application/json"))
 
       logger.debug(s"Endpoint=$endpoint")
 


### PR DESCRIPTION
If "file.encoding" property is set, request body of index requests is sent to elasticsearch as the charset specified  by it.

As a result, index requests fail with error like "json_parse_exception,Invalid UTF-8 start byte 0xXX at Source: ByteArrayInputStream" when file.encoding is not utf8.

To fix this problem, fix the charset of the argument byte array passed to the constructor of ByteArrayEntity to utf8.