### PR TITLE
Runtime composite fields

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/SearchBodyBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/SearchBodyBuilderFn.scala
@@ -134,6 +134,16 @@ object SearchBodyBuilderFn {
         mapping.script.foreach {
           script => builder.rawField("script", ScriptBuilderFn(script))
         }
+        if (mapping.fields.nonEmpty) {
+          builder.startObject("fields")
+          mapping.fields.foreach {
+            field =>
+              builder.startObject(field.name)
+              builder.field("type", field.`type`)
+              builder.endObject()
+          }
+          builder.endObject()
+        }
         builder.endObject()
       }
       builder.endObject()

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/RuntimeMapping.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/RuntimeMapping.scala
@@ -2,12 +2,20 @@ package com.sksamuel.elastic4s.requests.searches
 
 import com.sksamuel.elastic4s.requests.script.Script
 
-case class RuntimeMapping(field: String, `type`: String, script: Option[Script] = None)
+case class RuntimeMapping(field: String, `type`: String, script: Option[Script] = None, fields: Seq[RuntimeMapping.Field] = Seq.empty)
 
 object RuntimeMapping {
   def apply(field: String, `type`: String, script: Script): RuntimeMapping =
     RuntimeMapping(field, `type`, Some(script))
 
+  def apply(field: String, `type`: String, script: Script, fields: Seq[Field]): RuntimeMapping =
+    RuntimeMapping(field, `type`, Some(script), fields)
+
   def apply(field: String, `type`: String, scriptSource: String): RuntimeMapping =
     RuntimeMapping(field, `type`, Some(Script(scriptSource)))
+
+  def apply(field: String, `type`: String, scriptSource: String, fields: Seq[Field]): RuntimeMapping =
+    RuntimeMapping(field, `type`, Some(Script(scriptSource)), fields)
+
+  final case class Field(name: String, `type`: String)
 }


### PR DESCRIPTION
Runtime composite fields are useful to generate multiple fields with a single script. See https://www.elastic.co/guide/en/elasticsearch/reference/current/runtime-examples.html#runtime-examples-grok-composite for more documentation.