### PR TITLE
Fix text field builder

### DIFF
--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/TextFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/TextFieldBuilderFn.scala
@@ -67,7 +67,7 @@ object TextFieldBuilderFn {
     field.indexPrefixes.foreach { prefix =>
       builder.startObject("index_prefixes")
       builder.field("min_chars", prefix.minChars)
-      builder.field("min_chars", prefix.maxChars)
+      builder.field("max_chars", prefix.maxChars)
       builder.endObject()
     }
     field.indexPhrases.foreach(builder.field("index_phrases", _))


### PR DESCRIPTION
The max chars in the index prefixes mapping should be the max_chars field in the request to elasticsearch 