### PR TITLE
remove deprecated JVM option

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,4 +1,3 @@
 -J-Xmx4G
 -J-XX:MaxMetaspaceSize=1G
--J-XX:+CMSClassUnloadingEnabled
 -J-XX:+UseG1GC


### PR DESCRIPTION
`+CMSClassUnloadingEnabled` is not supported on newer JVMs.