### PR TITLE
Limit to one version for the same artifact in series/7.x

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -9,8 +9,6 @@ updates.pin = [
   { "groupId" = "org.elasticsearch.client", version = "7."}
   # zio-json should stay on 0.7.x, 0.8.0+ is JDK17+
   { "groupId" = "dev.zio", artifactId = "zio-json", version = "0.7." }
-  # scala 2.12 should stay on scala 2.12
-  { groupId = "org.scala-lang", artifactId = "scala-library", version = "2.12." }
   # scala 2.13 should stay on scala 2.13
   { groupId = "org.scala-lang", artifactId = "scala-library", version = "2.13." }
   # zio 1.0 should stay on zio 1.0


### PR DESCRIPTION
Pinning of different versions for the same artifact doesn't work, see https://github.com/scala-steward-org/scala-steward/issues/2593.