### PR TITLE
Typo in elastic4s-streams-pekko artifact name

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -272,7 +272,7 @@ lazy val akkastreams = (project in file("elastic4s-streams-akka"))
 
 lazy val pekkostreams = (project in file("elastic4s-streams-pekko"))
   .dependsOn(core, testkit % "test", jackson % "test")
-  .settings(name := "elastic4s-streams-pkko")
+  .settings(name := "elastic4s-streams-pekko")
   .settings(scala3Settings)
   .settings(libraryDependencies += Dependencies.pekkoStream)
 

--- a/build.sbt
+++ b/build.sbt
@@ -125,6 +125,7 @@ lazy val scala3Projects: Seq[ProjectReference] = Seq(
     clientcore,
     clientesjava,
     clientsSniffed,
+    clientpekko,
     cats_effect,
     cats_effect_2,
     zio_1,


### PR DESCRIPTION
* Unfortunately I made a typo
* `elastic4s-clint-pekko` was not published to Scala 3