### PR TITLE
Fix double encoding path for http4s client

### DIFF
--- a/elastic4s-client-http4s/src/main/scala/com/sksamuel/elastic4s/http4s/Http4sClient.scala
+++ b/elastic4s-client-http4s/src/main/scala/com/sksamuel/elastic4s/http4s/Http4sClient.scala
@@ -13,7 +13,7 @@ object Http4sClient {
       endpoint: ElasticNodeEndpoint
   ): Http4sClient[F] = {
     val uri = http4s.Uri(
-      scheme = Some(http4s.Uri.Scheme.http),
+      scheme = endpoint.prefix.flatMap(http4s.Uri.Scheme.fromString(_).toOption),
       authority = Some(http4s.Uri.Authority(host = http4s.Uri.RegName(endpoint.host), port = Some(endpoint.port)))
     )
     new Http4sClient(

--- a/elastic4s-client-http4s/src/main/scala/com/sksamuel/elastic4s/http4s/RequestResponseConverters.scala
+++ b/elastic4s-client-http4s/src/main/scala/com/sksamuel/elastic4s/http4s/RequestResponseConverters.scala
@@ -14,7 +14,7 @@ trait RequestResponseConverters extends Elastic4sEntityEncoders {
   ): http4s.Request[F] = {
     val uri =
       endpoint.copy(
-        path = http4s.Uri.Path(request.endpoint.stripPrefix("/").split('/').map(http4s.Uri.Path.Segment(_)).toVector),
+        path = http4s.Uri.Path(request.endpoint.stripPrefix("/").split('/').map(http4s.Uri.Path.Segment.encoded).toVector),
         query = http4s.Query.fromPairs(request.params.toList: _*)
       )
 

--- a/elastic4s-client-http4s/src/main/scala/com/sksamuel/elastic4s/http4s/RequestResponseConverters.scala
+++ b/elastic4s-client-http4s/src/main/scala/com/sksamuel/elastic4s/http4s/RequestResponseConverters.scala
@@ -14,7 +14,8 @@ trait RequestResponseConverters extends Elastic4sEntityEncoders {
   ): http4s.Request[F] = {
     val uri =
       endpoint.copy(
-        path = http4s.Uri.Path(request.endpoint.stripPrefix("/").split('/').map(http4s.Uri.Path.Segment.encoded).toVector),
+        path =
+          http4s.Uri.Path(request.endpoint.stripPrefix("/").split('/').map(http4s.Uri.Path.Segment.encoded).toVector),
         query = http4s.Query.fromPairs(request.params.toList: _*)
       )
 

--- a/elastic4s-client-http4s/src/test/scala/com/sksamuel/elastic4s/http4s/Http4sRequestHttpClientTest.scala
+++ b/elastic4s-client-http4s/src/test/scala/com/sksamuel/elastic4s/http4s/Http4sRequestHttpClientTest.scala
@@ -34,4 +34,10 @@ class Http4sRequestHttpClientTest extends AnyFlatSpec with Matchers with DockerT
     }.unsafeRunSync().result.status shouldBe "401"
   }
 
+  it should "be able index document with id properly" in {
+    val id = "id://test-id"
+    ioClient.execute {
+      indexInto("testindex").withId(id)
+    }.unsafeRunSync().result.id shouldBe id
+  }
 }


### PR DESCRIPTION
When using http4s client I found that id is stored incorrectly in ElasticSearch in case then it contains special characters. The trouble was in final resulting  URL.  

`ElasticUrlEncoder` in `IndexHandler` encoded path and convertor `org.http4s.Segment.apply` in `RequestResponseConverters. elasticRequestToHttp4sRequest` also encoded path before sending request.