### PR TITLE
Remove order field of CreateIndexTemplateRequest.

### DIFF
--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/indexes/CreateIndexTemplateRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/indexes/CreateIndexTemplateRequest.scala
@@ -11,7 +11,6 @@ case class CreateIndexTemplateRequest(name: String,
                                       @deprecated("use the new analysis package", "7.0.1")
                                       _analysis: Option[AnalysisDefinition] = None,
                                       analysis: Option[com.sksamuel.elastic4s.analysis.Analysis] = None,
-                                      order: Option[Int] = None,
                                       version: Option[Int] = None,
                                       create: Option[Boolean] = None,
                                       priority: Option[Int] = None,
@@ -57,7 +56,6 @@ case class CreateIndexTemplateRequest(name: String,
   // replaces all settings with the given settings
   def settings(settings: Map[String, Any]): CreateIndexTemplateRequest = copy(settings = settings)
 
-  def order(order: Int): CreateIndexTemplateRequest = copy(order = order.some)
   def create(create: Boolean): CreateIndexTemplateRequest = copy(create = create.some)
 
   def aliases(first: TemplateAlias, rest: TemplateAlias*): CreateIndexTemplateRequest = aliases(first +: rest)

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/index/IndexTemplateHandlers.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/index/IndexTemplateHandlers.scala
@@ -77,7 +77,6 @@ object CreateIndexTemplateBodyFn {
 
     val builder = XContentFactory.jsonBuilder()
     builder.array("index_patterns", create.pattern.toArray)
-    create.order.foreach(builder.field("order", _))
     create.version.foreach(builder.field("version", _))
     create.priority.foreach(builder.field("priority", _))
 


### PR DESCRIPTION
There is no order field in current Create index template API.
https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-put-template.html

So the request with order field fails with "unknown field [order]"  error.

Please let me know if it is better to deprecate the field than to delete.