### PR TITLE
Make SpanNotQuery, SpanContainaingQuery and SpanWithinQuery inherit SpanQuery

### DIFF
--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/span/SpanContainingQuery.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/span/SpanContainingQuery.scala
@@ -1,13 +1,12 @@
 package com.sksamuel.elastic4s.requests.searches.span
 
-import com.sksamuel.elastic4s.requests.searches.queries.Query
 import com.sksamuel.elastic4s.ext.OptionImplicits._
 
 case class SpanContainingQuery(little: SpanQuery,
                                big: SpanQuery,
                                boost: Option[Double] = None,
                                queryName: Option[String] = None)
-  extends Query {
+  extends SpanQuery {
 
   def boost(boost: Double): SpanContainingQuery = copy(boost = boost.some)
   def queryName(queryName: String): SpanContainingQuery = copy(queryName = queryName.some)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/span/SpanNotQuery.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/span/SpanNotQuery.scala
@@ -1,6 +1,5 @@
 package com.sksamuel.elastic4s.requests.searches.span
 
-import com.sksamuel.elastic4s.requests.searches.queries.Query
 import com.sksamuel.elastic4s.ext.OptionImplicits._
 
 case class SpanNotQuery(include: SpanQuery,
@@ -10,7 +9,7 @@ case class SpanNotQuery(include: SpanQuery,
                         post: Option[Int] = None,
                         boost: Option[Double] = None,
                         queryName: Option[String] = None)
-  extends Query {
+  extends SpanQuery {
 
   def boost(boost: Double): SpanNotQuery = copy(boost = Option(boost))
   def queryName(queryName: String): SpanNotQuery = copy(queryName = queryName.some)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/span/SpanWithinQuery.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/span/SpanWithinQuery.scala
@@ -1,13 +1,12 @@
 package com.sksamuel.elastic4s.requests.searches.span
 
-import com.sksamuel.elastic4s.requests.searches.queries.Query
 import com.sksamuel.elastic4s.ext.OptionImplicits._
 
 case class SpanWithinQuery(little: SpanQuery,
                            big: SpanQuery,
                            boost: Option[Double] = None,
                            queryName: Option[String] = None)
-  extends Query {
+  extends SpanQuery {
 
   def boost(boost: Double): SpanWithinQuery = copy(boost = boost.some)
   def queryName(queryName: String): SpanWithinQuery = copy(queryName = queryName.some)


### PR DESCRIPTION
As suggested by Elasticsearch documentation (https://www.elastic.co/guide/en/elasticsearch/reference/current/span-queries.html), these classes should be subclasses of `SpanQuery`.