### PR TITLE
Fix scheme detection in http4s client

### DIFF
--- a/elastic4s-client-http4s/src/main/scala/com/sksamuel/elastic4s/http4s/Http4sClient.scala
+++ b/elastic4s-client-http4s/src/main/scala/com/sksamuel/elastic4s/http4s/Http4sClient.scala
@@ -13,7 +13,7 @@ object Http4sClient {
       endpoint: ElasticNodeEndpoint
   ): Http4sClient[F] = {
     val uri = http4s.Uri(
-      scheme = endpoint.prefix.flatMap(http4s.Uri.Scheme.fromString(_).toOption),
+      scheme = http4s.Uri.Scheme.fromString(endpoint.protocol).toOption,
       authority = Some(http4s.Uri.Authority(host = http4s.Uri.RegName(endpoint.host), port = Some(endpoint.port)))
     )
     new Http4sClient(


### PR DESCRIPTION
For http4s client scheme was build from prefix instead of protocol information.