### PR TITLE
[series/9.x] add shard preference support for update by query async requests

### DIFF
--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryHandlerTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryHandlerTest.scala
@@ -1,6 +1,7 @@
 package com.sksamuel.elastic4s.requests.update
 
 import com.sksamuel.elastic4s.handlers.update.UpdateHandlers
+import com.sksamuel.elastic4s.requests.common.Preference.Shards
 import com.sksamuel.elastic4s.requests.searches.queries.matches.MatchAllQuery
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -11,22 +12,11 @@ class UpdateByQueryHandlerTest extends AnyFlatSpec with Matchers with UpdateHand
     val request = UpdateByQueryAsyncRequest(
       indexes = "test_index",
       query = MatchAllQuery()
-    ).shards(Set(0, 1, 2, 3))
+    ).preference(Shards(List("0", "1", "2", "3")))
 
     val elasticRequest = AsyncUpdateByQueryHandler.build(request)
 
     elasticRequest.params should contain("preference" -> "_shards:0,1,2,3")
-  }
-
-  it should "build preference parameter with single shard" in {
-    val request = UpdateByQueryAsyncRequest(
-      indexes = "test_index",
-      query = MatchAllQuery()
-    ).shards(5)
-
-    val elasticRequest = AsyncUpdateByQueryHandler.build(request)
-
-    elasticRequest.params should contain("preference" -> "_shards:5")
   }
 
   it should "not include preference parameter when shards is None" in {

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryHandlerTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryHandlerTest.scala
@@ -1,0 +1,42 @@
+package com.sksamuel.elastic4s.requests.update
+
+import com.sksamuel.elastic4s.handlers.update.UpdateHandlers
+import com.sksamuel.elastic4s.requests.searches.queries.matches.MatchAllQuery
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class UpdateByQueryHandlerTest extends AnyFlatSpec with Matchers with UpdateHandlers {
+
+  it should "build preference parameter with ShardsPreferenceRequest" in {
+    val request = UpdateByQueryAsyncRequest(
+      indexes = "test_index",
+      query = MatchAllQuery()
+    ).shards(Set(0, 1, 2, 3))
+
+    val elasticRequest = AsyncUpdateByQueryHandler.build(request)
+
+    elasticRequest.params should contain("preference" -> "_shards:0,1,2,3")
+  }
+
+  it should "build preference parameter with single shard" in {
+    val request = UpdateByQueryAsyncRequest(
+      indexes = "test_index",
+      query = MatchAllQuery()
+    ).shards(5)
+
+    val elasticRequest = AsyncUpdateByQueryHandler.build(request)
+
+    elasticRequest.params should contain("preference" -> "_shards:5")
+  }
+
+  it should "not include preference parameter when shards is None" in {
+    val request = UpdateByQueryAsyncRequest(
+      indexes = "test_index",
+      query = MatchAllQuery()
+    )
+
+    val elasticRequest = AsyncUpdateByQueryHandler.build(request)
+
+    elasticRequest.params should not contain key("preference")
+  }
+}

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryAsyncRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryAsyncRequest.scala
@@ -27,7 +27,8 @@ case class UpdateByQueryAsyncRequest(
     shouldStoreResult: Option[Boolean] = None,
     size: Option[Int] = None,
     indicesOptions: Option[IndicesOptionsRequest] = None,
-    routing: Option[String] = None
+    routing: Option[String] = None,
+    shards: Option[ShardsPreferenceRequest] = None
 ) extends BaseUpdateByQueryRequest {
 
   def proceedOnConflicts(proceedOnConflicts: Boolean): UpdateByQueryAsyncRequest =
@@ -72,6 +73,9 @@ case class UpdateByQueryAsyncRequest(
     copy(shouldStoreResult = shouldStoreResult.some)
 
   def indicesOptions(options: IndicesOptionsRequest): UpdateByQueryAsyncRequest = copy(indicesOptions = options.some)
+
+  def shards(shards: Set[Int]): UpdateByQueryAsyncRequest = copy(shards = shardsPreferenceRequest(shards))
+  def shards(shard: Int): UpdateByQueryAsyncRequest       = copy(shards = Some(ShardsPreferenceRequest(shard)))
 
   override val waitForCompletion: Option[Boolean] = Some(false)
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryAsyncRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryAsyncRequest.scala
@@ -3,9 +3,10 @@ package com.sksamuel.elastic4s.requests.update
 import com.sksamuel.elastic4s.Indexes
 import com.sksamuel.elastic4s.ext.OptionImplicits._
 import com.sksamuel.elastic4s.requests.admin.IndicesOptionsRequest
-import com.sksamuel.elastic4s.requests.common.{RefreshPolicy, Slice, Slicing}
+import com.sksamuel.elastic4s.requests.common.{Preference, RefreshPolicy, Slice, Slicing}
 import com.sksamuel.elastic4s.requests.script.Script
 import com.sksamuel.elastic4s.requests.searches.queries.Query
+
 import scala.concurrent.duration.FiniteDuration
 
 case class UpdateByQueryAsyncRequest(
@@ -28,7 +29,7 @@ case class UpdateByQueryAsyncRequest(
     size: Option[Int] = None,
     indicesOptions: Option[IndicesOptionsRequest] = None,
     routing: Option[String] = None,
-    shards: Option[ShardsPreferenceRequest] = None
+    preference: Option[String] = None
 ) extends BaseUpdateByQueryRequest {
 
   def proceedOnConflicts(proceedOnConflicts: Boolean): UpdateByQueryAsyncRequest =
@@ -74,8 +75,8 @@ case class UpdateByQueryAsyncRequest(
 
   def indicesOptions(options: IndicesOptionsRequest): UpdateByQueryAsyncRequest = copy(indicesOptions = options.some)
 
-  def shards(shards: Set[Int]): UpdateByQueryAsyncRequest = copy(shards = shardsPreferenceRequest(shards))
-  def shards(shard: Int): UpdateByQueryAsyncRequest       = copy(shards = Some(ShardsPreferenceRequest(shard)))
+  def preference(pref: Preference): UpdateByQueryAsyncRequest = preference(pref.value)
+  def preference(pref: String): UpdateByQueryAsyncRequest     = copy(preference = pref.some)
 
   override val waitForCompletion: Option[Boolean] = Some(false)
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryRequest.scala
@@ -9,6 +9,10 @@ import com.sksamuel.elastic4s.requests.admin.IndicesOptionsRequest
 
 import scala.concurrent.duration.FiniteDuration
 
+case class ShardsPreferenceRequest(shard: Int, optionalShards: Option[Set[Int]] = None) {
+  val shards: Set[Int] = Set(shard) ++ optionalShards.getOrElse(Set.empty)
+}
+
 trait BaseUpdateByQueryRequest {
   val indexes: Indexes
 
@@ -49,6 +53,14 @@ trait BaseUpdateByQueryRequest {
   val indicesOptions: Option[IndicesOptionsRequest]
 
   val routing: Option[String]
+
+  val shards: Option[ShardsPreferenceRequest]
+
+  def shardsPreferenceRequest(shards: Set[Int]): Option[ShardsPreferenceRequest] = shards.toList match {
+    case Nil          => None
+    case head :: Nil  => Some(ShardsPreferenceRequest(head))
+    case head :: tail => Some(ShardsPreferenceRequest(head, Some(tail.toSet)))
+  }
 }
 case class UpdateByQueryRequest(
     indexes: Indexes,
@@ -71,7 +83,8 @@ case class UpdateByQueryRequest(
     shouldStoreResult: Option[Boolean] = None,
     size: Option[Int] = None,
     indicesOptions: Option[IndicesOptionsRequest] = None,
-    routing: Option[String] = None
+    routing: Option[String] = None,
+    shards: Option[ShardsPreferenceRequest] = None
 ) extends BaseUpdateByQueryRequest {
 
   def proceedOnConflicts(proceedOnConflicts: Boolean): UpdateByQueryRequest =
@@ -119,4 +132,7 @@ case class UpdateByQueryRequest(
     copy(shouldStoreResult = shouldStoreResult.some)
 
   def indicesOptions(options: IndicesOptionsRequest): UpdateByQueryRequest = copy(indicesOptions = options.some)
+
+  def shards(shards: Set[Int]): UpdateByQueryRequest = copy(shards = shardsPreferenceRequest(shards))
+  def shards(shard: Int): UpdateByQueryRequest       = copy(shards = Some(ShardsPreferenceRequest(shard)))
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryRequest.scala
@@ -1,17 +1,13 @@
 package com.sksamuel.elastic4s.requests.update
 
 import com.sksamuel.elastic4s.Indexes
-import com.sksamuel.elastic4s.requests.common.{RefreshPolicy, Slice, Slicing}
+import com.sksamuel.elastic4s.requests.common.{Preference, RefreshPolicy, Slice, Slicing}
 import com.sksamuel.elastic4s.requests.script.Script
 import com.sksamuel.elastic4s.requests.searches.queries.Query
 import com.sksamuel.elastic4s.ext.OptionImplicits._
 import com.sksamuel.elastic4s.requests.admin.IndicesOptionsRequest
 
 import scala.concurrent.duration.FiniteDuration
-
-case class ShardsPreferenceRequest(shard: Int, optionalShards: Option[Set[Int]] = None) {
-  val shards: Set[Int] = Set(shard) ++ optionalShards.getOrElse(Set.empty)
-}
 
 trait BaseUpdateByQueryRequest {
   val indexes: Indexes
@@ -54,13 +50,7 @@ trait BaseUpdateByQueryRequest {
 
   val routing: Option[String]
 
-  val shards: Option[ShardsPreferenceRequest]
-
-  def shardsPreferenceRequest(shards: Set[Int]): Option[ShardsPreferenceRequest] = shards.toList match {
-    case Nil          => None
-    case head :: Nil  => Some(ShardsPreferenceRequest(head))
-    case head :: tail => Some(ShardsPreferenceRequest(head, Some(tail.toSet)))
-  }
+  val preference: Option[String]
 }
 case class UpdateByQueryRequest(
     indexes: Indexes,
@@ -84,7 +74,7 @@ case class UpdateByQueryRequest(
     size: Option[Int] = None,
     indicesOptions: Option[IndicesOptionsRequest] = None,
     routing: Option[String] = None,
-    shards: Option[ShardsPreferenceRequest] = None
+    preference: Option[String] = None
 ) extends BaseUpdateByQueryRequest {
 
   def proceedOnConflicts(proceedOnConflicts: Boolean): UpdateByQueryRequest =
@@ -133,6 +123,6 @@ case class UpdateByQueryRequest(
 
   def indicesOptions(options: IndicesOptionsRequest): UpdateByQueryRequest = copy(indicesOptions = options.some)
 
-  def shards(shards: Set[Int]): UpdateByQueryRequest = copy(shards = shardsPreferenceRequest(shards))
-  def shards(shard: Int): UpdateByQueryRequest       = copy(shards = Some(ShardsPreferenceRequest(shard)))
+  def preference(pref: Preference): UpdateByQueryRequest = preference(pref.value)
+  def preference(pref: String): UpdateByQueryRequest     = copy(preference = pref.some)
 }

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/update/UpdateHandlers.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/update/UpdateHandlers.scala
@@ -109,9 +109,7 @@ trait UpdateHandlers {
       request.slices.foreach(s =>
         if (s == Slicing.AutoSlices) params.put("slices", Slicing.AutoSlicesValue) else params.put("slices", s)
       )
-      request.shards.foreach { shardsPrefRequest =>
-        params.put("preference", s"_shards:${shardsPrefRequest.shards.mkString(",")}")
-      }
+      request.preference.foreach(params.put("preference", _))
 
       request.indicesOptions.foreach { opts =>
         IndicesOptionsParams(opts).foreach { case (key, value) => params.put(key, value) }

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/update/UpdateHandlers.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/update/UpdateHandlers.scala
@@ -109,6 +109,9 @@ trait UpdateHandlers {
       request.slices.foreach(s =>
         if (s == Slicing.AutoSlices) params.put("slices", Slicing.AutoSlicesValue) else params.put("slices", s)
       )
+      request.shards.foreach { shardsPrefRequest =>
+        params.put("preference", s"_shards:${shardsPrefRequest.shards.mkString(",")}")
+      }
 
       request.indicesOptions.foreach { opts =>
         IndicesOptionsParams(opts).foreach { case (key, value) => params.put(key, value) }


### PR DESCRIPTION
Add support for the `preference=_shards:0,1,2,3` parameter in async update-by-query operations through a new ShardsPreferenceRequest case class.

Changes:

- Add ShardsPreferenceRequest case class to model shard preferences. The goal of this model is to have a nonEmptyList
- Add `shards: Option[ShardsPreferenceRequest]` field to UpdateByQueryAsyncRequest
- Add fluent API methods: shards(Int) and shards(Set[Int])
- Propagate shard preference parameter to HTTP request in UpdateByQueryHandler
- Add comprehensive unit tests validating preference parameter building