### PR TITLE
Support asynchronous update by query

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/api/UpdateApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/api/UpdateApi.scala
@@ -1,14 +1,19 @@
 package com.sksamuel.elastic4s.api
 
 import com.sksamuel.elastic4s.requests.searches.queries.Query
-import com.sksamuel.elastic4s.requests.update.{UpdateByQueryRequest, UpdateRequest}
+import com.sksamuel.elastic4s.requests.update.{UpdateByQueryAsyncRequest, UpdateByQueryRequest, UpdateRequest}
 import com.sksamuel.elastic4s.{Index, Indexes}
 
 trait UpdateApi {
 
   def updateById(index: Index, id: String): UpdateRequest = UpdateRequest(index.name, id)
 
-  def updateByQuery(index: Index, query: Query): UpdateByQueryRequest = UpdateByQueryRequest(index.name, query)
+  @deprecated("Use updateByQuerySync", "8.4")
+  def updateByQuery(index: Index, query: Query): UpdateByQueryRequest = updateByQuerySync(index, query)
+
+  def updateByQuerySync(index: Index, query: Query): UpdateByQueryRequest = UpdateByQueryRequest(index.name, query)
+
+  def updateByQueryAsync(index: Index, query: Query): UpdateByQueryAsyncRequest = UpdateByQueryAsyncRequest(index.name, query)
 
   @deprecated("use updateById", "7.7")
   def update(id: String): UpdateExpectsIn = new UpdateExpectsIn(id)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryAsyncRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryAsyncRequest.scala
@@ -1,0 +1,67 @@
+package com.sksamuel.elastic4s.requests.update
+
+import com.sksamuel.elastic4s.Indexes
+import com.sksamuel.elastic4s.ext.OptionImplicits._
+import com.sksamuel.elastic4s.requests.common.{RefreshPolicy, Slice}
+import com.sksamuel.elastic4s.requests.script.Script
+import com.sksamuel.elastic4s.requests.searches.queries.Query
+
+import scala.concurrent.duration.FiniteDuration
+
+case class UpdateByQueryAsyncRequest(indexes: Indexes,
+                                     query: Query,
+                                     requestsPerSecond: Option[Float] = None,
+                                     maxRetries: Option[Int] = None,
+                                     proceedOnConflicts: Option[Boolean] = None,
+                                     pipeline: Option[String] = None,
+                                     refresh: Option[RefreshPolicy] = None,
+                                     script: Option[Script] = None,
+                                     waitForActiveShards: Option[Int] = None,
+                                     retryBackoffInitialTime: Option[FiniteDuration] = None,
+                                     scroll: Option[String] = None,
+                                     scrollSize: Option[Int] = None,
+                                     slices: Option[Int] = None,
+                                     slice: Option[Slice] = None,
+                                     timeout: Option[FiniteDuration] = None,
+                                     shouldStoreResult: Option[Boolean] = None,
+                                     size: Option[Int] = None) extends BaseUpdateByQueryRequest {
+
+  def proceedOnConflicts(proceedOnConflicts: Boolean): UpdateByQueryAsyncRequest =
+    copy(proceedOnConflicts = proceedOnConflicts.some)
+
+  def refresh(refresh: RefreshPolicy): UpdateByQueryAsyncRequest = {
+    if (refresh == RefreshPolicy.WAIT_FOR) throw new UnsupportedOperationException("Update by query does not support RefreshPolicy.WAIT_FOR")
+    copy(refresh = refresh.some)
+  }
+  def refreshImmediately: UpdateByQueryAsyncRequest = refresh(RefreshPolicy.IMMEDIATE)
+
+  def scroll(scroll: String): UpdateByQueryAsyncRequest = copy(scroll = scroll.some)
+  def scroll(duration: FiniteDuration): UpdateByQueryAsyncRequest = copy(scroll = Some(duration.toSeconds + "s"))
+
+  def scrollSize(scrollSize: Int): UpdateByQueryAsyncRequest = copy(scrollSize = scrollSize.some)
+  def slice(slice: Slice): UpdateByQueryAsyncRequest = copy(slice = slice.some)
+  def slices(slices: Int): UpdateByQueryAsyncRequest = copy(slices = slices.some)
+
+  def requestsPerSecond(requestsPerSecond: Float): UpdateByQueryAsyncRequest =
+    copy(requestsPerSecond = requestsPerSecond.some)
+
+  def maxRetries(maxRetries: Int): UpdateByQueryAsyncRequest = copy(maxRetries = maxRetries.some)
+
+  def waitForActiveShards(waitForActiveShards: Int): UpdateByQueryAsyncRequest =
+    copy(waitForActiveShards = waitForActiveShards.some)
+
+  def retryBackoffInitialTime(retryBackoffInitialTime: FiniteDuration): UpdateByQueryAsyncRequest =
+    copy(retryBackoffInitialTime = retryBackoffInitialTime.some)
+
+  def timeout(timeout: FiniteDuration): UpdateByQueryAsyncRequest = copy(timeout = timeout.some)
+
+  def size(size: Int): UpdateByQueryAsyncRequest = copy(size = size.some)
+
+  def script(script: Script): UpdateByQueryAsyncRequest = copy(script = script.some)
+  def script(source: String): UpdateByQueryAsyncRequest = script(Script(source))
+
+  def shouldStoreResult(shouldStoreResult: Boolean): UpdateByQueryAsyncRequest =
+    copy(shouldStoreResult = shouldStoreResult.some)
+
+  override val waitForCompletion: Option[Boolean] = Some(false)
+}

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryAsyncResponse.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryAsyncResponse.scala
@@ -1,0 +1,7 @@
+package com.sksamuel.elastic4s.requests.update
+
+import com.sksamuel.elastic4s.requests.task.GetTask
+
+case class UpdateByQueryAsyncResponse(task : String)
+
+case class UpdateByQueryTask(task: GetTask)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryRequest.scala
@@ -8,6 +8,43 @@ import com.sksamuel.elastic4s.ext.OptionImplicits._
 
 import scala.concurrent.duration.FiniteDuration
 
+trait BaseUpdateByQueryRequest {
+  val indexes: Indexes
+
+  val query: Query
+
+  val requestsPerSecond: Option[Float]
+
+  val maxRetries: Option[Int]
+
+  val proceedOnConflicts: Option[Boolean]
+
+  val pipeline: Option[String]
+
+  val refresh: Option[RefreshPolicy]
+
+  val script: Option[Script]
+
+  val waitForActiveShards: Option[Int]
+
+  val retryBackoffInitialTime: Option[FiniteDuration]
+
+  val scroll: Option[String]
+
+  val scrollSize: Option[Int]
+
+  val slices: Option[Int]
+
+  val slice: Option[Slice]
+
+  val timeout: Option[FiniteDuration]
+
+  val shouldStoreResult: Option[Boolean]
+
+  val size: Option[Int]
+
+  val waitForCompletion: Option[Boolean]
+}
 case class UpdateByQueryRequest(indexes: Indexes,
                                 query: Query,
                                 requestsPerSecond: Option[Float] = None,
@@ -17,6 +54,7 @@ case class UpdateByQueryRequest(indexes: Indexes,
                                 refresh: Option[RefreshPolicy] = None,
                                 script: Option[Script] = None,
                                 waitForActiveShards: Option[Int] = None,
+                                @deprecated("This class is for synchronous updates. If you put false, use UpdateByQueryAsyncRequest instead", "8.4")
                                 waitForCompletion: Option[Boolean] = None,
                                 retryBackoffInitialTime: Option[FiniteDuration] = None,
                                 scroll: Option[String] = None,
@@ -25,7 +63,7 @@ case class UpdateByQueryRequest(indexes: Indexes,
                                 slice: Option[Slice] = None,
                                 timeout: Option[FiniteDuration] = None,
                                 shouldStoreResult: Option[Boolean] = None,
-                                size: Option[Int] = None) {
+                                size: Option[Int] = None) extends BaseUpdateByQueryRequest {
 
   def proceedOnConflicts(proceedOnConflicts: Boolean): UpdateByQueryRequest =
     copy(proceedOnConflicts = proceedOnConflicts.some)
@@ -51,6 +89,7 @@ case class UpdateByQueryRequest(indexes: Indexes,
   def waitForActiveShards(waitForActiveShards: Int): UpdateByQueryRequest =
     copy(waitForActiveShards = waitForActiveShards.some)
 
+  @deprecated("This class is for synchronous updates. If you put false, use UpdateByQueryAsyncRequest instead", "8.4")
   def waitForCompletion(w: Boolean): UpdateByQueryRequest = copy(waitForCompletion = w.some)
 
   def retryBackoffInitialTime(retryBackoffInitialTime: FiniteDuration): UpdateByQueryRequest =


### PR DESCRIPTION
Current implementation of update by query allows to put `waitForCompletion`to false, however, the response format changes when this field value is false (https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-update-by-query.html#docs-update-by-query-task-api). The response will contain only a task id. The current response format does not allow to get the task id.

This PR provides a new API allowing to explicitly make an asynchronous update by query that returns a `GetTask`object allowing to then query for the task progress.

It is meant to be API compatible, type safe and less ambiguous. Current users would not need to modify their working code, that means that code using `UpdateByQueryRequest.waitForCompletion(true)`will remain valid, but it is now deprecated in favour of `updateByQueryAsync`.