### PR TITLE
Feat: add support for date format in runtime mappings

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/SearchBodyBuilderFn.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/SearchBodyBuilderFn.scala
@@ -133,6 +133,9 @@ object SearchBodyBuilderFn {
       request.runtimeMappings.foreach { mapping =>
         builder.startObject(mapping.field)
         builder.field("type", mapping.`type`)
+
+        // format is only allowed with a type of date
+        mapping.format.foreach(builder.field("format", _))
         mapping.script.foreach {
           script => builder.rawField("script", ScriptBuilderFn(script))
         }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/RuntimeMapping.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/RuntimeMapping.scala
@@ -2,20 +2,20 @@ package com.sksamuel.elastic4s.requests.searches
 
 import com.sksamuel.elastic4s.requests.script.Script
 
-case class RuntimeMapping(field: String, `type`: String, script: Option[Script] = None, fields: Seq[RuntimeMapping.Field] = Seq.empty)
+case class RuntimeMapping(field: String, `type`: String, format: Option[String] = None, script: Option[Script] = None, fields: Seq[RuntimeMapping.Field] = Seq.empty)
 
 object RuntimeMapping {
   def apply(field: String, `type`: String, script: Script): RuntimeMapping =
-    RuntimeMapping(field, `type`, Some(script))
+    RuntimeMapping(field, `type`, None, Some(script))
 
   def apply(field: String, `type`: String, script: Script, fields: Seq[Field]): RuntimeMapping =
-    RuntimeMapping(field, `type`, Some(script), fields)
+    RuntimeMapping(field, `type`, None, Some(script), fields)
 
   def apply(field: String, `type`: String, scriptSource: String): RuntimeMapping =
-    RuntimeMapping(field, `type`, Some(Script(scriptSource)))
+    RuntimeMapping(field, `type`, None, Some(Script(scriptSource)))
 
   def apply(field: String, `type`: String, scriptSource: String, fields: Seq[Field]): RuntimeMapping =
-    RuntimeMapping(field, `type`, Some(Script(scriptSource)), fields)
+    RuntimeMapping(field, `type`, None, Some(Script(scriptSource)), fields)
 
   final case class Field(name: String, `type`: String)
 }


### PR DESCRIPTION
Runtime mappings support format attribute:

https://www.elastic.co/guide/en/elasticsearch/reference/8.9/runtime-mapping-fields.html
Runtime fields with a type of date can accept the [format](https://www.elastic.co/guide/en/elasticsearch/reference/8.9/mapping-date-format.html) parameter exactly as the date field type.

I am not sure if any type checking on field to corroborate it is a DateField is necessary.

Anyhow elastic returns an error if format is not on a DateField.