### PR TITLE
Add bool filter constructor to QueryApi

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/api/QueryApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/api/QueryApi.scala
@@ -287,6 +287,10 @@ trait QueryApi {
   def not(queries: Query*): BoolQuery          = BoolQuery().not(queries: _*)
   def not(queries: Iterable[Query]): BoolQuery = BoolQuery().not(queries)
 
+  // short cut for a boolean query with filters
+  def filter(first: Query, rest: Query*): BoolQuery = filter(first +: rest)
+  def filter(queries: Iterable[Query]): BoolQuery   = BoolQuery().filter(queries)
+
   def sparseVectorQuery(field: String, inferenceId: String, query: String): SparseVectorQuery =
     SparseVectorQuery(field, inferenceId = Some(inferenceId), query = Some(query))
 


### PR DESCRIPTION
Hello,

First PR here, so sorry if I've broken any cultural norms.

I was just reading the elasticsearch docs, and saw that `filter` was an option I was unfamiliar with. When I went to try to use it in the QueryApi, I couldn't find it. I then thought maybe it nedeed to be added to BoolQuery itself, but evidently it just was not present in the helpers. Given that it could be a drop-in replacement for `must` in many circumstances, I think it is worthy of a helper as well.