### PR TITLE
add size parameter to reindex request

### DIFF
--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/reindex/ReindexRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/reindex/ReindexRequest.scala
@@ -26,7 +26,8 @@ case class ReindexRequest(sourceIndexes: Indexes,
                           // It’s also possible to limit the number of processed documents by setting size.
                           maxDocs: Option[Int] = None,
                           script: Option[Script] = None,
-                          scroll: Option[String] = None) {
+                          scroll: Option[String] = None,
+                          size: Option[Int] = None) {
 
   def remote(uri: String): ReindexRequest = copy(remoteHost = Option(uri))
   def remote(uri: String, user: String, pass: String): ReindexRequest =
@@ -64,4 +65,5 @@ case class ReindexRequest(sourceIndexes: Indexes,
 
   def scroll(scroll: String): ReindexRequest = copy(scroll = scroll.some)
   def scroll(duration: FiniteDuration): ReindexRequest = copy(scroll = Some(duration.toSeconds + "s"))
+  def size(size: Int): ReindexRequest = copy(size = size.some)
 }

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/reindex/ReindexBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/reindex/ReindexBuilderFn.scala
@@ -23,6 +23,8 @@ object ReindexBuilderFn {
 
     builder.startObject("source")
 
+    request.size.foreach(builder.field("size", _))
+
     request.remoteHost.foreach { host =>
       builder.startObject("remote")
       builder.field("host", host)

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/reindex/ReindexTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/reindex/ReindexTest.scala
@@ -34,7 +34,7 @@ class ReindexTest extends AnyWordSpec with Matchers with DockerTests {
         search("reindextarget")
       }.await.result.size shouldBe 3
     }
-    "support size parameter" in {
+    "support maxDocs parameter" in {
 
       deleteIdx("reindextarget")
       createIdx("reindextarget")
@@ -72,6 +72,19 @@ class ReindexTest extends AnyWordSpec with Matchers with DockerTests {
       client.execute {
         reindex("reindex", "reindextarget").proceedOnConflicts(false).refresh(RefreshPolicy.IMMEDIATE)
       }.await.result.left.get.created shouldBe 3
+    }
+    "support size parameter" in {
+
+      deleteIdx("reindextarget")
+      createIdx("reindextarget")
+
+      client.execute {
+        reindex("reindex", "reindextarget").size(2).refresh(RefreshPolicy.IMMEDIATE)
+      }.await.result.left.get.created shouldBe 3
+
+      client.execute {
+        search("reindextarget")
+      }.await.result.size shouldBe 3
     }
     "support multiple sources" in {
 


### PR DESCRIPTION
This parameter limits the number of documents to reindex per batch.
This is a cherry-pick from 7.17.x