### PR TITLE
Update akka to 2.8.0 and akka-http to 10.5.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,8 +2,8 @@ import sbt.Keys.libraryDependencies
 import sbt._
 
 object Dependencies {
-  val AkkaHttpVersion                = "10.4.0"
-  val AkkaVersion                    = "2.7.0"
+  val AkkaHttpVersion                = "10.5.0"
+  val AkkaVersion                    = "2.8.0"
   val CatsVersion                    = "2.13.0"
   val CatsEffectVersion              = "3.6.1"
   val CirceVersion                   = "0.14.15"


### PR DESCRIPTION
Akka 2.8.0 and akka-http 10.5.0 are now Apache 2.0.