### PR TITLE
Support arbitrary JSON within GetIndex _meta.

### DIFF
--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/index/IndexHandlers.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/index/IndexHandlers.scala
@@ -94,7 +94,7 @@ trait IndexHandlers {
 }
 
 case class Mapping(properties: Map[String, Field],
-                   @JsonProperty("_meta") meta: Map[String, String] = Map.empty)
+                   @JsonProperty("_meta") meta: Map[String, Any] = Map.empty)
 
 case class Field(`type`: Option[String], properties: Option[Map[String, Field]] = None)
 

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/index/mapping/MappingBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/index/mapping/MappingBuilderFn.scala
@@ -77,15 +77,7 @@ object MappingBuilderFn {
 
     if (d.meta.nonEmpty) {
       builder.startObject("_meta")
-      for (meta <- d.meta)
-        meta match {
-          case (name, s: String) => builder.field(name, s)
-          case (name, s: Double) => builder.field(name, s)
-          case (name, s: Boolean) => builder.field(name, s)
-          case (name, s: Long) => builder.field(name, s)
-          case (name, s: Float) => builder.field(name, s)
-          case (name, s: Int) => builder.field(name, s)
-        }
+      d.meta.foreach { case (k, v) => builder.autofield(k, v) }
       builder.endObject()
     }
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/GetIndexRequestTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexes/GetIndexRequestTest.scala
@@ -78,11 +78,18 @@ class GetIndexRequestTest extends AnyWordSpec with Matchers with DockerTests {
         }.await
       }
 
+      val meta = Map(
+        "foo" -> "bar",
+        "intvalue" -> 1,
+        "mapvalue" -> Map[String, Any]("key" -> "value")
+      )
+
       client.execute {
         createIndex("getindexwithmeta").mapping(
           properties(
             textField("a")
-          ).meta(Map("foo" -> "bar"))
+          )
+          .meta(meta)
         )
       }.await
 
@@ -90,7 +97,7 @@ class GetIndexRequestTest extends AnyWordSpec with Matchers with DockerTests {
         getIndex("getindexwithmeta")
       }.await.result
 
-      resp("getindexwithmeta").mappings.meta shouldBe Map("foo" -> "bar")
+      resp("getindexwithmeta").mappings.meta shouldBe meta
     }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/sksamuel/elastic4s/issues/2678

The previous implementation of the GetIndex handler typed the `_meta` field as a Map[String, String]. This causes failures when fetchingindices that use nested JSON within` _meta`.