### PR TITLE
feat(composite): add offset support to DateHistogramValueSource

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/CompositeAggregation.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/CompositeAggregation.scala
@@ -37,7 +37,8 @@ case class DateHistogramValueSource(
     override val order: Option[String] = None,
     timeZone: Option[String] = None,
     format: Option[String] = None,
-    override val missingBucket: Boolean = false
+    override val missingBucket: Boolean = false,
+    offset: Option[String] = None
 ) extends ValueSource("date_histogram", name, field, script, order, missingBucket)
 
 case class GeoTileGridValueSource(

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/CompositeAggregationBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/CompositeAggregationBuilder.scala
@@ -28,20 +28,23 @@ object CompositeAggregationBuilder {
       s.order.foreach(builder.field("order", _))
       if (s.missingBucket) builder.field("missing_bucket", true)
       s match {
-        case HistogramValueSource(_, interval, _, _, _, _)                                           => builder.field("interval", interval)
-        case DateHistogramValueSource(_, calendarInterval, None, None, _, _, _, timeZone, format, _) =>
+        case HistogramValueSource(_, interval, _, _, _, _)                                                   => builder.field("interval", interval)
+        case DateHistogramValueSource(_, calendarInterval, None, None, _, _, _, timeZone, format, _, offset) =>
           builder.field("calendar_interval", calendarInterval.get)
           timeZone.foreach(builder.field("time_zone", _))
           format.foreach(builder.field("format", _))
-        case DateHistogramValueSource(_, None, fixedInterval, None, _, _, _, timeZone, format, _)    =>
+          offset.foreach(builder.field("offset", _))
+        case DateHistogramValueSource(_, None, fixedInterval, None, _, _, _, timeZone, format, _, offset)    =>
           builder.field("fixed_interval", fixedInterval.get)
           timeZone.foreach(builder.field("time_zone", _))
           format.foreach(builder.field("format", _))
-        case DateHistogramValueSource(_, None, None, interval, _, _, _, timeZone, format, _)         =>
+          offset.foreach(builder.field("offset", _))
+        case DateHistogramValueSource(_, None, None, interval, _, _, _, timeZone, format, _, offset)         =>
           builder.field("interval", interval.get)
           timeZone.foreach(builder.field("time_zone", _))
           format.foreach(builder.field("format", _))
-        case GeoTileGridValueSource(_, precision, bounds, _, _, _, _)                                =>
+          offset.foreach(builder.field("offset", _))
+        case GeoTileGridValueSource(_, precision, bounds, _, _, _, _)                                        =>
           precision.foreach(builder.field("precision", _))
           bounds.foreach(bound => {
             builder.startObject("bounds")
@@ -58,7 +61,7 @@ object CompositeAggregationBuilder {
 
             builder.endObject()
           })
-        case _                                                                                       =>
+        case _                                                                                               =>
       }
       builder.endObject()
       builder.endObject()

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/CompositeAggregationBuilderTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/CompositeAggregationBuilderTest.scala
@@ -98,4 +98,41 @@ class CompositeAggregationBuilderTest extends AnyFunSuite with Matchers {
     SearchBodyBuilderFn(search).string shouldBe
       """{"aggs":{"comp":{"composite":{"sources":[{"s1":{"terms":{"field":"f1"}}}],"after":{"myafter1":1,"myafter2":"2"}}}}}"""
   }
+
+  test("CompositeAggregationBuilder should build date histogram with offset") {
+    val search = SearchRequest("myindex").aggs(
+      CompositeAggregation(
+        "comp",
+        sources = Seq(
+          DateHistogramValueSource(
+            "date",
+            calendarInterval = Some("1w"),
+            field = Some("timestamp"),
+            offset = Some("-60h")
+          )
+        )
+      )
+    )
+    SearchBodyBuilderFn(search).string shouldBe
+      """{"aggs":{"comp":{"composite":{"sources":[{"date":{"date_histogram":{"field":"timestamp","calendar_interval":"1w","offset":"-60h"}}}]}}}}"""
+  }
+
+  test("CompositeAggregationBuilder should build date histogram with offset and timezone") {
+    val search = SearchRequest("myindex").aggs(
+      CompositeAggregation(
+        "comp",
+        sources = Seq(
+          DateHistogramValueSource(
+            "date",
+            calendarInterval = Some("1w"),
+            field = Some("timestamp"),
+            timeZone = Some("UTC"),
+            offset = Some("-60h")
+          )
+        )
+      )
+    )
+    SearchBodyBuilderFn(search).string shouldBe
+      """{"aggs":{"comp":{"composite":{"sources":[{"date":{"date_histogram":{"field":"timestamp","calendar_interval":"1w","time_zone":"UTC","offset":"-60h"}}}]}}}}"""
+  }
 }


### PR DESCRIPTION
## Summary

This PR adds support for the `offset` parameter in `DateHistogramValueSource` within composite aggregations.

## Motivation

Elasticsearch's `date_histogram` aggregation supports an `offset` parameter to shift bucket boundaries, which is useful for aligning buckets with custom time periods (e.g., weekly periods that start on a specific day/time).

This `offset` parameter is missing in `DateHistogramValueSource` used within `CompositeAggregation`. This prevents users from creating time-shifted composite aggregations.

## Changes

1. Added `offset` parameter to `DateHistogramValueSource`
2. Updated `CompositeAggregationBuilder` to serialize the offset
3. Added tests

