### PR TITLE
Reduce buildBulkHttpBody's retained set by making BulkBuilderFn return an Iterator

### DIFF
--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/bulk/BulkHandlers.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/bulk/BulkHandlers.scala
@@ -28,7 +28,7 @@ trait BulkHandlers {
 
   private[bulk] def buildBulkHttpBody(bulk: BulkRequest): String = {
     val builder = StringBuilder.newBuilder
-    val rows: Seq[String] = BulkBuilderFn(bulk)
+    val rows: Iterator[String] = BulkBuilderFn(bulk)
     rows.addString(builder, "", "\n", "")
     builder.append("\n") // es seems to require a trailing new line as well
     builder.mkString


### PR DESCRIPTION
There's no need to keep all the rows in memory at the same time.