### PR TITLE
move size to source in reindex request

### DIFF
--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/reindex/ReindexRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/reindex/ReindexRequest.scala
@@ -26,9 +26,10 @@ case class ReindexRequest(sourceIndexes: Indexes,
                           remoteUser: Option[String] = None,
                           remotePass: Option[String] = None,
                           // It’s also possible to limit the number of processed documents by setting size.
-                          size: Option[Int] = None,
+                          maxDocs: Option[Int] = None,
                           script: Option[Script] = None,
-                          scroll: Option[String] = None) {
+                          scroll: Option[String] = None,
+                          size: Option[Int] = None) {
 
   def remote(uri: String): ReindexRequest = copy(remoteHost = Option(uri))
   def remote(uri: String, user: String, pass: String): ReindexRequest =
@@ -54,7 +55,7 @@ case class ReindexRequest(sourceIndexes: Indexes,
   def retryBackoffInitialTime(retryBackoffInitialTime: FiniteDuration): ReindexRequest =
     copy(retryBackoffInitialTime = retryBackoffInitialTime.some)
 
-  def size(size: Int): ReindexRequest = copy(size = size.some)
+  def maxDocs(maxDocs: Int): ReindexRequest = copy(maxDocs = maxDocs.some)
 
   def shouldStoreResult(shouldStoreResult: Boolean): ReindexRequest =
     copy(shouldStoreResult = shouldStoreResult.some)
@@ -66,4 +67,5 @@ case class ReindexRequest(sourceIndexes: Indexes,
 
   def scroll(scroll: String): ReindexRequest = copy(scroll = scroll.some)
   def scroll(duration: FiniteDuration): ReindexRequest = copy(scroll = Some(duration.toSeconds + "s"))
+  def size(size: Int): ReindexRequest = copy(size = size.some)
 }

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/reindex/ReindexBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/reindex/ReindexBuilderFn.scala
@@ -15,13 +15,15 @@ object ReindexBuilderFn {
       case false => builder.field("conflicts", "abort")
     }
 
-    request.size.foreach(builder.field("size", _))
+    request.maxDocs.foreach(builder.field("max_docs", _))
 
     request.script.foreach { script =>
       builder.rawField("script", handlers.script.ScriptBuilderFn(script))
     }
 
     builder.startObject("source")
+
+    request.size.foreach(builder.field("size", _))
 
     request.remoteHost.foreach { host =>
       builder.startObject("remote")

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/reindex/ReindexTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/reindex/ReindexTest.scala
@@ -41,11 +41,11 @@ class ReindexTest extends AnyWordSpec with Matchers with DockerTests {
 
       client.execute {
         reindex("reindex", "reindextarget").size(2).refresh(RefreshPolicy.IMMEDIATE)
-      }.await.result.left.get.created shouldBe 2
+      }.await.result.left.get.created shouldBe 3
 
       client.execute {
         search("reindextarget")
-      }.await.result.size shouldBe 2
+      }.await.result.size shouldBe 3
     }
     "support script parameter" in {
       deleteIdx("reindextarget")
@@ -73,6 +73,19 @@ class ReindexTest extends AnyWordSpec with Matchers with DockerTests {
         reindex("reindex", "reindextarget").proceedOnConflicts(false).refresh(RefreshPolicy.IMMEDIATE)
       }.await.result.left.get.created shouldBe 3
     }
+    "support maxDocs parameter" in {
+
+      deleteIdx("reindextarget")
+      createIdx("reindextarget")
+
+      client.execute {
+        reindex("reindex", "reindextarget").maxDocs(2).refresh(RefreshPolicy.IMMEDIATE)
+      }.await.result.left.get.created shouldBe 2
+
+      client.execute {
+        search("reindextarget")
+      }.await.result.size shouldBe 2
+    }
     "support multiple sources" in {
 
       deleteIdx("reindextarget")
@@ -93,7 +106,7 @@ class ReindexTest extends AnyWordSpec with Matchers with DockerTests {
     }
     "return a task when setting wait_for_completion to false" in {
       val result = client.execute {
-        reindex("reindex", "reindextarget").size(2).waitForCompletion(false)
+        reindex("reindex", "reindextarget").maxDocs(2).waitForCompletion(false)
       }.await.result.right.get
       result.nodeId should not be null
       result.taskId should not be null


### PR DESCRIPTION
Renamed the size parameter to maxDocs as it was done in elastic4s 8.x.
It limits the number of processed documents.
The new size parameter limits the number of documents to reindex per batch.