### PR TITLE
Limit to one version for the same artifact

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -11,6 +11,4 @@ updates.pin = [
   { groupId = "org.scala-lang", artifactId = "scala-library", version = "2.13." }
   # Scala 3.3 is an LTS
   { groupId = "org.scala-lang", artifactId = "scala3-library", version = "3.3." }
-  # Scala 3.9 will be an LTS
-  { groupId = "org.scala-lang", artifactId = "scala3-library", version = "3.9." }
 ]


### PR DESCRIPTION
Pinning of different versions for the same artifact doesn't work, see https://github.com/scala-steward-org/scala-steward/issues/2593.