### PR TITLE
Add time_series_* parameters to numeric field types

### DIFF
--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/ByteField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/ByteField.scala
@@ -13,6 +13,8 @@ case class ByteField(
     index: Option[Boolean] = None,
     nullValue: Option[Byte] = None,
     store: Option[Boolean] = None,
+    timeSeriesDimension: Option[Boolean] = None,
+    timeSeriesMetric: Option[String] = None,
     meta: Map[String, Any] = Map.empty
 ) extends NumberField[Byte] {
   override def `type`: String = ByteField.`type`

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DoubleField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DoubleField.scala
@@ -15,6 +15,7 @@ case class DoubleField(
     index: Option[Boolean] = None,
     nullValue: Option[Double] = None,
     store: Option[Boolean] = None,
+    timeSeriesMetric: Option[String] = None,
     meta: Map[String, Any] = Map.empty
 ) extends NumberField[Double] {
   override def `type`: String = DoubleField.`type`

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/FloatField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/FloatField.scala
@@ -13,6 +13,7 @@ case class FloatField(
     index: Option[Boolean] = None,
     nullValue: Option[Float] = None,
     store: Option[Boolean] = None,
+    timeSeriesMetric: Option[String] = None,
     meta: Map[String, Any] = Map.empty
 ) extends NumberField[Float] {
   override def `type`: String = FloatField.`type`

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/HalfFloatField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/HalfFloatField.scala
@@ -13,6 +13,7 @@ case class HalfFloatField(
     index: Option[Boolean] = None,
     nullValue: Option[Float] = None,
     store: Option[Boolean] = None,
+    timeSeriesMetric: Option[String] = None,
     meta: Map[String, Any] = Map.empty
 ) extends NumberField[Float] {
   override def `type`: String = HalfFloatField.`type`

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/IntegerField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/IntegerField.scala
@@ -15,6 +15,8 @@ case class IntegerField(
     index: Option[Boolean] = None,
     nullValue: Option[Int] = None,
     store: Option[Boolean] = None,
+    timeSeriesDimension: Option[Boolean] = None,
+    timeSeriesMetric: Option[String] = None,
     meta: Map[String, Any] = Map.empty
 ) extends NumberField[Int] {
   override def `type`: String = IntegerField.`type`

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/LongField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/LongField.scala
@@ -13,6 +13,8 @@ case class LongField(
     index: Option[Boolean] = None,
     store: Option[Boolean] = None,
     nullValue: Option[Long] = None,
+    timeSeriesDimension: Option[Boolean] = None,
+    timeSeriesMetric: Option[String] = None,
     meta: Map[String, Any] = Map.empty
 ) extends NumberField[Long] {
   override def `type`: String = LongField.`type`

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/NumberField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/NumberField.scala
@@ -9,4 +9,5 @@ trait NumberField[T] extends ElasticField {
   def docValues: Option[Boolean]
   def nullValue: Option[T]
   def copyTo: Seq[String]
+  def timeSeriesMetric: Option[String]
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/ScaledFloatField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/ScaledFloatField.scala
@@ -14,6 +14,7 @@ case class ScaledFloatField(
     index: Option[Boolean] = None,
     nullValue: Option[Float] = None,
     store: Option[Boolean] = None,
+    timeSeriesMetric: Option[String] = None,
     meta: Map[String, Any] = Map.empty
 ) extends NumberField[Float] {
   override def `type`: String = "scaled_float"

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/ShortField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/ShortField.scala
@@ -14,6 +14,8 @@ case class ShortField(
     index: Option[Boolean] = None,
     nullValue: Option[Short] = None,
     store: Option[Boolean] = None,
+    timeSeriesDimension: Option[Boolean] = None,
+    timeSeriesMetric: Option[String] = None,
     meta: Map[String, Any] = Map.empty
 ) extends NumberField[Short] {
   override def `type`: String = ShortField.`type`

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/UnsignedLongField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/UnsignedLongField.scala
@@ -13,6 +13,8 @@ case class UnsignedLongField(
     index: Option[Boolean] = None,
     store: Option[Boolean] = None,
     nullValue: Option[Long] = None,
+    timeSeriesDimension: Option[Boolean] = None,
+    timeSeriesMetric: Option[String] = None,
     meta: Map[String, Any] = Map.empty
 ) extends NumberField[Long] {
   override def `type`: String = UnsignedLongField.`type`

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/UnsignedLongStringField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/UnsignedLongStringField.scala
@@ -13,6 +13,8 @@ case class UnsignedLongStringField(
     index: Option[Boolean] = None,
     store: Option[Boolean] = None,
     nullValue: Option[String] = None,
+    timeSeriesDimension: Option[Boolean] = None,
+    timeSeriesMetric: Option[String] = None,
     meta: Map[String, Any] = Map.empty
 ) extends NumberField[String] {
   override def `type`: String = UnsignedLongStringField.`type`

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/NumberFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/NumberFieldBuilderFn.scala
@@ -26,7 +26,9 @@ object NumberFieldBuilderFn {
         values.get("ignore_malformed").map(_.asInstanceOf[Boolean]),
         values.get("index").map(_.asInstanceOf[Boolean]),
         values.get("null_value").map(_.asInstanceOf[Number]).map(_.byteValue()),
-        values.get("store").map(_.asInstanceOf[Boolean])
+        values.get("store").map(_.asInstanceOf[Boolean]),
+        values.get("time_series_dimension").map(_.asInstanceOf[Boolean]),
+        values.get("time_series_metric").map(_.asInstanceOf[String])
       )
     case DoubleField.`type`       => DoubleField(
         name,
@@ -37,7 +39,8 @@ object NumberFieldBuilderFn {
         values.get("ignore_malformed").map(_.asInstanceOf[Boolean]),
         values.get("index").map(_.asInstanceOf[Boolean]),
         values.get("null_value").map(_.asInstanceOf[Number]).map(_.doubleValue()),
-        values.get("store").map(_.asInstanceOf[Boolean])
+        values.get("store").map(_.asInstanceOf[Boolean]),
+        values.get("time_series_metric").map(_.asInstanceOf[String])
       )
     case FloatField.`type`        => FloatField(
         name,
@@ -48,7 +51,8 @@ object NumberFieldBuilderFn {
         values.get("ignore_malformed").map(_.asInstanceOf[Boolean]),
         values.get("index").map(_.asInstanceOf[Boolean]),
         values.get("null_value").map(_.asInstanceOf[Number]).map(_.floatValue()),
-        values.get("store").map(_.asInstanceOf[Boolean])
+        values.get("store").map(_.asInstanceOf[Boolean]),
+        values.get("time_series_metric").map(_.asInstanceOf[String])
       )
     case HalfFloatField.`type`    => HalfFloatField(
         name,
@@ -59,7 +63,8 @@ object NumberFieldBuilderFn {
         values.get("ignore_malformed").map(_.asInstanceOf[Boolean]),
         values.get("index").map(_.asInstanceOf[Boolean]),
         values.get("null_value").map(_.asInstanceOf[Number]).map(_.floatValue()),
-        values.get("store").map(_.asInstanceOf[Boolean])
+        values.get("store").map(_.asInstanceOf[Boolean]),
+        values.get("time_series_metric").map(_.asInstanceOf[String])
       )
     case ScaledFloatField.`type`  => ScaledFloatField(
         name,
@@ -71,7 +76,8 @@ object NumberFieldBuilderFn {
         values.get("scaling_factor").map(_.asInstanceOf[Int]),
         values.get("index").map(_.asInstanceOf[Boolean]),
         values.get("null_value").map(_.asInstanceOf[Number]).map(_.floatValue()),
-        values.get("store").map(_.asInstanceOf[Boolean])
+        values.get("store").map(_.asInstanceOf[Boolean]),
+        values.get("time_series_metric").map(_.asInstanceOf[String])
       )
     case IntegerField.`type`      => IntegerField(
         name,
@@ -82,7 +88,9 @@ object NumberFieldBuilderFn {
         values.get("ignore_malformed").map(_.asInstanceOf[Boolean]),
         values.get("index").map(_.asInstanceOf[Boolean]),
         values.get("null_value").map(_.asInstanceOf[Number]).map(_.intValue()),
-        values.get("store").map(_.asInstanceOf[Boolean])
+        values.get("store").map(_.asInstanceOf[Boolean]),
+        values.get("time_series_dimension").map(_.asInstanceOf[Boolean]),
+        values.get("time_series_metric").map(_.asInstanceOf[String])
       )
     case LongField.`type`         => LongField(
         name,
@@ -93,7 +101,9 @@ object NumberFieldBuilderFn {
         values.get("ignore_malformed").map(_.asInstanceOf[Boolean]),
         values.get("index").map(_.asInstanceOf[Boolean]),
         values.get("store").map(_.asInstanceOf[Boolean]),
-        values.get("null_value").map(_.asInstanceOf[Number]).map(_.longValue())
+        values.get("null_value").map(_.asInstanceOf[Number]).map(_.longValue()),
+        values.get("time_series_dimension").map(_.asInstanceOf[Boolean]),
+        values.get("time_series_metric").map(_.asInstanceOf[String])
       )
     case ShortField.`type`        => ShortField(
         name,
@@ -105,7 +115,9 @@ object NumberFieldBuilderFn {
         values.get("ignore_malformed").map(_.asInstanceOf[Boolean]),
         values.get("index").map(_.asInstanceOf[Boolean]),
         values.get("null_value").map(_.asInstanceOf[Number]).map(_.shortValue()),
-        values.get("store").map(_.asInstanceOf[Boolean])
+        values.get("store").map(_.asInstanceOf[Boolean]),
+        values.get("time_series_dimension").map(_.asInstanceOf[Boolean]),
+        values.get("time_series_metric").map(_.asInstanceOf[String])
       )
     case UnsignedLongField.`type` => UnsignedLongField(
         name,
@@ -116,7 +128,9 @@ object NumberFieldBuilderFn {
         values.get("ignore_malformed").map(_.asInstanceOf[Boolean]),
         values.get("index").map(_.asInstanceOf[Boolean]),
         values.get("store").map(_.asInstanceOf[Boolean]),
-        values.get("null_value").map(_.asInstanceOf[Number]).map(_.longValue())
+        values.get("null_value").map(_.asInstanceOf[Number]).map(_.longValue()),
+        values.get("time_series_dimension").map(_.asInstanceOf[Boolean]),
+        values.get("time_series_metric").map(_.asInstanceOf[String])
       )
   }
 
@@ -149,6 +163,22 @@ object NumberFieldBuilderFn {
         f.scalingFactor.foreach(builder.field("scaling_factor", _))
       case _                   =>
     }
+
+    field match {
+      case f: ByteField         =>
+        f.timeSeriesDimension.foreach(builder.field("time_series_dimension", _))
+      case f: ShortField        =>
+        f.timeSeriesDimension.foreach(builder.field("time_series_dimension", _))
+      case f: IntegerField      =>
+        f.timeSeriesDimension.foreach(builder.field("time_series_dimension", _))
+      case f: LongField         =>
+        f.timeSeriesDimension.foreach(builder.field("time_series_dimension", _))
+      case f: UnsignedLongField =>
+        f.timeSeriesDimension.foreach(builder.field("time_series_dimension", _))
+      case _                    =>
+    }
+
+    field.timeSeriesMetric.foreach(builder.field("time_series_metric", _))
 
     builder.endObject()
   }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/fields/LongFieldTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/fields/LongFieldTest.scala
@@ -16,11 +16,13 @@ class LongFieldTest extends AnyFunSuite with Matchers {
       nullValue = Some(142),
       ignoreMalformed = Some(true),
       index = Some(true),
-      copyTo = List("q", "er")
+      copyTo = List("q", "er"),
+      timeSeriesDimension = Some(true),
+      timeSeriesMetric = Some("gauge")
     )
 
     val jsonStringValue =
-      """{"type":"long","copy_to":["q","er"],"boost":1.2,"index":true,"null_value":142,"store":true,"coerce":true,"ignore_malformed":true}"""
+      """{"type":"long","copy_to":["q","er"],"boost":1.2,"index":true,"null_value":142,"store":true,"coerce":true,"ignore_malformed":true,"time_series_dimension":true,"time_series_metric":"gauge"}"""
     ElasticFieldBuilderFn(field).string shouldBe jsonStringValue
     ElasticFieldBuilderFn.construct(
       field.name,


### PR DESCRIPTION
Applying this PR will add the time_series_dimension (where applicable) and time_series_metric parameters (all) to the numeric field types.